### PR TITLE
Log live catalog router identity

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -135,6 +135,11 @@ jobs:
             exit 1
           fi
 
+          echo "Catalog API containers after rollout:"
+          for container in $(docker ps -aq --filter label=com.docker.compose.service=catalog-api); do
+            docker inspect --format '{{.Name}} project={{ index .Config.Labels "com.docker.compose.project" }} image={{.Config.Image}} admin={{ index .Config.Labels "traefik.http.routers.terento-admin.rule" }}' "$container"
+          done
+
           # Remove only the known stale project created by the earlier
           # deployment attempt.  Keep its database and volumes untouched.
           duplicate_project="terento-catalog"


### PR DESCRIPTION
Add non-sensitive deployment diagnostics for catalog-api container/project/image and the Traefik admin rule. This is needed because the external gate still sees the old CSP despite the expected Compose rollout.