### PR TITLE
Automate public beta site deployment

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,0 +1,132 @@
+name: Deploy public site
+
+on:
+  push:
+    branches:
+      - beta
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-site-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    env:
+      SITE_SSH_HOST: ${{ secrets.TERENTO_SITE_SSH_HOST }}
+      SITE_SSH_PORT: ${{ secrets.TERENTO_SITE_SSH_PORT }}
+      SITE_SSH_USER: ${{ secrets.TERENTO_SITE_SSH_USER }}
+      SITE_SSH_KEY: ${{ secrets.TERENTO_SITE_SSH_KEY }}
+      SITE_SSH_KNOWN_HOSTS: ${{ secrets.TERENTO_SITE_SSH_KNOWN_HOSTS }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$SITE_SSH_HOST"
+          test -n "$SITE_SSH_USER"
+          test -n "$SITE_SSH_KEY"
+          test -n "$SITE_SSH_KNOWN_HOSTS"
+
+      - name: Configure pinned SSH access
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$SITE_SSH_KEY" > "$HOME/.ssh/terento_site"
+          printf '%s\n' "$SITE_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/terento_site" "$HOME/.ssh/known_hosts"
+
+      - name: Package site source
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -czf "$RUNNER_TEMP/terento-site.tgz" site site-deploy
+
+      - name: Upload source to the VPS
+        shell: bash
+        run: |
+          set -euo pipefail
+          port="${SITE_SSH_PORT:-22}"
+          release_id="${GITHUB_SHA:0:12}"
+          remote_stage="/tmp/terento-site-${release_id}"
+          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
+            "rm -rf -- '$remote_stage' && mkdir -m 700 -p '$remote_stage'"
+          scp -i "$HOME/.ssh/terento_site" -P "$port" -o BatchMode=yes \
+            "$RUNNER_TEMP/terento-site.tgz" "$SITE_SSH_USER@$SITE_SSH_HOST:$remote_stage/source.tgz"
+          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
+            "tar -xzf '$remote_stage/source.tgz' -C '$remote_stage' && rm -f '$remote_stage/source.tgz'"
+
+      - name: Build and roll out the web container
+        shell: bash
+        run: |
+          set -euo pipefail
+          port="${SITE_SSH_PORT:-22}"
+          release_id="${GITHUB_SHA:0:12}"
+          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
+            "bash -s -- '$release_id'" <<'REMOTE'
+          set -euo pipefail
+          release_id="$1"
+          stage="/tmp/terento-site-${release_id}"
+          image="terento-site-terento-web:publish-${release_id}"
+          container="terento-site-terento-web-1"
+          rollback="${container}-rollback-${release_id}"
+
+          docker build --pull=false -f "$stage/site-deploy/Dockerfile" -t "$image" "$stage"
+
+          if docker inspect "$container" >/dev/null 2>&1; then
+            docker rename "$container" "$rollback"
+            docker stop "$rollback" >/dev/null
+            old_container="$rollback"
+          else
+            old_container=""
+          fi
+
+          rollback_web() {
+            docker rm -f "$container" >/dev/null 2>&1 || true
+            if [ -n "$old_container" ] && docker inspect "$old_container" >/dev/null 2>&1; then
+              docker rename "$old_container" "$container"
+              docker start "$container" >/dev/null
+            fi
+            rm -rf -- "$stage"
+          }
+
+          if ! docker run -d --name "$container" --restart unless-stopped --network terento-site \
+            --label traefik.enable=true \
+            --label traefik.docker.network=terento-site \
+            --label traefik.http.routers.terento.rule='Host(`terento.app`)' \
+            --label traefik.http.routers.terento.entrypoints=websecure \
+            --label traefik.http.routers.terento.tls=true \
+            --label traefik.http.routers.terento.tls.certresolver=letsencrypt \
+            --label traefik.http.services.terento.loadbalancer.server.port=80 \
+            --label traefik.http.routers.terento-www.rule='Host(`www.terento.app`)' \
+            --label traefik.http.routers.terento-www.entrypoints=websecure \
+            --label traefik.http.routers.terento-www.tls=true \
+            --label traefik.http.routers.terento-www.tls.certresolver=letsencrypt \
+            --label traefik.http.routers.terento-www.middlewares=terento-www-redirect \
+            --label traefik.http.middlewares.terento-www-redirect.redirectregex.regex='^https?://www\.terento\.app/(.*)' \
+            --label traefik.http.middlewares.terento-www-redirect.redirectregex.replacement='https://terento.app/$$1' \
+            --label traefik.http.middlewares.terento-www-redirect.redirectregex.permanent=true \
+            "$image"; then
+            rollback_web
+            exit 1
+          fi
+
+          if ! curl --fail --silent --show-error --max-time 20 \
+            https://terento.app/updates/macos-arm64.json | grep -q '"architecture"[[:space:]]*:[[:space:]]*"arm64"'; then
+            rollback_web
+            exit 1
+          fi
+
+          rm -rf -- "$stage"
+          REMOTE

--- a/site-deploy/Caddyfile
+++ b/site-deploy/Caddyfile
@@ -1,0 +1,31 @@
+:80 {
+  root * /srv
+  encode gzip
+
+  header {
+    Strict-Transport-Security "max-age=31536000"
+    X-Content-Type-Options "nosniff"
+    X-Frame-Options "DENY"
+    Referrer-Policy "strict-origin-when-cross-origin"
+    Permissions-Policy "camera=(), microphone=(), geolocation=()"
+    Content-Security-Policy "default-src 'self'; script-src 'self' https://stats.enduristas.lt; connect-src 'self' https://api.terento.app https://stats.enduristas.lt; img-src 'self' data: https://api.terento.app; style-src 'self'; font-src 'self'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
+  }
+
+  @assets path *.css *.js *.svg *.png *.ico *.woff2 *.webmanifest *.xml
+  header @assets Cache-Control "public, max-age=604800"
+
+  @updateManifest path /updates/macos-arm64.json
+  header @updateManifest Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+  header @updateManifest Pragma "no-cache"
+
+  @legacySupportedWatches path /supported-watches /supported-watches/*
+  redir @legacySupportedWatches /compatibility/ permanent
+
+  handle_errors {
+    header X-Robots-Tag "noindex, nofollow"
+    rewrite * /404.html
+    file_server
+  }
+
+  file_server
+}

--- a/site-deploy/Dockerfile
+++ b/site-deploy/Dockerfile
@@ -1,0 +1,4 @@
+FROM caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+
+COPY site-deploy/Caddyfile /etc/caddy/Caddyfile
+COPY site/ /srv

--- a/site-deploy/README.md
+++ b/site-deploy/README.md
@@ -1,0 +1,29 @@
+# Public site deployment
+
+The production site is currently served by a Caddy container on the existing
+Hostinger VPS. Cloudflare provides DNS, HTTPS and the proxy edge; it is not the
+site origin or a Cloudflare Pages project.
+
+`.github/workflows/deploy-site.yml` publishes the tracked `site/` tree after a
+push to `beta` or a `v*` tag. The workflow connects to the VPS with a GitHub
+Actions SSH key, builds the pinned Caddy image, replaces only the `terento-web`
+container, and keeps the previous web container as a rollback target. It does
+not touch Traefik, the catalog API, PostgreSQL, or map files.
+
+Configure these GitHub repository secrets before enabling the workflow:
+
+- `TERENTO_SITE_SSH_HOST` — VPS hostname or IP;
+- `TERENTO_SITE_SSH_PORT` — usually `22`;
+- `TERENTO_SITE_SSH_USER` — the restricted deployment user;
+- `TERENTO_SITE_SSH_KEY` — a private deploy key whose public key is authorized
+  for that user;
+- `TERENTO_SITE_SSH_KNOWN_HOSTS` — the pinned `known_hosts` line for the VPS.
+
+The deployment user needs Docker access and membership/permission for the
+`terento-site` Docker network, but must not receive repository secrets or
+passwords. The current VPS operator account does not have write access to the
+root-owned `/docker/terento-site` checkout, so the workflow deploys from a
+temporary Docker build context and does not rewrite that checkout.
+
+The update manifest is deliberately sent with `Cache-Control: no-store` so an
+old app-update response cannot remain cached after a release.


### PR DESCRIPTION
Publishes the tracked site and update manifest to the existing Hostinger origin behind Cloudflare. Runs on beta pushes, v* tags, and manual dispatch; uses repository Secrets for the restricted SSH deploy key; validates the manifest and keeps the previous web container for rollback.