### PR TITLE
fix: accept strict default CSP in API deploy check

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -154,7 +154,7 @@ jobs:
           admin_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' https://terento.app/admin/campaign-links || true)"
           admin_headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
           admin_location="$(printf '%s\n' "$admin_headers" | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r' | head -n 1)"
-          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ] || ! printf '%s\n' "$admin_headers" | grep -qi "script-src 'none'"; then
+          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ] || ! printf '%s\n' "$admin_headers" | grep -Eqi "(script-src|default-src)[[:space:]]+'none'"; then
             rollback
             exit 1
           fi
@@ -170,7 +170,7 @@ jobs:
           headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
           status="$(printf '%s\n' "$headers" | awk 'tolower($1)=="http/2" {print $2; exit}')"
           location="$(printf '%s\n' "$headers" | awk 'tolower($1)=="location:" {print $2; exit}' | tr -d '\r')"
-          if [ "$health" != '{"status":"ok"}' ] || [ "$status" != "303" ] || [ "$location" != "/admin/login" ] || ! printf '%s\n' "$headers" | grep -qi "script-src 'none'"; then
+          if [ "$health" != '{"status":"ok"}' ] || [ "$status" != "303" ] || [ "$location" != "/admin/login" ] || ! printf '%s\n' "$headers" | grep -Eqi "(script-src|default-src)[[:space:]]+'none'"; then
             printf '%s\n' "Public catalog verification failed" >&2
             printf '%s\n' "$headers" >&2
             exit 1


### PR DESCRIPTION
## Summary
- accept the valid default-src none CSP form in the catalog API deploy verification
- retain support for an explicit script-src none directive
- prevent a successfully rolled-out API container from being rolled back due to an over-specific header assertion

## Validation
- shell regex check passed
- git diff --check passed