### PR TITLE
fix: use catalog compose project directory

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -76,9 +76,9 @@ jobs:
           set -euo pipefail
           release_id="$1"
           stage="/tmp/terento-catalog-api-${release_id}"
-          project="/docker/terento-catalog"
-          compose="$project/deploy/hostinger/catalog/docker-compose.yml"
-          env_file="$project/deploy/hostinger/catalog/.env"
+          project="/docker/terento-catalog/deploy/hostinger/catalog"
+          compose="$project/docker-compose.yml"
+          env_file="$project/.env"
           image="terento-catalog-api:publish-${release_id}"
           override="/tmp/terento-catalog-api-override-${release_id}.yml"
           old_image=""


### PR DESCRIPTION
## Summary
- run the catalog Compose project from its actual `/docker/terento-catalog/deploy/hostinger/catalog` directory
- keep the explicit production `.env` and rollback/health checks

## Context
The image build succeeded in the previous attempt, but Compose resolved `env_file: .env` relative to `/docker/terento-catalog` and stopped before changing any service.

## Verification
- workflow YAML parses and extracted remote shell passes `bash -n`
