### PR TITLE
Fix live catalog router deployment

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -81,12 +81,19 @@ jobs:
           env_file="$project/.env"
           image="terento-catalog-api:publish-${release_id}"
           override="/tmp/terento-catalog-api-override-${release_id}.yml"
+          # The live Traefik router is attached to this Compose project.  Do
+          # not infer the project from an arbitrary catalog-api container:
+          # earlier failed deploys left a second `catalog` project running and
+          # Docker returns both when filtering only by service label.
+          compose_project="terento-catalog"
           old_image=""
           old_container=""
 
           test -f "$compose"
           test -f "$env_file"
-          old_container="$(docker ps -aq --filter label=com.docker.compose.service=catalog-api | head -n 1)"
+          old_container="$(docker ps -aq \
+            --filter label=com.docker.compose.project=${compose_project} \
+            --filter label=com.docker.compose.service=catalog-api | head -n 1)"
           if [ -n "$old_container" ]; then
             old_image="$(docker inspect --format '{{.Config.Image}}' "$old_container")"
           fi
@@ -107,7 +114,7 @@ jobs:
               image: $image
           EOF
 
-          compose_args=(--project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
+          compose_args=(--project-name "$compose_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
           docker compose "${compose_args[@]}" config --quiet
           docker compose "${compose_args[@]}" --profile manual run --rm --no-deps catalog-migrate
 
@@ -119,15 +126,20 @@ jobs:
             catalog-scheduler:
               image: $old_image
           EOF
-            docker compose "${compose_args[@]}" up -d --no-build catalog-api catalog-scheduler || true
+            docker compose "${compose_args[@]}" up -d --force-recreate --no-build catalog-api catalog-scheduler || true
             rm -rf -- "$stage" "$override"
           }
 
-          if ! docker compose "${compose_args[@]}" up -d --no-build catalog-api catalog-scheduler; then
+          if ! docker compose "${compose_args[@]}" up -d --force-recreate --no-build catalog-api catalog-scheduler; then
             rollback
             exit 1
           fi
 
+          # Remove only the known stale project created by the earlier
+          # deployment attempt.  Keep its database and volumes untouched.
+          duplicate_project="catalog"
+          duplicate_args=(--project-name "$duplicate_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
+          docker compose "${duplicate_args[@]}" rm -sf catalog-api catalog-scheduler || true
           health_url="https://api.terento.app/health"
           health_verified=false
           deadline=$(( $(date +%s) + 90 ))
@@ -140,8 +152,9 @@ jobs:
           done
 
           admin_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' https://terento.app/admin/campaign-links || true)"
-          admin_location="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r' | head -n 1 || true)"
-          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ]; then
+          admin_headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
+          admin_location="$(printf '%s\n' "$admin_headers" | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r' | head -n 1)"
+          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ] || ! printf '%s\n' "$admin_headers" | grep -qi "script-src 'none'"; then
             rollback
             exit 1
           fi


### PR DESCRIPTION
The catalog API deploy was replacing a stale Compose project while Traefik continued routing to the live project.

This pins production rollout to the `terento-catalog` Compose project, force-recreates the API/scheduler, removes only the known stale `catalog` services, and gates success on the new admin CSP plus the protected campaign-links redirect.