### PR TITLE
feat: publish admin campaign link builder

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -1,0 +1,142 @@
+name: Deploy catalog API
+
+on:
+  push:
+    branches:
+      - beta
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: catalog-api-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/beta'
+    runs-on: ubuntu-latest
+    env:
+      CATALOG_SSH_HOST: ${{ secrets.TERENTO_SITE_SSH_HOST }}
+      CATALOG_SSH_PORT: ${{ secrets.TERENTO_SITE_SSH_PORT }}
+      CATALOG_SSH_USER: ${{ secrets.TERENTO_SITE_SSH_USER }}
+      CATALOG_SSH_KEY: ${{ secrets.TERENTO_SITE_SSH_KEY }}
+      CATALOG_SSH_KNOWN_HOSTS: ${{ secrets.TERENTO_SITE_SSH_KNOWN_HOSTS }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Validate deployment configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CATALOG_SSH_HOST"
+          test -n "$CATALOG_SSH_USER"
+          test -n "$CATALOG_SSH_KEY"
+          test -n "$CATALOG_SSH_KNOWN_HOSTS"
+
+      - name: Configure pinned SSH access
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$CATALOG_SSH_KEY" > "$HOME/.ssh/terento_catalog"
+          printf '%s\n' "$CATALOG_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/terento_catalog" "$HOME/.ssh/known_hosts"
+
+      - name: Package catalog API source
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -czf "$RUNNER_TEMP/terento-catalog-api.tgz" backend/catalog-api
+
+      - name: Upload source to the VPS
+        shell: bash
+        run: |
+          set -euo pipefail
+          port="${CATALOG_SSH_PORT:-22}"
+          release_id="${GITHUB_SHA:0:12}"
+          remote_stage="/tmp/terento-catalog-api-${release_id}"
+          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
+            "rm -rf -- '$remote_stage' && mkdir -m 700 -p '$remote_stage'"
+          scp -i "$HOME/.ssh/terento_catalog" -P "$port" -o BatchMode=yes \
+            "$RUNNER_TEMP/terento-catalog-api.tgz" "$CATALOG_SSH_USER@$CATALOG_SSH_HOST:$remote_stage/source.tgz"
+          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
+            "tar -xzf '$remote_stage/source.tgz' -C '$remote_stage' && rm -f '$remote_stage/source.tgz'"
+
+      - name: Build and roll out the API container
+        shell: bash
+        run: |
+          set -euo pipefail
+          port="${CATALOG_SSH_PORT:-22}"
+          release_id="${GITHUB_SHA:0:12}"
+          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
+            "bash -s -- '$release_id'" <<'REMOTE'
+          set -euo pipefail
+          release_id="$1"
+          stage="/tmp/terento-catalog-api-${release_id}"
+          project="/docker/terento-catalog"
+          compose="$project/deploy/hostinger/catalog/docker-compose.yml"
+          image="terento-catalog-api:publish-${release_id}"
+          override="/tmp/terento-catalog-api-override-${release_id}.yml"
+          old_image=""
+
+          test -f "$compose"
+          test -f "$project/deploy/hostinger/catalog/.env"
+          old_image="$(docker compose --project-directory "$project" -f "$compose" images -q catalog-api | head -n 1)"
+          test -n "$old_image"
+
+          docker build --pull=false -f "$stage/backend/catalog-api/Dockerfile" -t "$image" "$stage/backend/catalog-api"
+
+          cat > "$override" <<EOF
+          services:
+            catalog-api:
+              image: $image
+            catalog-scheduler:
+              image: $image
+            catalog-migrate:
+              image: $image
+          EOF
+
+          compose_args=(--project-directory "$project" -f "$compose" -f "$override")
+          docker compose "${compose_args[@]}" config --quiet
+          docker compose "${compose_args[@]}" --profile manual run --rm --no-deps catalog-migrate
+
+          rollback() {
+            cat > "$override" <<EOF
+          services:
+            catalog-api:
+              image: $old_image
+            catalog-scheduler:
+              image: $old_image
+          EOF
+            docker compose "${compose_args[@]}" up -d --no-build catalog-api catalog-scheduler || true
+            rm -rf -- "$stage" "$override"
+          }
+
+          if ! docker compose "${compose_args[@]}" up -d --no-build catalog-api catalog-scheduler; then
+            rollback
+            exit 1
+          fi
+
+          health_url="https://api.terento.app/health"
+          health_verified=false
+          deadline=$(( $(date +%s) + 90 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            if curl --fail --silent --connect-timeout 5 --max-time 10 "$health_url" | grep -q '"status":"ok"'; then
+              health_verified=true
+              break
+            fi
+            sleep 2
+          done
+
+          admin_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' https://terento.app/admin/campaign-links || true)"
+          admin_location="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r' | head -n 1 || true)"
+          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ]; then
+            rollback
+            exit 1
+          fi
+
+          rm -rf -- "$stage" "$override"
+          REMOTE

--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -65,9 +65,21 @@ PYTHONPATH=backend/catalog-api/src python3 -m unittest discover -s backend/catal
 - `GET /admin` serves the authenticated, noindex aggregate operator dashboard
   and account settings. The first account requires `ADMIN_BOOTSTRAP_SECRET`;
   later credentials are PBKDF2-hashed in PostgreSQL.
+- `GET /admin/campaign-links` serves the authenticated, client-side campaign
+  link builder. It shares the `/admin` session gate and stores no campaign
+  links or history.
 - `GET /compatibility/public/top-models.json` is a prepared, default-disabled
   aggregate API. It returns only individually reviewed and approved models
   after `PUBLIC_COMPATIBILITY_STATS_ENABLED=true`; it never returns raw events.
+
+Production API updates are rolled out by
+`.github/workflows/deploy-catalog-api.yml`. The workflow builds the API image
+from the checked-in source, runs the forward migration command against the
+existing private database, replaces only the API and scheduler containers,
+waits for `/health`, and verifies that unauthenticated admin requests redirect
+to `/admin/login`. It keeps the previous API image available for rollback and
+does not change the PostgreSQL or asset volumes. The workflow uses the pinned
+SSH secrets already documented for the Hostinger deployment account.
 
 The catalog includes a map only after a collector has a normalized version and
 a known download size. A missing size is retained in the database but omitted

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -61,6 +61,17 @@ are rate limited. Pages include no-store, noindex and restrictive CSP headers.
 Raw event payloads are not displayed. `/internal/compatibility/` redirects to
 this route for the earlier local implementation.
 
+## `GET /admin/campaign-links`
+
+Returns the authenticated operator's local Campaign link builder. It is a
+client-side tool: no campaign links, history, or analytics data are stored and
+no campaign-link API is exposed. The builder restricts destinations to
+`terento.app`, normalizes UTM values, replaces existing UTM parameters, and
+keeps the canonical parameter order `utm_source`, `utm_medium`,
+`utm_campaign`, `utm_content`, `utm_term`. The page uses the same private
+admin session, CSRF cookie, no-store response policy, and noindex policy as
+`GET /admin`.
+
 ## `GET /compatibility/public/top-models.json`
 
 Prepared for a later public TOP-models widget. The route returns 404 unless

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -9,6 +9,7 @@ import secrets
 from datetime import datetime, timezone
 from typing import Any
 
+from .campaign_links import CAMPAIGN_SUGGESTIONS, MEDIUM_OPTIONS, SOURCE_OPTIONS
 from .compatibility_status import STATUS_PUBLIC_COPY, CompatibilityStatus
 
 
@@ -183,9 +184,12 @@ def _admin_brand() -> str:
     </a>"""
 
 
-def _admin_header(user: dict[str, Any], csrf_token: str) -> str:
+def _admin_header(user: dict[str, Any], csrf_token: str, *, active: str = "evidence") -> str:
     username = html.escape(str(user.get("username") or ""))
+    evidence_class = " class='active'" if active == "evidence" else ""
+    campaign_class = " class='active'" if active == "campaigns" else ""
     return f"""<header class="admin-topbar"><div class="admin-topbar-inner">{_admin_brand()}
+      <nav class="admin-section-nav" aria-label="Admin sections"><a{evidence_class} href="/admin">Installation evidence</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a></nav>
       <nav class="admin-nav" aria-label="Admin navigation"><a href="/admin/account">Account</a><span class="admin-user">{username}</span>
       <form method="post" action="/admin/logout"><input type="hidden" name="csrf_token" value="{html.escape(csrf_token)}"><button class="link-button" type="submit">Sign out</button></form></nav>
     </div></header>"""
@@ -281,12 +285,92 @@ def dashboard_page(
     return _layout("Installation evidence", content)
 
 
+def _campaign_info(control_id: str, title: str, body: str) -> str:
+    info_id = f"{control_id}-info"
+    return (
+        f"<button class='info-control' type='button' aria-expanded='false' "
+        f"aria-controls='{info_id}' aria-label='More information about {html.escape(title)}'>i</button>"
+        f"<div class='info-popover' id='{info_id}' role='status' hidden><strong>{html.escape(title)}</strong>{body}</div>"
+    )
+
+
+def campaign_links_page(user: dict[str, Any], csrf_token: str) -> bytes:
+    destination_options = "".join(
+        f"<option value='{html.escape(key)}'>{html.escape(label)}</option>"
+        for key, label in (("home", "Home"), ("download", "Download"), ("compatibility", "Compatibility"), ("other", "Other"))
+    )
+    source_options = "".join(
+        f"<option value='{html.escape(value)}'>{html.escape(label)}</option>"
+        for value, label in SOURCE_OPTIONS
+    )
+    medium_options = "".join(
+        f"<option value='{html.escape(value)}'>{html.escape(label)}</option>"
+        for value, label in MEDIUM_OPTIONS
+    )
+    campaign_options = "".join(f"<option value='{html.escape(value)}'></option>" for value in CAMPAIGN_SUGGESTIONS)
+    content = f"""
+      {_admin_header(user, csrf_token, active="campaigns")}
+      <main class="dashboard campaign-page" id="main-content">
+        <div class="heading-row"><div><p class="eyebrow">Admin</p><h1>Campaign links</h1><p class="lede">Create consistent tracking links for Terento campaigns.</p></div></div>
+        <section class="campaign-card" aria-labelledby="campaign-builder-title">
+          <div class="section-heading"><div><p class="section-kicker">Attribution</p><h2 id="campaign-builder-title">Campaign link builder</h2></div><p class="table-help">Links are generated locally in this browser.</p></div>
+          <div class="campaign-preset-row">
+            <label class="campaign-label" for="campaign-preset">Preset { _campaign_info("campaign-preset", "Preset", "<p>Choose a common campaign setup, then edit any field before copying.</p><p><strong>Recommendation:</strong> use the Reddit preset for a community post.</p>") }</label>
+            <select id="campaign-preset"><option value="reddit-community">Reddit community post</option><option value="" selected>Custom</option></select>
+          </div>
+          <form id="campaign-link-form" class="campaign-form" novalidate>
+            <div class="campaign-fields">
+              <div class="campaign-field campaign-field-wide">
+                <label class="campaign-label" for="destination">Destination <span class="required-label">Required</span> { _campaign_info("destination", "Destination", "<p>Choose the Terento page a visitor should reach.</p><p><strong>Recommendation:</strong> use the most specific page for the campaign.</p><p><strong>Example:</strong> Home → <code>https://terento.app/</code></p>") }</label>
+                <select id="destination" required>{destination_options}</select>
+                <div class="custom-input" id="destination-custom-wrap" hidden aria-hidden="true"><label for="destination-custom">Custom Terento URL or path <span class="required-label">Required for Other</span></label><input id="destination-custom" type="url" inputmode="url" placeholder="https://terento.app/your-page" autocomplete="off"></div>
+              </div>
+              <div class="campaign-field">
+                <label class="campaign-label" for="source">Source <span class="required-label">Required</span> { _campaign_info("source", "Source", "<p>Identifies the platform or referrer that sends traffic.</p><p><strong>Recommendation:</strong> keep one source value per platform.</p><p><strong>Example:</strong> Reddit → <code>reddit</code></p>") }</label>
+                <select id="source" required>{source_options}</select>
+                <div class="custom-input" id="source-custom-wrap" hidden aria-hidden="true"><label for="source-custom">Custom source <span class="required-label">Required for Other</span></label><input id="source-custom" type="text" placeholder="forum" autocomplete="off"></div>
+              </div>
+              <div class="campaign-field">
+                <label class="campaign-label" for="medium">Medium <span class="required-label">Required</span> { _campaign_info("medium", "Medium", "<p>Describes the channel type used by the source.</p><p><strong>Recommendation:</strong> use <code>social</code> for social networks and <code>community</code> for forums.</p><p><strong>Example:</strong> Social → <code>social</code></p>") }</label>
+                <select id="medium" required>{medium_options}</select>
+                <div class="custom-input" id="medium-custom-wrap" hidden aria-hidden="true"><label for="medium-custom">Custom medium <span class="required-label">Required for Other</span></label><input id="medium-custom" type="text" placeholder="partner" autocomplete="off"></div>
+              </div>
+              <div class="campaign-field">
+                <label class="campaign-label" for="campaign">Campaign <span class="required-label">Required</span> { _campaign_info("campaign", "Campaign", "<p>Names the launch, initiative, or audience being measured.</p><p><strong>Recommendation:</strong> use a stable name such as <code>early_beta</code>.</p><p><strong>Example:</strong> <code>early_beta</code></p>") }</label>
+                <input id="campaign" type="text" value="early_beta" list="campaign-suggestions" required autocomplete="off"><datalist id="campaign-suggestions">{campaign_options}</datalist>
+              </div>
+              <div class="campaign-field">
+                <label class="campaign-label" for="content">Content <span class="optional-label">Optional</span> { _campaign_info("content", "Content", "<p>Distinguishes different creatives, posts, or calls to action in one campaign.</p><p><strong>Recommendation:</strong> use it when one placement has multiple variants.</p><p><strong>Example:</strong> <code>garminwatches</code></p>") }</label>
+                <input id="content" type="text" placeholder="garminwatches" autocomplete="off">
+              </div>
+              <div class="campaign-field">
+                <label class="campaign-label" for="term">Term <span class="optional-label">Optional</span> { _campaign_info("term", "Term", "<p>Optional keyword or audience label for paid or partner campaigns.</p><p><strong>Recommendation:</strong> leave blank unless you need this extra breakdown.</p><p><strong>Example:</strong> <code>47mm</code></p>") }</label>
+                <input id="term" type="text" placeholder="47mm" autocomplete="off">
+              </div>
+            </div>
+          </form>
+          <section class="campaign-result" aria-labelledby="generated-link-title">
+            <div class="section-heading"><div><p class="section-kicker">Output</p><h2 id="generated-link-title">Generated URL</h2></div></div>
+            <p class="incomplete-state" id="incomplete-state" aria-live="polite">Complete the required fields to generate a link.</p>
+            <div class="generated-url-row" id="generated-url-row" hidden><output id="generated-url" class="generated-url" aria-live="polite"></output><button id="copy-link" type="button" class="copy-button">Copy link</button><span id="copy-status" class="copy-status" role="status" aria-live="polite"></span></div>
+          </section>
+          <section class="attribution-preview" aria-labelledby="attribution-title">
+            <div><p class="section-kicker">Analytics</p><h2 id="attribution-title">Umami attribution preview</h2><p class="table-help">This preview explains the attribution values; no Umami query parameter is added.</p></div>
+            <dl class="preview-grid"><div><dt>Source</dt><dd id="preview-source">—</dd></div><div><dt>Medium</dt><dd id="preview-medium">—</dd></div><div><dt>Campaign</dt><dd id="preview-campaign">—</dd></div><div><dt>Content</dt><dd id="preview-content">—</dd></div><div><dt>Term</dt><dd id="preview-term">—</dd></div></dl>
+          </section>
+        </section>
+      </main>
+      <script>{_campaign_links_script()}</script>
+    """
+    return _layout("Campaign links", content)
+
+
 def account_page(user: dict[str, Any], csrf_token: str, *, error: str | None = None, success: str | None = None) -> bytes:
     notice = _error(error) if error else (f"<p class='success'>{html.escape(success or '')}</p>" if success else "")
     return _layout(
         "Account",
         f"""
-        {_admin_header(user, csrf_token)}
+        {_admin_header(user, csrf_token, active="")}
         <main class="auth-card account" id="main-content"><p class="eyebrow">Admin</p><h1>Account</h1>{notice}
           <form method="post" action="/admin/account">
             <input type="hidden" name="csrf_token" value="{html.escape(csrf_token)}">
@@ -330,6 +414,163 @@ def _status_badge(value: str) -> str:
         f"aria-label='{html.escape(label)}: {html.escape(STATUS_PUBLIC_COPY[status])}'>"
         f"{html.escape(label)}</span>"
     )
+
+
+def _campaign_links_script() -> str:
+    return r"""(() => {
+      const destinations = {
+        home: 'https://terento.app/',
+        download: 'https://terento.app/download/',
+        compatibility: 'https://terento.app/compatibility/'
+      };
+      const utmKeys = new Set(['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term']);
+      const form = document.querySelector('#campaign-link-form');
+      if (!form) return;
+      const controls = {
+        destination: document.querySelector('#destination'),
+        destinationCustom: document.querySelector('#destination-custom'),
+        destinationCustomWrap: document.querySelector('#destination-custom-wrap'),
+        source: document.querySelector('#source'),
+        sourceCustom: document.querySelector('#source-custom'),
+        sourceCustomWrap: document.querySelector('#source-custom-wrap'),
+        medium: document.querySelector('#medium'),
+        mediumCustom: document.querySelector('#medium-custom'),
+        mediumCustomWrap: document.querySelector('#medium-custom-wrap'),
+        campaign: document.querySelector('#campaign'),
+        content: document.querySelector('#content'),
+        term: document.querySelector('#term'),
+        preset: document.querySelector('#campaign-preset'),
+        incomplete: document.querySelector('#incomplete-state'),
+        urlRow: document.querySelector('#generated-url-row'),
+        output: document.querySelector('#generated-url'),
+        copy: document.querySelector('#copy-link'),
+        copyStatus: document.querySelector('#copy-status'),
+        previewSource: document.querySelector('#preview-source'),
+        previewMedium: document.querySelector('#preview-medium'),
+        previewCampaign: document.querySelector('#preview-campaign'),
+        previewContent: document.querySelector('#preview-content'),
+        previewTerm: document.querySelector('#preview-term')
+      };
+      const normalizeValue = (value) => {
+        let text = String(value || '').normalize('NFKD').replace(/[\u0300-\u036f]/g, '').trim().toLowerCase();
+        text = text.replace(/\s+/g, '_').replace(/[^a-z0-9_-]/g, '').replace(/[-_]{2,}/g, (match) => match[0]);
+        return text.replace(/^[-_]+|[-_]+$/g, '');
+      };
+      const destinationUrl = () => {
+        if (controls.destination.value !== 'other') return destinations[controls.destination.value];
+        const value = controls.destinationCustom.value.trim();
+        if (!value || (value.startsWith('/') && value.startsWith('//'))) return null;
+        if (value.startsWith('/')) return `https://terento.app${value}`;
+        try {
+          const parsed = new URL(value);
+          if (parsed.protocol !== 'https:' || parsed.hostname !== 'terento.app' || parsed.username || parsed.password || (parsed.port && parsed.port !== '443')) return null;
+          return `https://terento.app${parsed.pathname || '/'}${parsed.search}${parsed.hash}`;
+        } catch (_) {
+          return null;
+        }
+      };
+      const buildUrl = () => {
+        const base = destinationUrl();
+        const source = normalizeValue(controls.source.value === 'other' ? controls.sourceCustom.value : controls.source.value);
+        const medium = normalizeValue(controls.medium.value === 'other' ? controls.mediumCustom.value : controls.medium.value);
+        const campaign = normalizeValue(controls.campaign.value);
+        const content = normalizeValue(controls.content.value);
+        const term = normalizeValue(controls.term.value);
+        if (!base || !source || !medium || !campaign) return null;
+        const parsed = new URL(base);
+        const existing = [...parsed.searchParams.entries()].filter(([key]) => !utmKeys.has(key.toLowerCase()));
+        parsed.search = new URLSearchParams(existing).toString();
+        parsed.searchParams.append('utm_source', source);
+        parsed.searchParams.append('utm_medium', medium);
+        parsed.searchParams.append('utm_campaign', campaign);
+        if (content) parsed.searchParams.append('utm_content', content);
+        if (term) parsed.searchParams.append('utm_term', term);
+        return { url: parsed.toString(), source, medium, campaign, content, term };
+      };
+      window.TerentoCampaignLinkBuilder = { normalizeValue, buildUrl };
+      const setCustomVisibility = (select, wrapper, input) => {
+        const visible = select.value === 'other';
+        wrapper.hidden = !visible;
+        wrapper.setAttribute('aria-hidden', String(!visible));
+        input.required = visible;
+      };
+      const updateCustomVisibility = () => {
+        setCustomVisibility(controls.destination, controls.destinationCustomWrap, controls.destinationCustom);
+        setCustomVisibility(controls.source, controls.sourceCustomWrap, controls.sourceCustom);
+        setCustomVisibility(controls.medium, controls.mediumCustomWrap, controls.mediumCustom);
+      };
+      const setPreview = (value, control) => { control.textContent = value || '—'; };
+      const refresh = () => {
+        updateCustomVisibility();
+        const result = buildUrl();
+        controls.urlRow.hidden = !result;
+        controls.incomplete.hidden = Boolean(result);
+        controls.copy.disabled = !result;
+        controls.output.textContent = result ? result.url : '';
+        setPreview(result ? result.source : '', controls.previewSource);
+        setPreview(result ? result.medium : '', controls.previewMedium);
+        setPreview(result ? result.campaign : '', controls.previewCampaign);
+        setPreview(result ? result.content : '', controls.previewContent);
+        setPreview(result ? result.term : '', controls.previewTerm);
+      };
+      const applyPreset = () => {
+        if (controls.preset.value === 'reddit-community') {
+          controls.destination.value = 'home';
+          controls.source.value = 'reddit';
+          controls.medium.value = 'social';
+          controls.campaign.value = 'early_beta';
+          controls.content.value = '';
+          controls.term.value = '';
+        }
+        refresh();
+      };
+      const copyText = async (value) => {
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(value);
+          return;
+        }
+        const helper = document.createElement('textarea');
+        helper.value = value;
+        helper.setAttribute('readonly', '');
+        helper.style.position = 'fixed';
+        helper.style.opacity = '0';
+        document.body.appendChild(helper);
+        helper.select();
+        document.execCommand('copy');
+        helper.remove();
+      };
+      form.addEventListener('submit', (event) => event.preventDefault());
+      form.querySelectorAll('input, select').forEach((control) => control.addEventListener('input', refresh));
+      form.querySelectorAll('select').forEach((control) => control.addEventListener('change', refresh));
+      controls.preset.addEventListener('change', applyPreset);
+      controls.copy.addEventListener('click', async () => {
+        const result = buildUrl();
+        if (!result) return;
+        try {
+          await copyText(result.url);
+          controls.copyStatus.textContent = 'Copied';
+          window.setTimeout(() => { controls.copyStatus.textContent = ''; }, 1400);
+        } catch (_) {
+          controls.copyStatus.textContent = 'Copy failed — select the URL to copy it.';
+        }
+      });
+      document.querySelectorAll('.info-control').forEach((button) => {
+        button.addEventListener('click', () => {
+          const target = document.getElementById(button.getAttribute('aria-controls'));
+          const open = button.getAttribute('aria-expanded') === 'true';
+          document.querySelectorAll('.info-control[aria-expanded="true"]').forEach((other) => {
+            other.setAttribute('aria-expanded', 'false');
+            const otherTarget = document.getElementById(other.getAttribute('aria-controls'));
+            if (otherTarget) otherTarget.hidden = true;
+          });
+          if (target && !open) {
+            button.setAttribute('aria-expanded', 'true');
+            target.hidden = false;
+          }
+        });
+      });
+      refresh();
+    })();"""
 
 
 def _dashboard_script() -> str:
@@ -380,6 +621,9 @@ button{cursor:pointer}
 .admin-brand{display:inline-flex;align-items:center;gap:10px;text-decoration:none;color:var(--graphite);font-family:"Instrument Sans","Helvetica Neue",Arial,sans-serif;font-size:20px;font-weight:700;letter-spacing:-.02em}
 .admin-brand img{width:25px;height:29px;object-fit:contain}
 .admin-badge{display:inline-flex;align-items:center;min-height:22px;padding:3px 8px;border:1px solid color-mix(in srgb,var(--sky) 48%,var(--border));border-radius:999px;color:var(--interactive);font-family:"Inter",sans-serif;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase}
+.admin-section-nav{display:flex;align-items:center;gap:4px;margin-left:auto;color:var(--secondary);font-size:13px;font-weight:650}
+.admin-section-nav a{padding:7px 10px;border-radius:8px;text-decoration:none}
+.admin-section-nav a:hover,.admin-section-nav a.active{background:var(--surface);color:var(--interactive)}
 .admin-nav{display:flex;align-items:center;gap:18px;color:var(--secondary);font-size:13px}
 .admin-nav a{text-decoration:none}
 .admin-nav a:hover{color:var(--interactive)}
@@ -443,9 +687,44 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 .error{background:#FBEAE6;color:#81372D}
 .success{background:var(--success-bg);color:#365B3B}
 .account{margin-top:48px}
+.campaign-card{padding:24px;background:var(--surface);border:1px solid var(--border);border-radius:14px}
+.campaign-card>.section-heading{margin-bottom:22px}
+.campaign-preset-row{display:grid;grid-template-columns:minmax(0,1fr) minmax(220px,360px);align-items:center;gap:16px;margin-bottom:20px;padding:13px 14px;background:var(--surface-muted);border:1px solid var(--border);border-radius:10px}
+.campaign-preset-row select,.campaign-field input,.campaign-field select{width:100%;min-height:42px;padding:9px 11px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--graphite)}
+.campaign-form{margin:0}
+.campaign-fields{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px 16px}
+.campaign-field{min-width:0}
+.campaign-field-wide{grid-column:1/-1}
+.campaign-label{display:flex;align-items:center;flex-wrap:wrap;gap:7px;margin:0 0 7px;color:var(--graphite);font-size:13px;font-weight:700}
+.required-label,.optional-label{color:var(--secondary);font-size:10px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}
+.required-label{color:var(--danger)}
+.info-control{display:inline-flex;align-items:center;justify-content:center;width:19px;height:19px;padding:0;border:1px solid var(--border);border-radius:50%;background:var(--surface);color:var(--interactive);font-size:12px;font-weight:750;line-height:1}
+.info-control:hover{border-color:var(--interactive);background:var(--success-bg)}
+.info-popover{position:relative;margin:8px 0 10px;padding:10px 12px;background:var(--surface-muted);border:1px solid var(--border);border-radius:8px;color:var(--secondary);font-size:12px;font-weight:400}
+.info-popover strong{display:block;margin-bottom:3px;color:var(--graphite);font-size:12px}
+.info-popover p{margin:3px 0}
+.info-popover code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;color:var(--graphite)}
+.custom-input{margin-top:9px;padding:10px;background:var(--surface-muted);border-radius:8px}
+.custom-input label{display:block;margin:0 0 6px;color:var(--secondary);font-size:11px;font-weight:650}
+.custom-input input{min-height:38px}
+.campaign-result{margin-top:26px;padding-top:21px;border-top:1px solid var(--border)}
+.incomplete-state{margin:0;padding:12px 14px;background:var(--surface-muted);border:1px dashed var(--border);border-radius:8px;color:var(--secondary);font-size:13px}
+.generated-url-row{display:grid;grid-template-columns:minmax(0,1fr) auto auto;align-items:center;gap:10px}
+.generated-url{display:block;min-width:0;padding:12px 13px;overflow:auto;border:1px solid var(--border);border-radius:8px;background:var(--surface-muted);color:var(--graphite);font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;white-space:nowrap}
+.copy-button{min-height:42px;padding:9px 15px;border:0;border-radius:8px;background:var(--interactive);color:white;font-weight:700}
+.copy-button:hover{background:var(--interactive-hover)}
+.copy-button:disabled{cursor:not-allowed;opacity:.45}
+.copy-status{min-width:54px;color:var(--interactive);font-size:12px;font-weight:700}
+.attribution-preview{display:grid;grid-template-columns:minmax(220px,.65fr) minmax(0,1.35fr);gap:24px;margin-top:26px;padding-top:21px;border-top:1px solid var(--border)}
+.attribution-preview h2{font-size:20px}
+.attribution-preview .table-help{margin-top:8px;max-width:420px}
+.preview-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px;margin:0}
+.preview-grid div{padding:10px 12px;background:var(--surface-muted);border-radius:8px}
+.preview-grid dt{color:var(--secondary);font-size:11px;font-weight:650}
+.preview-grid dd{margin:2px 0 0;overflow-wrap:anywhere;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-@media(max-width:800px){.admin-topbar-inner,.dashboard{width:min(calc(100% - 32px),var(--max-width))}.heading-row{align-items:flex-start;flex-direction:column;gap:12px}.updated-at{margin:0}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.filter-bar input{width:min(100%,360px)}.filter-bar{align-items:stretch}.filter-bar label,.filter-bar select,.filter-bar input{flex:1 1 170px}.public-status{align-items:flex-start;flex-direction:column}.public-status-value{width:100%;justify-content:space-between}}
-@media(max-width:560px){.admin-topbar-inner{align-items:flex-start;flex-direction:column;padding:14px 0}.admin-nav{width:100%;justify-content:space-between;gap:10px}.dashboard{padding-top:28px}.metrics{gap:8px}.metric{min-height:92px;padding:14px}.metric strong{font-size:26px}.auth-card{width:calc(100% - 32px);padding:24px}.section-heading{align-items:flex-start;flex-direction:column;gap:4px}}
+@media(max-width:800px){.admin-topbar-inner,.dashboard{width:min(calc(100% - 32px),var(--max-width))}.admin-section-nav{margin-left:0}.heading-row{align-items:flex-start;flex-direction:column;gap:12px}.updated-at{margin:0}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.filter-bar input{width:min(100%,360px)}.filter-bar{align-items:stretch}.filter-bar label,.filter-bar select,.filter-bar input{flex:1 1 170px}.public-status{align-items:flex-start;flex-direction:column}.public-status-value{width:100%;justify-content:space-between}.campaign-fields{grid-template-columns:1fr}.campaign-field-wide{grid-column:auto}.attribution-preview{grid-template-columns:1fr}}
+@media(max-width:560px){.admin-topbar-inner{align-items:flex-start;flex-direction:column;padding:14px 0}.admin-section-nav{width:100%;overflow:auto}.admin-section-nav a{white-space:nowrap}.admin-nav{width:100%;justify-content:space-between;gap:10px}.dashboard{padding-top:28px}.metrics{gap:8px}.metric{min-height:92px;padding:14px}.metric strong{font-size:26px}.auth-card{width:calc(100% - 32px);padding:24px}.section-heading{align-items:flex-start;flex-direction:column;gap:4px}.campaign-card{padding:16px}.campaign-preset-row{grid-template-columns:1fr;gap:8px}.generated-url-row{grid-template-columns:1fr}.copy-button{width:100%}.copy-status{min-height:18px}}
 """
 
 
@@ -454,6 +733,8 @@ def _error(message: str | None) -> str:
 
 
 def _layout(title: str, content: str) -> bytes:
+    nonce = secrets.token_urlsafe(18)
+    content = content.replace("<script>", f"<script nonce=\"{nonce}\">")
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>{html.escape(title)} · Terento</title><style>{ADMIN_STYLES}</style></head><body>{content}</body></html>""".encode("utf-8")
 
 

--- a/backend/catalog-api/src/terento_catalog/campaign_links.py
+++ b/backend/catalog-api/src/terento_catalog/campaign_links.py
@@ -1,0 +1,113 @@
+"""Pure campaign-link contract used by the private admin link builder.
+
+The admin page performs generation locally in the browser.  Keeping the
+destination and normalization rules here gives the contract a small,
+dependency-free test surface without introducing persistence or an API
+endpoint for campaign links.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+DESTINATIONS = {
+    "home": "https://terento.app/",
+    "download": "https://terento.app/download/",
+    "compatibility": "https://terento.app/compatibility/",
+}
+
+SOURCE_OPTIONS = (
+    ("reddit", "Reddit"),
+    ("github", "GitHub"),
+    ("discord", "Discord"),
+    ("facebook", "Facebook"),
+    ("x", "X"),
+    ("linkedin", "LinkedIn"),
+    ("email", "Email"),
+    ("other", "Other"),
+)
+
+MEDIUM_OPTIONS = (
+    ("social", "Social"),
+    ("community", "Community"),
+    ("email", "Email"),
+    ("referral", "Referral"),
+    ("paid_social", "Paid social"),
+    ("other", "Other"),
+)
+
+CAMPAIGN_SUGGESTIONS = ("early_beta", "launch", "compatibility", "community")
+
+UTM_KEYS = {"utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"}
+
+
+def normalize_value(value: str | None) -> str:
+    """Return the canonical, URL-safe value used for a UTM component."""
+
+    text = unicodedata.normalize("NFKD", str(value or ""))
+    text = "".join(character for character in text if not unicodedata.combining(character))
+    text = text.strip().lower()
+    text = re.sub(r"\s+", "_", text)
+    # Keep the two documented separators, remove other punctuation, and
+    # preserve valid values such as ``garmin-forum-de`` unchanged.
+    text = re.sub(r"[^a-z0-9_-]", "", text)
+    text = re.sub(r"[-_]{2,}", lambda match: match.group(0)[0], text)
+    return text.strip("-_")
+
+
+def _destination_url(destination: str, custom_destination: str | None = None) -> str:
+    if destination in DESTINATIONS:
+        return DESTINATIONS[destination]
+    if destination != "other":
+        raise ValueError("Unknown destination")
+    value = str(custom_destination or "").strip()
+    if not value:
+        raise ValueError("A custom Terento destination is required")
+    if value.startswith("/"):
+        return "https://terento.app" + value
+    parsed = urlsplit(value)
+    if parsed.scheme != "https" or parsed.hostname != "terento.app" or parsed.username or parsed.password:
+        raise ValueError("Custom destinations must use https://terento.app")
+    if parsed.port not in (None, 443):
+        raise ValueError("Custom destinations must use https://terento.app")
+    return urlunsplit(("https", "terento.app", parsed.path or "/", parsed.query, parsed.fragment))
+
+
+def build_campaign_url(
+    *,
+    destination: str,
+    source: str,
+    medium: str,
+    campaign: str,
+    content: str = "",
+    term: str = "",
+    custom_destination: str = "",
+    custom_source: str = "",
+    custom_medium: str = "",
+) -> str:
+    """Build a canonical campaign URL or raise ``ValueError`` when incomplete."""
+
+    destination_url = _destination_url(destination, custom_destination)
+    source_value = normalize_value(custom_source if source == "other" else source)
+    medium_value = normalize_value(custom_medium if medium == "other" else medium)
+    campaign_value = normalize_value(campaign)
+    if not source_value or not medium_value or not campaign_value:
+        raise ValueError("Source, medium, and campaign are required")
+
+    parsed = urlsplit(destination_url)
+    existing = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in UTM_KEYS
+    ]
+    params = existing + [("utm_source", source_value), ("utm_medium", medium_value), ("utm_campaign", campaign_value)]
+    content_value = normalize_value(content)
+    term_value = normalize_value(term)
+    if content_value:
+        params.append(("utm_content", content_value))
+    if term_value:
+        params.append(("utm_term", term_value))
+    return urlunsplit(("https", "terento.app", parsed.path or "/", urlencode(params), parsed.fragment))

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import hmac
+import re
 import time
 from collections import defaultdict, deque
 from datetime import datetime, timedelta, timezone
@@ -16,6 +17,7 @@ from urllib.parse import parse_qs, urlsplit
 from .admin import (
     AdminValidationError,
     account_page,
+    campaign_links_page,
     dashboard_page,
     hash_password,
     login_page,
@@ -307,6 +309,9 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     return
                 self._send_admin_html(body, send_body=send_body)
                 return
+            if request_path in {"/admin/campaign-links", "/admin/campaign-links/"}:
+                self._send_admin_html(campaign_links_page(session, csrf_token), send_body=send_body)
+                return
             if request_path == "/admin/account":
                 self._send_admin_html(account_page(session, csrf_token), send_body=send_body)
                 return
@@ -455,19 +460,24 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
             self, body: bytes, *, send_body: bool, status: HTTPStatus = HTTPStatus.OK
         ) -> None:
             self.send_response(status)
-            self._admin_headers(content_length=len(body))
+            self._admin_headers(content_length=len(body), body=body)
             self.end_headers()
             if send_body:
                 self.wfile.write(body)
 
-        def _admin_headers(self, *, content_length: int) -> None:
+        def _admin_headers(self, *, content_length: int, body: bytes = b"") -> None:
             self._common_headers(
                 cache_control="no-store",
                 content_type="text/html; charset=utf-8",
                 content_length=content_length,
             )
             self.send_header("X-Robots-Tag", "noindex, nofollow")
-            self.send_header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'")
+            nonce_match = re.search(rb'<script nonce="([A-Za-z0-9_-]+)">', body)
+            script_policy = f"script-src 'nonce-{nonce_match.group(1).decode('ascii')}'" if nonce_match else "script-src 'none'"
+            self.send_header(
+                "Content-Security-Policy",
+                f"default-src 'none'; {script_policy}; style-src 'unsafe-inline' https://terento.app; font-src https://terento.app; img-src https://terento.app data:; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+            )
             self.send_header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 
         def _redirect(

--- a/backend/catalog-api/tests/test_campaign_links.py
+++ b/backend/catalog-api/tests/test_campaign_links.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import unittest
+
+from terento_catalog.admin import campaign_links_page
+from terento_catalog.campaign_links import build_campaign_url, normalize_value
+
+
+class CampaignLinkContractTests(unittest.TestCase):
+    def test_normalization_keeps_valid_separators_and_removes_punctuation(self):
+        self.assertEqual(normalize_value(" Garmin Forum-DE! "), "garmin_forum-de")
+        self.assertEqual(normalize_value("Paid__social"), "paid_social")
+        self.assertEqual(normalize_value("  "), "")
+
+    def test_reddit_preset_shape_is_canonical(self):
+        self.assertEqual(
+            build_campaign_url(
+                destination="home",
+                source="reddit",
+                medium="social",
+                campaign="early_beta",
+            ),
+            "https://terento.app/?utm_source=reddit&utm_medium=social&utm_campaign=early_beta",
+        )
+
+    def test_optional_values_are_omitted(self):
+        url = build_campaign_url(
+            destination="compatibility",
+            source="github",
+            medium="community",
+            campaign="early_beta",
+            content="",
+            term="",
+        )
+        self.assertNotIn("utm_content", url)
+        self.assertNotIn("utm_term", url)
+
+    def test_existing_query_is_preserved_and_utms_are_replaced(self):
+        url = build_campaign_url(
+            destination="other",
+            custom_destination="https://terento.app/download/?ref=reddit&utm_source=old&utm_term=old#top",
+            source="reddit",
+            medium="social",
+            campaign="early_beta",
+            content="garminwatches",
+        )
+        self.assertEqual(
+            url,
+            "https://terento.app/download/?ref=reddit&utm_source=reddit&utm_medium=social&utm_campaign=early_beta&utm_content=garminwatches#top",
+        )
+
+    def test_custom_values_and_destination_are_restricted(self):
+        self.assertEqual(
+            build_campaign_url(
+                destination="other",
+                custom_destination="/community/",
+                source="other",
+                custom_source="forum",
+                medium="other",
+                custom_medium="community",
+                campaign="launch",
+            ),
+            "https://terento.app/community/?utm_source=forum&utm_medium=community&utm_campaign=launch",
+        )
+        with self.assertRaises(ValueError):
+            build_campaign_url(
+                destination="other",
+                custom_destination="https://example.com/",
+                source="reddit",
+                medium="social",
+                campaign="launch",
+            )
+
+    def test_page_contains_builder_contract_and_accessible_help(self):
+        body = campaign_links_page({"username": "operator"}, "csrf").decode()
+        for text in (
+            "Campaign links",
+            "Create consistent tracking links for Terento campaigns.",
+            "Campaign link builder",
+            "Reddit community post",
+            "Home",
+            "Download",
+            "Compatibility",
+            "Custom Terento URL or path",
+            "Copy link",
+            "Umami attribution preview",
+            "aria-controls='destination-info'",
+            "aria-controls='campaign-info'",
+            "window.TerentoCampaignLinkBuilder",
+        ):
+            self.assertIn(text, body)
+        self.assertIn("grid-template-columns:repeat(2", body)
+        self.assertNotIn(">Generate<", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -266,6 +266,9 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         initial, _ = self.request("GET", "/admin")
         self.assertEqual(initial.status, 303)
         self.assertEqual(initial.headers["Location"], "/admin/setup")
+        initial_campaign, _ = self.request("GET", "/admin/campaign-links")
+        self.assertEqual(initial_campaign.status, 303)
+        self.assertEqual(initial_campaign.headers["Location"], "/admin/setup")
 
         setup_body = urlencode({
             "username": "operator", "password": "long-test-password",
@@ -289,6 +292,17 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(allowed.status, 200)
         self.assertEqual(allowed.headers["X-Robots-Tag"], "noindex, nofollow")
         self.assertIn(b"f\xc4\x93nix 8", body)
+
+        unauthenticated_campaign, _ = self.request("GET", "/admin/campaign-links")
+        self.assertEqual(unauthenticated_campaign.status, 303)
+        self.assertEqual(unauthenticated_campaign.headers["Location"], "/admin/login")
+
+        campaign_links, campaign_body = self.request("GET", "/admin/campaign-links", headers={"Cookie": cookie_header})
+        self.assertEqual(campaign_links.status, 200)
+        self.assertIn("script-src 'nonce-", campaign_links.headers["Content-Security-Policy"])
+        self.assertRegex(campaign_body, rb'<script nonce="[A-Za-z0-9_-]+">')
+        self.assertIn(b"Campaign link builder", campaign_body)
+        self.assertIn(b"Reddit community post", campaign_body)
 
         update_body = urlencode({
             "csrf_token": csrf_token, "username": "owner",


### PR DESCRIPTION
## Summary
- add the authenticated Campaign links admin destination alongside Installation evidence
- generate canonical Terento UTM links locally with presets, validation, copy feedback, and attribution preview
- keep `/admin/campaign-links` behind the existing admin session/CSRF gate
- add a guarded catalog API deployment workflow with health and unauthenticated admin-route verification

## Verification
- `PYTHONPATH=backend/catalog-api/src python3 -m unittest discover -s backend/catalog-api/tests -p 'test_*.py'`
- `git diff --check`
