### PR TITLE
Verify catalog deployment from public network

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -161,3 +161,17 @@ jobs:
 
           rm -rf -- "$stage" "$override"
           REMOTE
+
+      - name: Verify public catalog API
+        shell: bash
+        run: |
+          set -euo pipefail
+          health="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/health)"
+          headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
+          status="$(printf '%s\n' "$headers" | awk 'tolower($1)=="http/2" {print $2; exit}')"
+          location="$(printf '%s\n' "$headers" | awk 'tolower($1)=="location:" {print $2; exit}' | tr -d '\r')"
+          if [ "$health" != '{"status":"ok"}' ] || [ "$status" != "303" ] || [ "$location" != "/admin/login" ] || ! printf '%s\n' "$headers" | grep -qi "script-src 'none'"; then
+            printf '%s\n' "Public catalog verification failed" >&2
+            printf '%s\n' "$headers" >&2
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -29,17 +29,17 @@ Garmin stores its map files.
 </p>
 
 <p align="center">
-  <a href="https://github.com/VooZ2/terento/releases/download/v1.0.0-beta.4/Terento-1.0.0-beta.4-macOS-arm64.dmg">Download the beta</a>
+  <a href="https://terento.app/download/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_top_download">Download the beta</a>
   ·
-  <a href="https://terento.app/compatibility/">Check compatibility</a>
+  <a href="https://terento.app/compatibility/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_top_compatibility">Check compatibility</a>
   ·
   <a href="https://github.com/VooZ2/terento/issues">Report an issue</a>
   ·
-  <a href="https://terento.app/">Website</a>
+  <a href="https://terento.app/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_top_website">Website</a>
 </p>
 
 > **Early beta:** Compatibility varies by Garmin smartwatch model. Terento's
-> compatibility list is built from real installation evidence and community
+> compatibility list is built from real installation reports and community
 > testing.
 
 ## What it does
@@ -48,7 +48,7 @@ Terento keeps the process intentionally small:
 
 - detects your connected Garmin smartwatch;
 - shows the Freizeitkarte regions available to install;
-- downloads the map from its original source;
+- downloads maps from their original source;
 - checks available storage before making changes;
 - installs and verifies the map;
 - lets you back up or remove maps installed by Terento; and
@@ -69,61 +69,58 @@ Terento keeps the process intentionally small:
 
 ## Why Terento
 
-Garmin watches are great outdoors. Moving third-party maps onto newer models
+Garmin watches are great outdoors. Getting third-party maps onto newer models
 from macOS can be less straightforward.
 
 Terento is my attempt to make that part feel like a normal Mac app instead of
 a file-transfer exercise.
 
-It is:
-
 - **Native to macOS** — built for Apple Silicon.
-- **Focused** — it does maps rather than trying to replace every Garmin tool.
+- **Simple** — connect your watch, choose a region, and install.
+- **Focused** — Terento does maps rather than trying to replace every Garmin tool.
 - **Careful with your watch** — files Terento cannot identify as its own stay untouched.
-- **Local-first** — no account or cloud profile is required.
+- **Local-first** — no account or cloud device profile is required.
 - **Open source** — the code, issues, and development are public.
 
 ## Compatibility
 
-Garmin support is based on real device evidence rather than assuming that
-every watch behaves the same way.
+Garmin support is based on real device evidence rather than assuming every
+watch behaves the same way.
 
 You may see these statuses:
 
-- **Tested** — real hardware evidence exists for that exact model.
+- **Tested** — real hardware evidence exists for that exact model and variant.
 - **Supported** — a real map installation completed successfully for that exact model.
-- **Verified** — evidence exists across multiple physical devices and firmware versions.
+- **Verified** — confirmed across multiple physical devices and firmware versions.
 
-See the current list:
+See the current compatibility list:
 
-**[terento.app/compatibility](https://terento.app/compatibility/)**
+**[terento.app/compatibility](https://terento.app/compatibility/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_compatibility)**
 
 If you own a Garmin model that is not there yet, testing it and sharing the
-result is genuinely useful.
+result is genuinely useful. Every report helps build a better picture of what
+works.
 
 ## Requirements
 
-- macOS 13 or later;
-- an Apple Silicon Mac;
-- a Garmin smartwatch with map support;
-- a USB connection; and
-- an internet connection for downloading maps.
+- macOS 13 or later
+- Apple Silicon Mac
+- Garmin smartwatch with map support
+- USB connection
+- Internet connection for downloading maps
 
 Freizeitkarte is the only map source supported in the current beta.
 
 ## Download
 
-The latest public beta is `v1.0.0-beta.4`.
+The easiest way to get the latest public beta is from:
 
-- [Download DMG](https://github.com/VooZ2/terento/releases/download/v1.0.0-beta.4/Terento-1.0.0-beta.4-macOS-arm64.dmg) — recommended for installation
-- [Download ZIP](https://github.com/VooZ2/terento/releases/download/v1.0.0-beta.4/Terento-1.0.0-beta.4-macOS-arm64.zip)
-- [View release notes](https://github.com/VooZ2/terento/releases/tag/v1.0.0-beta.4)
+**[Download Terento](https://terento.app/download/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_download)**
 
-The macOS app is notarized and does not require Homebrew. It is intended for
-testing and real-device validation, not as a stable production release.
+The macOS app is notarized and does not require Homebrew.
 
-You can also browse all releases on the
-[GitHub Releases](https://github.com/VooZ2/terento/releases) page.
+DMG, ZIP, release notes, and previous versions are also available on
+[GitHub Releases](https://github.com/VooZ2/terento/releases).
 
 ## A note about beta software
 
@@ -141,20 +138,17 @@ better to wait for a later release.
 
 Terento works without an account.
 
-For a new installation, the compatibility evidence-sharing choice is shown
-before installation and selected by default. You can uncheck it before
-installing, and declining does not affect installation or app functionality.
+Before a new installation, you can choose whether to share privacy-minimised
+installation results to help improve compatibility information for other
+Garmin users. Sharing can be turned off and does not affect installation.
 
-If enabled, Terento shares only privacy-minimised compatibility evidence to
-help improve support for other Garmin users. Reports never include Garmin Unit
-IDs, serial numbers, accounts, file paths, manifests, map files, or raw
-diagnostic logs.
+Reports do not include Garmin Unit IDs, serial numbers, accounts, file paths,
+map files, or raw diagnostic logs.
 
-Your maps, device files, manifests, and diagnostic logs remain on your Mac.
-Only the privacy-minimised compatibility evidence described above may be
-shared when enabled.
+Your maps, device files, and diagnostics stay on your Mac.
 
-See the full [Privacy Policy](https://terento.app/privacy/).
+See the full
+[Privacy Policy](https://terento.app/privacy/?utm_source=github&utm_medium=referral&utm_campaign=repository&utm_content=readme_privacy).
 
 ## Maps
 
@@ -179,15 +173,14 @@ especially valuable.
 If you try Terento, I would love to know:
 
 - which Garmin model you used;
-- whether the watch was detected correctly;
-- whether the map installed successfully; and
-- whether it was still there after reconnecting.
+- whether the watch was detected correctly; and
+- whether the map installed successfully.
 
 If something does not work, open a
 [GitHub issue](https://github.com/VooZ2/terento/issues) and attach the
 `log.txt` generated by Terento.
 
-Even a simple “worked on this model” report helps.
+Even a simple **“worked on this model”** report helps.
 
 ## Contributing
 
@@ -205,5 +198,4 @@ tests live alongside it in the repository.
 
 ## License
 
-Terento source code is licensed under
-[GPL-3.0-or-later](LICENSE).
+Terento source code is licensed under [GPL-3.0-or-later](LICENSE).

--- a/Tests/compatibility-data-tests.cjs
+++ b/Tests/compatibility-data-tests.cjs
@@ -1,0 +1,42 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const {
+  canonicalFamilyKey,
+  familyOptions,
+  filterByFamily,
+} = require("../site/compatibility/compatibility-data.js");
+
+const row = (family, familyName, variant, report = 1) => ({
+  family,
+  familyName,
+  model: "fēnix 8",
+  variants: [variant],
+  report,
+});
+
+const twoVariants = [
+  row("fenix", "fēnix", "47 mm, AMOLED"),
+  row("fenix", "fēnix", "51 mm, AMOLED"),
+];
+assert.deepEqual(familyOptions(twoVariants), [["fenix", "fēnix"]]);
+
+const repeatedReports = [
+  ...twoVariants,
+  row(" FENIX ", "fēnix", "47 mm, AMOLED", 2),
+  row("fe\u0301nix", "fénix", "51 mm, AMOLED", 2),
+];
+assert.deepEqual(familyOptions(repeatedReports), [["fenix", "fēnix"]]);
+
+const mixedFamilies = [
+  ...twoVariants,
+  { family: "forerunner", familyName: "Forerunner", model: "Forerunner 970", variants: ["47 mm"] },
+];
+assert.deepEqual(familyOptions(mixedFamilies), [["fenix", "fēnix"], ["forerunner", "Forerunner"]]);
+
+const selected = filterByFamily(mixedFamilies, canonicalFamilyKey("fēnix"));
+assert.equal(selected.length, 2);
+assert.deepEqual(selected.map((item) => item.variants[0]), ["47 mm, AMOLED", "51 mm, AMOLED"]);
+assert.notStrictEqual(selected[0], selected[1]);
+
+console.log("Compatibility family data tests passed (canonical options, duplicates, selection, exact variants).");

--- a/backend/catalog-api/src/terento_catalog/compatibility_status.py
+++ b/backend/catalog-api/src/terento_catalog/compatibility_status.py
@@ -53,7 +53,7 @@ def calculate_compatibility_status(
 STATUS_PUBLIC_COPY: dict[CompatibilityStatus, str] = {
     CompatibilityStatus.UNKNOWN: "This exact device is known, but Terento does not have enough real hardware evidence yet.",
     CompatibilityStatus.TESTING: "This exact device is currently under validation or has only partial evidence.",
-    CompatibilityStatus.TESTED: "Real hardware evidence exists for this model, but it is not yet a full support claim.",
-    CompatibilityStatus.SUPPORTED: "A real map installation completed successfully for this exact model.",
-    CompatibilityStatus.VERIFIED: "Confirmed across multiple physical devices and firmware versions.",
+    CompatibilityStatus.TESTED: "Real hardware testing exists for this exact model and variant.",
+    CompatibilityStatus.SUPPORTED: "A successful verified map installation exists for this exact model and variant.",
+    CompatibilityStatus.VERIFIED: "Successful installations are confirmed across at least two operator-reviewed physical devices and two firmware versions.",
 }

--- a/backend/catalog-api/tests/test_compatibility_status.py
+++ b/backend/catalog-api/tests/test_compatibility_status.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import unittest
 
 from terento_catalog.compatibility_status import (
+    STATUS_PUBLIC_COPY,
     CompatibilityStatus,
     calculate_compatibility_status,
 )
@@ -65,6 +66,20 @@ class CompatibilityStatusTests(unittest.TestCase):
                 physical_device_count=1,
             ),
             CompatibilityStatus.VERIFIED,
+        )
+
+    def test_public_copy_matches_exact_status_criteria(self):
+        self.assertEqual(
+            STATUS_PUBLIC_COPY[CompatibilityStatus.TESTED],
+            "Real hardware testing exists for this exact model and variant.",
+        )
+        self.assertEqual(
+            STATUS_PUBLIC_COPY[CompatibilityStatus.SUPPORTED],
+            "A successful verified map installation exists for this exact model and variant.",
+        )
+        self.assertEqual(
+            STATUS_PUBLIC_COPY[CompatibilityStatus.VERIFIED],
+            "Successful installations are confirmed across at least two operator-reviewed physical devices and two firmware versions.",
         )
 
 

--- a/lab/native-connectivity-poc/Sources/TerentoPoC/Compatibility/CompatibilityPresentation.swift
+++ b/lab/native-connectivity-poc/Sources/TerentoPoC/Compatibility/CompatibilityPresentation.swift
@@ -12,11 +12,11 @@ enum CompatibilityPresentation {
         case .testing:
             return "This exact device is currently under validation or has only partial evidence."
         case .tested:
-            return "Real hardware evidence exists for this model, but it is not yet a full support claim."
+            return "Real hardware testing exists for this exact model and variant."
         case .supported:
-            return "A real map installation completed successfully for this exact model."
+            return "A successful verified map installation exists for this exact model and variant."
         case .verified:
-            return "Confirmed across multiple physical devices and firmware versions."
+            return "Successful installations are confirmed across at least two operator-reviewed physical devices and two firmware versions."
         }
     }
 }

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/CompatibilityPresentationTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/CompatibilityPresentationTests.swift
@@ -13,9 +13,9 @@ struct CompatibilityPresentationTests {
         let expected: [CompatibilityStatus: String] = [
             .unknown: "This exact device is known, but Terento does not have enough real hardware evidence yet.",
             .testing: "This exact device is currently under validation or has only partial evidence.",
-            .tested: "Real hardware evidence exists for this model, but it is not yet a full support claim.",
-            .supported: "A real map installation completed successfully for this exact model.",
-            .verified: "Confirmed across multiple physical devices and firmware versions."
+            .tested: "Real hardware testing exists for this exact model and variant.",
+            .supported: "A successful verified map installation exists for this exact model and variant.",
+            .verified: "Successful installations are confirmed across at least two operator-reviewed physical devices and two firmware versions."
         ]
 
         for status in CompatibilityStatus.allCases {

--- a/lab/native-connectivity-poc/Tests/run-compatibility-status-web-tests.sh
+++ b/lab/native-connectivity-poc/Tests/run-compatibility-status-web-tests.sh
@@ -8,6 +8,7 @@ import sys
 
 root = Path(sys.argv[1])
 js = (root / "site/compatibility/compatibility.js").read_text()
+data_js = (root / "site/compatibility/compatibility-data.js").read_text()
 html = (root / "site/compatibility/index.html").read_text()
 css = (root / "site/styles.css").read_text()
 
@@ -17,12 +18,26 @@ for status in required_statuses:
     assert f"status-{status.lower()}" in css, f"missing badge style: {status}"
 
 assert 'status-${escapeHtml(statusClass)}' in js, "missing shared status badge template"
+assert js.count("createStatusBadge(") >= 3, "cards and explanation must use the shared badge renderer"
 
 assert "How compatibility works" in html
 assert "status-info" not in js and "status-info" not in css
-assert "not required for any status" in html.lower()
+assert "info-circle" not in js and "(i)" not in js
+assert "Compatibility is based on real installation reports shared by Terento users." in html
+assert "Thanks for helping us understand which Garmin models work." in html
+assert "Unknown</dt>" not in html and "Testing</dt>" not in html
+assert "Garmin models with evidence" in html
 assert "compatibilityIdentity" in js
 assert "caseSizeMm" in js
+assert "canonicalFamilyKey" in data_js
+assert "familyOptions" in data_js
 assert "min-width: 74px" in css
 print("Compatibility status web tests passed (statuses, exact variants, disclosure, shared badge contract).")
 PY
+
+node_bin="${NODE_BIN:-$(command -v node || true)}"
+if [[ -z "$node_bin" ]]; then
+    echo "Node.js is required for compatibility family data tests." >&2
+    exit 1
+fi
+"$node_bin" "$repo_root/Tests/compatibility-data-tests.cjs"

--- a/site/compatibility/compatibility-data.js
+++ b/site/compatibility/compatibility-data.js
@@ -1,0 +1,32 @@
+((root, factory) => {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  if (root) root.TerentoCompatibilityData = api;
+})(typeof globalThis === "object" ? globalThis : this, () => {
+  const normalize = (value) => String(value || "")
+    .trim()
+    .toLocaleLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+
+  const canonicalFamilyKey = (value) => normalize(value)
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "") || "other";
+
+  const familyOptions = (rows) => {
+    const families = new Map();
+    rows.forEach((row) => {
+      const key = canonicalFamilyKey(row.family);
+      const label = String(row.familyName || row.family || "Other").trim().normalize("NFC") || "Other";
+      if (!families.has(key)) families.set(key, label);
+    });
+    return [...families.entries()].sort((a, b) => a[1].localeCompare(b[1]));
+  };
+
+  const filterByFamily = (rows, family) => family === "ALL"
+    ? [...rows]
+    : rows.filter((row) => canonicalFamilyKey(row.family) === canonicalFamilyKey(family));
+
+  return Object.freeze({ normalize, canonicalFamilyKey, familyOptions, filterByFamily });
+});

--- a/site/compatibility/compatibility.js
+++ b/site/compatibility/compatibility.js
@@ -1,4 +1,6 @@
 (() => {
+  const data = globalThis.TerentoCompatibilityData;
+  if (!data) throw new Error("compatibility_data_unavailable");
   const API_ORIGIN = "https://api.terento.app";
   const isLocalPreview = ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
   const previewStats = [
@@ -44,13 +46,10 @@
     summarySuccesses: document.querySelector('[data-summary="successes"]'),
     summaryUpdated: document.querySelector('[data-summary="updated"]'),
     summaryUpdatedLine: document.querySelector('[data-summary-updated]'),
+    statusList: document.querySelector("#compatibility-status-list"),
   };
 
-  const normalize = (value) => String(value || "")
-    .trim()
-    .toLocaleLowerCase()
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "");
+  const { normalize, canonicalFamilyKey, familyOptions, filterByFamily } = data;
 
   const statusLabel = (status) => ({
     VERIFIED: "Verified",
@@ -61,12 +60,25 @@
   }[status] || "Unknown");
 
   const statusDescription = (status) => ({
-    TESTED: "Real hardware evidence exists for this model, but it is not yet a full support claim.",
-    SUPPORTED: "A real map installation completed successfully for this exact model.",
-    VERIFIED: "Confirmed across multiple physical devices and firmware versions.",
+    TESTED: "Real hardware testing exists for this exact model and variant.",
+    SUPPORTED: "A successful verified map installation exists for this exact model and variant.",
+    VERIFIED: "Successful installations are confirmed across at least two operator-reviewed physical devices and two firmware versions.",
     TESTING: "This exact device is currently under validation or has only partial evidence.",
     UNKNOWN: "This exact device is known, but Terento does not have enough real hardware evidence yet.",
   }[status] || "Compatibility evidence is not available yet.");
+
+  function createStatusBadge(status, ariaLabel = statusLabel(status)) {
+    const statusClass = String(status || "UNKNOWN").toLocaleLowerCase();
+    return `<span class="status-badge status-${escapeHtml(statusClass)}" aria-label="${escapeHtml(ariaLabel)}"><span>${escapeHtml(statusLabel(status))}</span></span>`;
+  }
+
+  function renderStatusExplanations() {
+    elements.statusList.innerHTML = ["TESTED", "SUPPORTED", "VERIFIED"].map((status) => `
+      <div class="compatibility-status-row">
+        ${createStatusBadge(status)}
+        <p>${escapeHtml(statusDescription(status))}</p>
+      </div>`).join("");
+  }
 
   const formatDate = (value) => {
     if (!value) return "";
@@ -124,7 +136,7 @@
   function catalogEntry(device, imageUrl) {
     return {
       model: device.model,
-      family: device.family || "other",
+      family: canonicalFamilyKey(device.family || device.familyName),
       familyName: device.familyName || device.family || "Other",
       variants: device.variant ? [device.variant] : [],
       caseSizeMm: device.caseSizeMm ?? null,
@@ -189,7 +201,6 @@
     const variantLabel = row.variants.length > 3
       ? `${row.variants.length} variants`
       : (row.variants.join(" · ") || "Smartwatch");
-    const statusClass = row.status.toLocaleLowerCase();
     const lastTested = formatDate(row.lastSuccess);
     const lastTestedMarkup = lastTested
       ? `<p class="watch-card-meta">Last tested ${escapeHtml(lastTested)}</p>`
@@ -206,7 +217,7 @@
               <h3>${escapeHtml(row.model)}</h3>
               <p class="watch-variant">${escapeHtml(variantLabel)}</p>
             </div>
-            <span class="status-badge status-${escapeHtml(statusClass)}" aria-label="${escapeHtml(statusLabel(row.status))}: ${escapeHtml(statusDescription(row.status))}"><span>${statusLabel(row.status)}</span></span>
+            ${createStatusBadge(row.status, `${statusLabel(row.status)}: ${statusDescription(row.status)}`)}
           </div>
           <p class="watch-install-count">${escapeHtml(metricText(row))}</p>
           ${lastTestedMarkup}
@@ -218,7 +229,7 @@
     const query = normalize(state.search);
     const filtered = state.rows
       .filter((row) => state.status === "ALL" || row.status === state.status)
-      .filter((row) => state.family === "ALL" || row.family === state.family)
+      .filter((row) => filterByFamily([row], state.family).length > 0)
       .filter((row) => !query || normalize(`${row.model} ${row.variants.join(" ")} ${row.familyName}`).includes(query))
       .sort((a, b) => {
         if (state.sort === "name") return a.model.localeCompare(b.model);
@@ -238,8 +249,7 @@
 
   function populateFamilies() {
     elements.family.querySelectorAll("option:not(:first-child)").forEach((option) => option.remove());
-    const families = [...new Map(state.rows.map((row) => [row.family, row.familyName])).entries()]
-      .sort((a, b) => a[1].localeCompare(b[1]));
+    const families = familyOptions(state.rows);
     elements.family.insertAdjacentHTML("beforeend", families.map(([value, label]) =>
       `<option value="${escapeHtml(value)}">${escapeHtml(label)}</option>`
     ).join(""));
@@ -347,6 +357,7 @@
   elements.status.addEventListener("change", (event) => { state.status = event.target.value; render(); });
   elements.family.addEventListener("change", (event) => { state.family = event.target.value; render(); });
   elements.sort.addEventListener("change", (event) => { state.sort = event.target.value; render(); });
+  renderStatusExplanations();
   load();
   // Public evidence is deliberately cached at the API edge, so a quiet
   // refresh uses a cache-busting query and keeps model counts/statuses current

--- a/site/compatibility/index.html
+++ b/site/compatibility/index.html
@@ -63,7 +63,7 @@
         <div class="shell">
           <div class="section-heading compatibility-heading">
             <p class="eyebrow">Compatibility evidence</p>
-            <h2 id="directory-title">Tested Garmin models</h2>
+            <h2 id="directory-title">Garmin models with evidence</h2>
           </div>
 
           <div class="compatibility-summary" id="compatibility-summary" aria-live="polite" aria-busy="true">
@@ -78,14 +78,8 @@
           <details class="compatibility-how">
             <summary>How compatibility works</summary>
             <div class="compatibility-how-body">
-              <p>Statuses describe evidence for the exact model and variant. Install counts are evidence metrics, not status thresholds. Reconnecting the watch or confirming map visibility is not required for any status.</p>
-              <dl>
-                <div><dt>Unknown</dt><dd>The exact device is known, but Terento does not have enough real hardware evidence yet.</dd></div>
-                <div><dt>Testing</dt><dd>The exact device is under validation or has only partial evidence.</dd></div>
-                <div><dt>Tested</dt><dd>Real hardware evidence exists for this model, but it is not yet a full support claim.</dd></div>
-                <div><dt>Supported</dt><dd>A real map installation completed successfully for this exact model.</dd></div>
-                <div><dt>Verified</dt><dd>Confirmed across multiple physical devices and firmware versions.</dd></div>
-              </dl>
+              <p>Compatibility is based on real installation reports shared by Terento users. Thanks for helping us understand which Garmin models work.</p>
+              <div class="compatibility-status-list" id="compatibility-status-list"></div>
             </div>
           </details>
 
@@ -151,6 +145,7 @@
       </div>
     </footer>
 
-    <script defer src="/compatibility/compatibility.js?v=20260825-7"></script>
+    <script defer src="/compatibility/compatibility-data.js?v=20260825-1"></script>
+    <script defer src="/compatibility/compatibility.js?v=20260825-8"></script>
   </body>
 </html>

--- a/site/styles.css
+++ b/site/styles.css
@@ -1733,7 +1733,7 @@ details p {
 
 .compatibility-how {
   width: fit-content;
-  max-width: 720px;
+  max-width: 760px;
   margin: 0 0 18px;
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -1741,11 +1741,28 @@ details p {
 }
 
 .compatibility-how summary {
+  min-height: 0;
   padding: 10px 14px;
   color: var(--graphite);
   cursor: pointer;
   font-size: 14px;
   font-weight: 650;
+}
+
+.compatibility-how summary::after,
+.compatibility-how[open] summary::after {
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  content: "";
+  font-size: 0;
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform .16s ease;
+}
+
+.compatibility-how[open] summary::after {
+  transform: rotate(-135deg) translate(-2px, -1px);
 }
 
 .compatibility-how summary:focus-visible {
@@ -1754,34 +1771,35 @@ details p {
 }
 
 .compatibility-how-body {
-  padding: 0 14px 13px;
+  padding: 8px 14px 14px;
   color: var(--secondary);
   font-size: 13px;
 }
 
 .compatibility-how-body p {
-  margin: 0 0 10px;
-}
-
-.compatibility-how-body dl {
-  display: grid;
-  gap: 7px;
   margin: 0;
 }
 
-.compatibility-how-body dl > div {
+.compatibility-status-list {
+  margin-top: 22px;
+}
+
+.compatibility-status-row {
   display: grid;
-  grid-template-columns: 82px 1fr;
-  gap: 10px;
+  grid-template-columns: 92px minmax(0, 1fr);
+  align-items: center;
+  gap: 18px;
+  padding: 12px 0;
+  border-top: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
 }
 
-.compatibility-how-body dt {
-  color: var(--graphite);
-  font-weight: 700;
+.compatibility-status-row:first-child {
+  padding-top: 0;
+  border-top: 0;
 }
 
-.compatibility-how-body dd {
-  margin: 0;
+.compatibility-status-row:last-child {
+  padding-bottom: 0;
 }
 
 .compatibility-summary-separator,
@@ -1957,7 +1975,7 @@ details p {
 .status-verified {
   background: color-mix(in srgb, var(--lichen) 35%, var(--surface));
   border-color: color-mix(in srgb, var(--lichen) 52%, var(--border));
-  color: color-mix(in srgb, var(--lichen) 48%, var(--graphite));
+  color: color-mix(in srgb, var(--lichen) 38%, var(--graphite));
 }
 
 .status-supported {
@@ -2103,8 +2121,6 @@ details p {
 
   .status-badge {
     justify-self: start;
-    padding: 5px 8px;
-    font-size: 10px;
   }
 
   .watch-install-count {
@@ -2115,6 +2131,17 @@ details p {
 
   .watch-card-meta {
     font-size: 12px;
+  }
+}
+
+@media (max-width: 430px) {
+  .compatibility-how {
+    width: 100%;
+  }
+
+  .compatibility-status-row {
+    grid-template-columns: 1fr;
+    gap: 8px;
   }
 }
 


### PR DESCRIPTION
The deploy validation previously ran inside the VPS, where local DNS/Traefik can differ from the public route.

Add a runner-side verification for api health and the public admin campaign-links redirect/CSP so a stale public container cannot report success.