### PR TITLE
Make public site deployment rerunnable

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -89,6 +89,9 @@ jobs:
           docker build --pull=false -f "$stage/site-deploy/Dockerfile" -t "$image" "$stage"
 
           if docker inspect "$container" >/dev/null 2>&1; then
+            # A repeated deployment of the same commit reuses release_id. Remove
+            # only its stale, stopped rollback container before reserving the name.
+            docker rm -f "$rollback" >/dev/null 2>&1 || true
             docker rename "$container" "$rollback"
             docker stop "$rollback" >/dev/null
             old_container="$rollback"
@@ -150,5 +153,8 @@ jobs:
             exit 1
           fi
 
+          if [ -n "$old_container" ]; then
+            docker rm -f "$old_container" >/dev/null
+          fi
           rm -rf -- "$stage"
           REMOTE

--- a/site-deploy/README.md
+++ b/site-deploy/README.md
@@ -7,12 +7,15 @@ site origin or a Cloudflare Pages project.
 `.github/workflows/deploy-site.yml` publishes the tracked `site/` tree after a
 push to `beta` or a `v*` tag. The workflow connects to the VPS with a GitHub
 Actions SSH key, builds the pinned Caddy image, replaces only the `terento-web`
-container, and keeps the previous web container as a rollback target. It does
-not touch Traefik, the catalog API, PostgreSQL, or map files. After the new
-container starts, the workflow first verifies that the update manifest exists
-inside the image, then waits up to 60 seconds for the public Traefik/Cloudflare
-route to serve the arm64 manifest. A transient route-refresh delay therefore
-does not cause an unnecessary rollback.
+container, and keeps the previous web container as a rollback target only
+until the new deployment passes its checks. The workflow then removes that
+temporary rollback container; rerunning the same commit also clears a stale
+rollback bearing the same release identifier before switching containers. It
+does not touch Traefik, the catalog API, PostgreSQL, or map files. After the
+new container starts, the workflow first verifies that the update manifest
+exists inside the image, then waits up to 60 seconds for the public
+Traefik/Cloudflare route to serve the arm64 manifest. A transient route-refresh
+delay therefore does not cause an unnecessary rollback.
 
 Configure these GitHub repository secrets before enabling the workflow:
 


### PR DESCRIPTION
## Summary
- remove a stale same-release rollback container before renaming the active site container
- retain rollback only while the new deployment is being verified
- remove the temporary rollback after successful public manifest verification
- document the idempotent deployment lifecycle

## Evidence
- reproduced by beta.5 branch/tag deploys sharing the same commit SHA
- workflow YAML parses successfully
- live beta.5 site and update manifest remain healthy