### PR TITLE
Move admin to the catalog API deployment

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -155,9 +155,9 @@ jobs:
           duplicate_args=(--project-name "$duplicate_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
           docker compose "${duplicate_args[@]}" rm -sf catalog-api catalog-scheduler catalog-db || true
 
-          mapfile -t api_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-api)
-          mapfile -t scheduler_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-scheduler)
-          mapfile -t db_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-db)
+          mapfile -t api_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-api)
+          mapfile -t scheduler_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-scheduler)
+          mapfile -t db_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-db)
           api_container="$(docker compose "${compose_args[@]}" ps -q catalog-api)"
           scheduler_container="$(docker compose "${compose_args[@]}" ps -q catalog-scheduler)"
           db_container="$(docker compose "${compose_args[@]}" ps -q catalog-db)"

--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -183,7 +183,17 @@ jobs:
             exit 1
           fi
 
+          if ! docker exec "$api_container" python -c \
+            'import urllib.request; assert b"<title>Admin sign in \xc2\xb7 Terento</title>" in urllib.request.urlopen("http://127.0.0.1:8000/admin/login", timeout=5).read()'; then
+            rollback
+            exit 1
+          fi
+
           echo "Catalog services: one API, one scheduler, one healthy database; release $release_id"
+          echo "Active Traefik containers:"
+          for container in $(docker ps -q --filter label=traefik.enable=true); do
+            docker inspect --format '{{.Name}} project={{ index .Config.Labels "com.docker.compose.project" }} image={{.Config.Image}} catalog={{ index .Config.Labels "traefik.http.routers.terento-catalog.rule" }} admin={{ index .Config.Labels "traefik.http.routers.terento-admin.rule" }}' "$container"
+          done
 
           rm -rf -- "$stage" "$override"
           REMOTE

--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - beta
+    paths:
+      - "backend/catalog-api/src/**"
+      - "backend/catalog-api/Dockerfile"
+      - "backend/catalog-api/pyproject.toml"
+      - ".github/workflows/deploy-catalog-api.yml"
   workflow_dispatch:
 
 permissions:
@@ -102,12 +107,18 @@ jobs:
           fi
           test -n "$old_image"
 
-          docker build --pull=false -f "$stage/backend/catalog-api/Dockerfile" -t "$image" "$stage/backend/catalog-api"
+          docker build --pull=false \
+            --label "io.terento.release=$release_id" \
+            -f "$stage/backend/catalog-api/Dockerfile" \
+            -t "$image" \
+            "$stage/backend/catalog-api"
 
           cat > "$override" <<EOF
           services:
             catalog-api:
               image: $image
+              labels:
+                traefik.http.routers.terento-admin.rule: 'Host(\`api.terento.app\`) && PathPrefix(\`/admin\`)'
             catalog-scheduler:
               image: $image
             catalog-migrate:
@@ -135,29 +146,44 @@ jobs:
             exit 1
           fi
 
-          # Remove only the known stale project created by the earlier
-          # deployment attempt.  Keep its database and volumes untouched.
+          # Remove only services from the known duplicate project created by
+          # the earlier rollout attempts. Database/asset volumes are retained.
           duplicate_project="terento-catalog"
           duplicate_args=(--project-name "$duplicate_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
-          docker compose "${duplicate_args[@]}" rm -sf catalog-api catalog-scheduler || true
-          health_url="https://api.terento.app/health"
-          health_verified=false
-          deadline=$(( $(date +%s) + 90 ))
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            if curl --fail --silent --connect-timeout 5 --max-time 10 "$health_url" | grep -q '"status":"ok"'; then
-              health_verified=true
-              break
-            fi
-            sleep 2
-          done
+          docker compose "${duplicate_args[@]}" rm -sf catalog-api catalog-scheduler catalog-db || true
 
-          admin_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' https://terento.app/admin/campaign-links || true)"
-          admin_headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
-          admin_location="$(printf '%s\n' "$admin_headers" | awk 'tolower($1)=="location:" {print $2}' | tr -d '\r' | head -n 1)"
-          if [ "$health_verified" != true ] || [ "$admin_status" != "303" ] || [ "$admin_location" != "/admin/login" ] || ! printf '%s\n' "$admin_headers" | grep -Eqi "(script-src|default-src)[[:space:]]+'none'"; then
+          mapfile -t api_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-api)
+          mapfile -t scheduler_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-scheduler)
+          mapfile -t db_containers < <(docker ps -q --filter label=com.docker.compose.service=catalog-db)
+          api_container="$(docker compose "${compose_args[@]}" ps -q catalog-api)"
+          scheduler_container="$(docker compose "${compose_args[@]}" ps -q catalog-scheduler)"
+          db_container="$(docker compose "${compose_args[@]}" ps -q catalog-db)"
+
+          if [ "${#api_containers[@]}" -ne 1 ] || [ "${#scheduler_containers[@]}" -ne 1 ] || [ "${#db_containers[@]}" -ne 1 ] \
+            || [ "${api_containers[0]:-}" != "$api_container" ] \
+            || [ "${scheduler_containers[0]:-}" != "$scheduler_container" ] \
+            || [ "${db_containers[0]:-}" != "$db_container" ]; then
+            docker ps -a --format 'container={{.Names}} image={{.Image}} status={{.Status}}' \
+              --filter label=com.docker.compose.service
             rollback
             exit 1
           fi
+
+          api_release="$(docker inspect --format '{{ index .Config.Labels "io.terento.release" }}' "$api_container")"
+          scheduler_release="$(docker inspect --format '{{ index .Config.Labels "io.terento.release" }}' "$scheduler_container")"
+          db_health="$(docker inspect --format '{{.State.Health.Status}}' "$db_container")"
+          if [ "$api_release" != "$release_id" ] || [ "$scheduler_release" != "$release_id" ] || [ "$db_health" != "healthy" ]; then
+            rollback
+            exit 1
+          fi
+
+          if ! docker exec "$api_container" python -c \
+            'import urllib.request; assert urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=5).read() == b"{\"status\":\"ok\"}"'; then
+            rollback
+            exit 1
+          fi
+
+          echo "Catalog services: one API, one scheduler, one healthy database; release $release_id"
 
           rm -rf -- "$stage" "$override"
           REMOTE
@@ -167,11 +193,23 @@ jobs:
         run: |
           set -euo pipefail
           health="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/health)"
-          headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://terento.app/admin/campaign-links || true)"
-          status="$(printf '%s\n' "$headers" | awk 'tolower($1)=="http/2" {print $2; exit}')"
+          maps="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/maps/catalog.json)"
+          devices="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/devices/catalog.json)"
+          login="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/admin/login)"
+          headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://api.terento.app/admin/campaign-links || true)"
+          status="$(printf '%s\n' "$headers" | awk 'toupper($1) ~ /^HTTP\// {code=$2} END {print code}')"
           location="$(printf '%s\n' "$headers" | awk 'tolower($1)=="location:" {print $2; exit}' | tr -d '\r')"
-          if [ "$health" != '{"status":"ok"}' ] || [ "$status" != "303" ] || [ "$location" != "/admin/login" ] || ! printf '%s\n' "$headers" | grep -Eqi "(script-src|default-src)[[:space:]]+'none'"; then
+          if [ "$health" != '{"status":"ok"}' ] \
+            || ! printf '%s\n' "$maps" | grep -q '"catalogVersion"' \
+            || ! printf '%s\n' "$devices" | grep -q '"catalogVersion"' \
+            || ! printf '%s\n' "$login" | grep -q '<title>Admin sign in · Terento</title>' \
+            || [ "$status" != "303" ] \
+            || [ "$location" != "/admin/login" ] \
+            || ! printf '%s\n' "$headers" | grep -qi "script-src 'none'"; then
             printf '%s\n' "Public catalog verification failed" >&2
             printf '%s\n' "$headers" >&2
             exit 1
           fi
+
+          compatibility_script="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://terento.app/compatibility/compatibility.js)"
+          printf '%s\n' "$compatibility_script" | grep -q 'https://api.terento.app'

--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -127,7 +127,10 @@ jobs:
 
           compose_args=(--project-name "$compose_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
           docker compose "${compose_args[@]}" config --quiet
-          docker compose "${compose_args[@]}" --profile manual run --rm --no-deps catalog-migrate
+          # The remote script itself arrives over stdin. Keep the migration
+          # container detached from that stream or it consumes the remaining
+          # rollout commands after printing its migration result.
+          docker compose "${compose_args[@]}" --profile manual run --rm --no-deps -T catalog-migrate </dev/null
 
           rollback() {
             cat > "$override" <<EOF

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - beta
+    paths:
+      - "site/**"
+      - "site-deploy/**"
+      - ".github/workflows/deploy-site.yml"
     tags:
       - "v*"
   workflow_dispatch:

--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -62,24 +62,29 @@ PYTHONPATH=backend/catalog-api/src python3 -m unittest discover -s backend/catal
 - `DELETE /compatibility/events` lets the client erase one uploaded event by
   presenting its event UUID and secret deletion token. Events are also pruned
   automatically after 24 months.
-- `GET /admin` serves the authenticated, noindex aggregate operator dashboard
+- `GET https://api.terento.app/admin` serves the authenticated, noindex
+  aggregate operator dashboard from the same API container as the catalog
   and account settings. The first account requires `ADMIN_BOOTSTRAP_SECRET`;
   later credentials are PBKDF2-hashed in PostgreSQL.
-- `GET /admin/campaign-links` serves the authenticated, client-side campaign
-  link builder. It shares the `/admin` session gate and stores no campaign
-  links or history.
+- `GET https://api.terento.app/admin/campaign-links` serves the authenticated,
+  client-side campaign link builder. It shares the `/admin` session gate and
+  stores no campaign links or history.
 - `GET /compatibility/public/top-models.json` is a prepared, default-disabled
   aggregate API. It returns only individually reviewed and approved models
   after `PUBLIC_COMPATIBILITY_STATS_ENABLED=true`; it never returns raw events.
 
-Production API updates are rolled out by
+Production API and admin updates are rolled out only when the catalog backend
+or its deployment workflow changes; application releases and unrelated site
+changes do not restart this service. They are rolled out by
 `.github/workflows/deploy-catalog-api.yml`. The workflow builds the API image
 from the checked-in source, runs the forward migration command against the
 existing private database, replaces only the API and scheduler containers,
-waits for `/health`, and verifies that unauthenticated admin requests redirect
-to `/admin/login`. It keeps the previous API image available for rollback and
-does not change the PostgreSQL or asset volumes. The workflow uses the pinned
-SSH secrets already documented for the Hostinger deployment account.
+removes services from the known stale Compose project without deleting its
+volumes, and asserts that exactly one API, scheduler, and healthy database are
+running. It verifies the image release label, internal API-to-database health,
+the public catalog/device endpoints, the website's API reference, and the
+authenticated admin gate at `api.terento.app`. It keeps the previous API image
+available for rollback and does not change the PostgreSQL or asset volumes.
 
 The catalog includes a map only after a collector has a normalized version and
 a known download size. A missing size is retained in the database but omitted

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -47,7 +47,7 @@ client keeps deletion tokens locally; the server stores only their hashes.
 Compatibility events older than 24 months are pruned from the active database
 by the service health cycle.
 
-## `GET /admin`
+## `GET https://api.terento.app/admin`
 
 Returns an aggregate HTML operator dashboard after database-backed login. The
 dashboard uses the Terento branded English admin shell, exact model/variant
@@ -61,7 +61,7 @@ are rate limited. Pages include no-store, noindex and restrictive CSP headers.
 Raw event payloads are not displayed. `/internal/compatibility/` redirects to
 this route for the earlier local implementation.
 
-## `GET /admin/campaign-links`
+## `GET https://api.terento.app/admin/campaign-links`
 
 Returns the authenticated operator's local Campaign link builder. It is a
 client-side tool: no campaign links, history, or analytics data are stored and
@@ -70,7 +70,7 @@ no campaign-link API is exposed. The builder restricts destinations to
 keeps the canonical parameter order `utm_source`, `utm_medium`,
 `utm_campaign`, `utm_content`, `utm_term`. The page uses the same private
 admin session, CSRF cookie, no-store response policy, and noindex policy as
-`GET /admin`.
+`GET https://api.terento.app/admin`.
 
 ## `GET /compatibility/public/top-models.json`
 

--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -99,10 +99,10 @@ curl -fsS https://api.terento.app/health
 curl -fsSI https://api.terento.app/maps/catalog.json
 curl -fsSI https://api.terento.app/devices/catalog.json
 curl -fsSI https://api.terento.app/assets/devices/garmin/example.webp
-curl -fsSI https://terento.app/admin
+curl -fsSI https://api.terento.app/admin
 ```
 
 The asset URL returns 404 until an asset is explicitly approved and published.
-Before an administrator exists, `/admin` returns a 303 redirect to
-`/admin/setup`; after setup it redirects unauthenticated requests to
-`/admin/login`. Both are expected and remain noindex/no-store.
+Before an administrator exists, `https://api.terento.app/admin` returns a 303
+redirect to `/admin/setup`; after setup it redirects unauthenticated requests
+to `/admin/login`. Both are expected and remain noindex/no-store.

--- a/site-deploy/Caddyfile
+++ b/site-deploy/Caddyfile
@@ -21,6 +21,9 @@
   @legacySupportedWatches path /supported-watches /supported-watches/*
   redir @legacySupportedWatches /compatibility/ permanent
 
+  @legacyAdmin path /admin /admin/*
+  redir @legacyAdmin https://api.terento.app{uri} permanent
+
   handle_errors {
     header X-Robots-Tag "noindex, nofollow"
     rewrite * /404.html


### PR DESCRIPTION
## Summary
- serve the authenticated admin and campaign link builder from https://api.terento.app/admin
- isolate API and site deploy triggers so unrelated beta changes do not restart both stacks
- fix the SSH rollout script so the migration container cannot consume the remaining deployment commands
- verify a single API, scheduler, and healthy database plus live API, admin, website, and app integration endpoints
- permanently redirect the legacy https://terento.app/admin route

## Validation
- 69 catalog API tests pass locally
- workflow YAML and embedded shell validate locally
- catalog API deployment run 32889975891 passed in 36 seconds
- public site deployment run 32890052854 passed in 40 seconds
- live health, catalogs, admin login protection, campaign-links CSP, redirect, and compatibility API origin verified