### PR TITLE
Deploy backward-compatible installation diagnostics API

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -13,7 +13,7 @@ aggregate route. No route serves map binaries.
 
 ## `POST /compatibility/events`
 
-Accepts at most 16 KiB of allowlisted schema-version-1 or schema-version-2 JSON after client
+Accepts at most 16 KiB of allowlisted schema-version-1, schema-version-2, or schema-version-3 JSON after client
 opt-in. Event UUIDs are idempotent. Unknown fields, local paths, malformed
 payloads, non-Freizeitkarte providers, and privacy-prohibited data are
 rejected. A random per-event deletion token is required; older beta payloads
@@ -41,6 +41,18 @@ event IDs do not increase the successful count. Firmware variation, physical
 device count, operator review, reconnect, and map visibility are retained only
 as optional evidence dimensions and do not promote a status.
 
+Version 3 groups all map results from one Install press under a random
+`operationId` and records the exact app release/build plus controlled failure
+stage/code, write/remote-object/cleanup booleans, and a coarse transfer
+progress bucket. It never accepts raw native messages, local paths, object
+IDs, manifests, hashes, serials, Unit IDs, or local watch keys. Selected maps
+not reached after an earlier failure use `NOT_STARTED`. Download, extraction,
+source-validation, and preflight failures remain visible in the private
+operation detail but `writeStarted=false` excludes them from device
+compatibility rates. Compatibility thresholds count distinct write-started
+operations, not child map rows; a multi-map operation succeeds only when all
+of its selected map results verify. Legacy events remain one operation each.
+
 ## `DELETE /compatibility/events`
 
 Accepts the event UUID and its 64-character deletion token. The service hashes
@@ -63,7 +75,9 @@ bootstrap secret. Passwords use salted PBKDF2-SHA256;
 opaque sessions and CSRF values are stored only as SHA-256 hashes. Cookies are
 Secure, HttpOnly, SameSite=Strict, and scoped to `/admin`. Login/setup attempts
 are rate limited. Pages include no-store, noindex and restrictive CSP headers.
-Raw event payloads are not displayed. `/internal/compatibility/` redirects to
+The error count links to a private per-operation detail with child map results,
+release/build, failure stage and allowlisted codes. Raw event payloads and raw
+diagnostic text are not displayed. `/internal/compatibility/` redirects to
 this route for the earlier local implementation.
 
 ## `GET https://api.terento.app/admin/campaign-links`
@@ -97,6 +111,13 @@ is no-store/noindex, and joins installation events only through
 `canonical_device_model_id`. It is not part of the native or public device
 catalog API contracts.
 
+The page labels the operator field `Support decision` and shows a separate,
+classifier-derived `Evidence status`. `POST /admin/devices/support` accepts
+the CSRF-protected `device_id` and one of `SUPPORTED`, `UNSUPPORTED`, or
+`NOT_EVALUATED`; it updates only `device_model.support_status`. It cannot
+change evidence events, install counts, evidence status, or any native device
+write authorization.
+
 ## `GET /compatibility/public/top-models.json`
 
 Prepared for a later public TOP-models widget. The route returns 404 unless
@@ -106,8 +127,9 @@ statistics. Results are ordered by successful installation count and include
 attempted, successful, failed, canonical model, exact identity, case size,
 display type, canonical device-catalog ID, map-capability, last-evidence, and
 canonical-status fields; firmware and raw event records are omitted. All
-four canonical statuses may be public after review. The public `/compatibility/` page calls this
-endpoint when the public compatibility flag is enabled. The endpoint remains
+four canonical statuses may be public after review. The native macOS client
+continues to use this existing route. The public website uses the additive
+`/compatibility/public/models.json` projection below. The endpoint remains
 default-disabled and the page shows no public evidence when the flag or
 approved aggregate data is absent.
 
@@ -133,6 +155,24 @@ when MTP omits the display token. This is reviewed identity evidence, not an
 inference from case size or artwork. An unreviewed 47 mm identity without
 display evidence must not match either the AMOLED or Solar row, including via
 the native offline cache.
+
+## `GET /compatibility/public/models.json`
+
+Additive evidence-first projection for the public Compatibility page. It uses
+the same default-disabled flag and `APPROVED`/`public_statistics_enabled`
+review gate as the existing route, but it is a separate contract so the
+website does not need to join the retail device catalog. Historical evidence
+rows can therefore appear even when Garmin no longer lists that model in its
+current retail category. The response contains exact identity, evidence
+counts, `evidenceStatus`, family/variant display metadata, and an optional
+`image` object. `image` follows controlled Terento asset → allowlisted Garmin
+`garmin-source` URL → `null`; a null image is a valid public card state.
+
+This endpoint does not expose `supportStatus`, operator review decisions,
+transport profiles, write authorization, Unit IDs, or raw event data. The
+website uses only `evidenceStatus` for its compatibility badge. Existing
+native/web clients are not required to call this endpoint, and
+`/devices/catalog.json` remains unchanged.
 
 ## `GET /health`
 

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -32,8 +32,9 @@ optional `reconnectVerified` and `mapVisibleAfterReconnect` observations.
 Older beta clients remain accepted when the newer identity fields are absent;
 such model-only evidence must not be matched to a sibling exact variant.
 Reconnect is never required for any compatibility status. The canonical
-aggregate uses the exact successful
-opt-in installation count: `TESTING` for zero successful installations on
+aggregate groups by `canonicalDeviceId` when available and uses exact
+`compatibilityIdentity` only as the fallback for older uncanonicalized events.
+It then uses the successful opt-in installation count: `TESTING` for zero successful installations on
 recognized map-capable evidence, `TESTED` for 1–2, `SUPPORTED` for 3–4, and
 `VERIFIED` for 5 or more. Failed reports, opt-out local installs, and duplicate
 event IDs do not increase the successful count. Firmware variation, physical
@@ -75,6 +76,26 @@ keeps the canonical parameter order `utm_source`, `utm_medium`,
 `utm_campaign`, `utm_content`, `utm_term`. The page uses the same private
 admin session, CSRF cookie, no-store response policy, and noindex policy as
 `GET https://api.terento.app/admin`.
+
+## `GET https://api.terento.app/admin/devices`
+
+Returns the authenticated Garmin device observability page. The page is
+limited to Garmin catalog records and combines catalogue metadata, map
+capability, separate operator support state, exact-ID installation
+aggregates, approved cached assets or allowlisted Garmin `sourceAsset`
+thumbnails, and latest successful sync metadata. Map-capable Yes/No uses a
+stored `device_model.map_capable` value when present; otherwise the page
+classifies the canonical model with the same Map Manager prefix list as the
+native macOS client. Unknown remains only for models outside that list. The
+page keeps the dense list paginated in the browser and opens a detail dialog
+for technical fields, including which image origin was used
+(controlled Terento asset vs official Garmin product media).
+
+`GET https://api.terento.app/admin/devices.json` returns the same additive
+data as JSON for admin tooling. The endpoint uses the existing admin session,
+is no-store/noindex, and joins installation events only through
+`canonical_device_model_id`. It is not part of the native or public device
+catalog API contracts.
 
 ## `GET /compatibility/public/top-models.json`
 

--- a/backend/catalog-api/docs/device-api.md
+++ b/backend/catalog-api/docs/device-api.md
@@ -30,6 +30,26 @@ install maps on it. Compatibility status is deliberately absent from this
 public contract. The existing validated fēnix 8 USB identity (`VID 0x091e`,
 `PID 0x51b8`) is stored separately and is not copied to other devices.
 
+The private admin view is additive and is not part of this public contract.
+`/admin/devices.json` is authenticated and may include catalogue sync
+metadata, map-capability state, operator support state, installation
+aggregates joined by the exact canonical device record ID, and image
+observability fields (`asset`, `sourceAsset`, `image`). When
+`device_model.map_capable` is NULL, the admin payload classifies the
+canonical model with the same Map Manager prefix list as the native client.
+The HTML page may render an allowlisted `res.garmin.com` `sourceAsset` as a
+thumbnail when no controlled `AVAILABLE` asset exists; that image is not
+proxied by Terento. Public clients must continue to use
+`/devices/catalog.json` for catalog data.
+
+## Admin time display
+
+Authenticated `/admin` pages keep API and storage timestamps in UTC ISO 8601,
+then render them in the visitor's browser time zone by default. The header
+includes a time-zone selector for manual IANA-zone changes; the choice is
+stored only in that browser's local storage. This changes presentation only
+and does not alter API fields, database values, or collector schedules.
+
 ## Canonicalization
 
 Display names retain official diacritics, for example `fēnix`. Stable identity
@@ -104,7 +124,11 @@ metadata. If `sourceAsset` is not yet present, the macOS client may derive the
 same official product-media path from a validated catalog part number. The
 client downloads that source image directly to the user's Mac and caches it
 locally; the catalog API never relays the image. Invalid or incomplete source
-metadata is ignored and the generic fallback remains.
+metadata is ignored and the generic fallback remains. Authenticated admin HTML
+pages, including `/admin/devices`, may additionally load allowlisted
+`https://res.garmin.com` URLs as thumbnails so operators can verify that a
+catalog row has a model-matched official product image. The catalog API still
+never downloads, mirrors, or proxies those bytes.
 
 ## Asset delivery and fallback contract
 

--- a/backend/catalog-api/docs/device-api.md
+++ b/backend/catalog-api/docs/device-api.md
@@ -11,7 +11,7 @@ The source category is the initial scope for Garmin watch/wearable discovery.
 The collector does not expand into unrelated automotive, marine, cycling,
 handheld, dog, or other product categories. Garmin's retail category is not a
 complete historical device database, so known older models may be inserted
-later from separately reviewed sources.
+from separately reviewed sources.
 
 The current official JSON request is:
 
@@ -25,10 +25,21 @@ response shape fails closed and preserves the previous catalog.
 ## Device catalog versus compatibility
 
 `/devices/catalog.json` answers only: “This Garmin product exists in the
-official catalog.” It does not answer whether Terento can connect to it or
-install maps on it. Compatibility status is deliberately absent from this
-public contract. The existing validated fēnix 8 USB identity (`VID 0x091e`,
-`PID 0x51b8`) is stored separately and is not copied to other devices.
+official current retail catalog.” It does not answer whether Terento can
+connect to it or install maps on it. Compatibility status is deliberately
+absent from this public contract. Retail rows are collector-managed; inactive
+retail rows remain in the database for continuity, while reviewed historical
+rows have `record_source = HISTORICAL_REVIEWED` and
+`collector_managed = false` and are intentionally excluded from this endpoint.
+The existing validated fēnix 8 USB identity (`VID 0x091e`, `PID 0x51b8`) is
+stored separately and is not copied to other devices.
+
+The historical registry in `terento_catalog.historical_devices` is versioned
+and sourced from Garmin's official Connect IQ compatible-device references.
+It includes fēnix 7, fēnix 7S/7X, fēnix 6 variants, epix Gen 2, and Forerunner
+955. A consented evidence event can resolve to one of these rows even when
+the current retail collector has never returned it. Historical rows are never
+deactivated by retail absence.
 
 The private admin view is additive and is not part of this public contract.
 `/admin/devices.json` is authenticated and may include catalogue sync
@@ -160,7 +171,22 @@ validated WebP under `/assets/devices/` and changes the record to `AVAILABLE`.
 The public API never serves review storage. The runtime limit is 8 MiB and
 dimensions must be valid and between 1 and 16384 pixels.
 
-## Failure and inactive policy
+## Historical evidence and inactive policy
+
+Compatibility ingestion resolves a reviewed historical identity in the same
+database transaction as event insertion. If no reviewed identity matches, the
+event remains stored under its privacy-minimised textual identity instead of
+being rejected because it is absent from the retail catalog. This resolution
+does not grant a device write and is not consulted by the native write safety
+profile.
+
+The collector writes only current retail rows. A historical row is not part of
+the collector's absence counter and remains active in the database regardless
+of how many weekly retail collections omit it. Current retail rows are never
+deleted automatically; a model is marked inactive only after it is absent
+from three consecutive successful complete collections.
+
+## Failure policy
 
 The collector writes only after the category response has passed shape and
 scope validation. A product-page enrichment failure keeps the successful

--- a/backend/catalog-api/docs/schema.md
+++ b/backend/catalog-api/docs/schema.md
@@ -167,7 +167,24 @@ cache it locally only after validating the host and HTTPS URL.
 Append-only operational diagnostics for Garmin collections. It stores source,
 timestamps, counts, status (`RUNNING`, `SUCCEEDED`, `PARTIAL`, `FAILED`), and
 structured warning/error diagnostics. These diagnostics are not exposed by
-the public API.
+the public API. Migration `014` adds nullable before/after/add/update counts
+for syncs recorded after that migration and exact first/last collection-run
+links on `device_model`. Historical runs without those counters remain
+explicitly unknown rather than being presented as zero.
+
+Migration `014` also adds the admin-only `device_model.map_capable` field
+(`true`, `false`, or `NULL` for unknown) and the separate operator-controlled
+`device_model.support_status` field (`SUPPORTED`, `UNSUPPORTED`, or
+`NOT_EVALUATED`). Neither field is added to the public device catalog
+contract. Map capability, support state, and installation evidence remain
+independent concepts. The migration carries forward the existing exact
+write-capable `garmin-fenix-8-47-amoled` profile as `map_capable = true` and
+`support_status = 'SUPPORTED'`. For other records, a stored `map_capable`
+value still wins, but a `NULL` column is classified at admin-read time and on
+the next Garmin collection from the same Map Manager prefix list used by the
+native client (`terento_catalog.map_capability`, kept aligned with
+`GarminMapCapabilityRegistry`). That classification is not a support claim
+and does not authorize writes. Unrecognised models remain `NULL` / Unknown.
 
 ## Compatibility evidence and statistics
 
@@ -184,17 +201,26 @@ stores maintainer-reviewed physical-device evidence, notes, review state, and
 the default-false public-statistics switch/display name.
 
 `compatibility_model_statistics` is a live SQL view over the immutable event
-table and model review metadata. It calculates attempted, successful and
+table and model review metadata. Events with a `canonical_device_model_id` are
+grouped by that exact Garmin catalog record; textual `compatibility_identity`
+is only the fallback for older uncanonicalized events. Formatting changes
+between app versions therefore increase one variant's report and success
+counts instead of creating another model row. The view calculates attempted, successful and
 failed installation counts, success rate, firmware coverage, latest outcomes,
 error-category totals and the canonical evidence status. Events carry an exact
 compatibility identity plus optional variant/case-size and reconnect/map-
-visibility observations. Reconnect is informational only. `SUPPORTED` means
-at least one successful verified map installation; `VERIFIED` additionally
-requires successful evidence across multiple operator-reviewed physical
-devices and firmware versions. The private dashboard reads this view. The
+visibility observations. Reconnect is informational only. Status depends only
+on successful opt-in installations: zero is `TESTING`, 1–2 is `TESTED`, 3–4
+is `SUPPORTED`, and 5 or more is `VERIFIED`. The private dashboard reads this view. The
 prepared public query additionally requires both `review_status = 'APPROVED'`
 and `public_statistics_enabled = true` and only exposes evidence-backed
 statuses.
+
+The private `/admin/devices.json` aggregate joins evidence only through
+`compatibility_evidence_event.canonical_device_model_id = device_model.id`.
+It returns one row per exact Garmin catalog record, so display model strings
+cannot merge separate variants. The HTML `/admin/devices` page uses the same
+query and keeps technical USB identities inside the detail dialog.
 
 ## Administrator authentication
 

--- a/backend/catalog-api/docs/schema.md
+++ b/backend/catalog-api/docs/schema.md
@@ -105,12 +105,17 @@ band, and material SKUs are collapsed by the collector.
 | `source_image_url` | `text` | Allowlisted direct official Garmin media URL (`res.garmin.com`), nullable |
 | `active` | `boolean` | Conservative current/ historical state |
 | `consecutive_missed_collections` | `smallint` | Absence counter used by inactive policy |
+| `record_source` | `text` | `CURRENT_RETAIL`, `HISTORICAL_REVIEWED`, or `EVIDENCE_DISCOVERED` |
+| `collector_managed` | `boolean` | Whether the current retail collector may update/deactivate this row |
 | `first_seen_at`, `last_seen_at` | `timestamptz` | Observation timestamps |
 | `created_at`, `updated_at` | `timestamptz` | Local audit timestamps |
 
-Records are preserved. `active` becomes false only after three consecutive
-successful complete collections do not observe a model; a partial or failed
-collection does not advance that policy.
+Records are preserved. Only `collector_managed = true` rows participate in the
+absence policy: `active` becomes false after three consecutive successful
+complete collections do not observe a model; a partial or failed collection
+does not advance that policy. Migration `016` seeds reviewed historical
+identities, including fēnix 7, with `collector_managed = false`, so retail
+absence cannot deactivate them.
 
 ## `device_usb_identity`
 
@@ -200,12 +205,24 @@ revised client could not erase. `compatibility_model_review`
 stores maintainer-reviewed physical-device evidence, notes, review state, and
 the default-false public-statistics switch/display name.
 
+Migration 017 adds schema-v3 structured diagnostics. `operation_id` groups the
+per-map rows produced by one Install action; map index/count, app build/release,
+allowlisted failure stage and codes, write/object/cleanup state, and coarse
+progress are stored as separate columns. No raw JSON or error message is
+retained. `NOT_STARTED` is reserved for selected child maps skipped after an
+earlier result stopped the batch.
+
 `compatibility_model_statistics` is a live SQL view over the immutable event
 table and model review metadata. Events with a `canonical_device_model_id` are
 grouped by that exact Garmin catalog record; textual `compatibility_identity`
 is only the fallback for older uncanonicalized events. Formatting changes
 between app versions therefore increase one variant's report and success
-counts instead of creating another model row. The view calculates attempted, successful and
+counts instead of creating another model row. Schema-v3 rows are first grouped
+by operation; legacy rows each form one operation. Only write-started
+operations enter attempted/success/failed compatibility counts, and a
+multi-map operation succeeds only if every selected child result verifies.
+Separate map-result and pre-write-failure totals remain available for private
+diagnosis. The view calculates attempted, successful and
 failed installation counts, success rate, firmware coverage, latest outcomes,
 error-category totals and the canonical evidence status. Events carry an exact
 compatibility identity plus optional variant/case-size and reconnect/map-
@@ -215,6 +232,18 @@ is `SUPPORTED`, and 5 or more is `VERIFIED`. The private dashboard reads this vi
 prepared public query additionally requires both `review_status = 'APPROVED'`
 and `public_statistics_enabled = true` and only exposes evidence-backed
 statuses.
+
+Migration `015_canonical_compatibility_aggregation.sql` replaces the earlier
+view rule that promoted one successful install to `SUPPORTED`. The view now
+uses the same thresholds as `terento_catalog.compatibility_status`, and the
+runtime API reapplies that classifier before rendering. This keeps raw DB
+views, admin output, and public evidence output aligned.
+
+Compatibility evidence may resolve to a reviewed historical `device_model`
+transactionally during ingestion. An unresolved identity is retained under
+its textual compatibility identity rather than rejected for missing retail
+catalog membership. Neither the canonical link nor the evidence status is a
+device write authorization.
 
 The private `/admin/devices.json` aggregate joins evidence only through
 `compatibility_evidence_event.canonical_device_model_id = device_model.id`.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -4,13 +4,20 @@ import base64
 import hashlib
 import hmac
 import html
+import json
 import re
 import secrets
 from datetime import datetime, timezone
 from typing import Any
 
 from .campaign_links import CAMPAIGN_SUGGESTIONS, MEDIUM_OPTIONS, SOURCE_OPTIONS
-from .compatibility_status import STATUS_PUBLIC_COPY, CompatibilityStatus
+from .compatibility_status import (
+    STATUS_PUBLIC_COPY,
+    CompatibilityStatus,
+    calculate_compatibility_status,
+)
+from .device_catalog import _official_source_image_url
+from .map_capability import classify_map_capable
 
 
 PASSWORD_MIN_LENGTH = 14
@@ -82,6 +89,18 @@ def format_timestamp(value: Any) -> str:
         months = ("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec")
         return f"{parsed.day:02d} {months[parsed.month - 1]} {parsed.year}, {parsed.hour:02d}:{parsed.minute:02d} UTC"
     return str(value)
+
+
+def _timestamp_markup(value: Any) -> str:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return html.escape(format_timestamp(value))
+    iso = parsed.isoformat()
+    return (
+        f"<time class='admin-timestamp' datetime='{html.escape(iso, quote=True)}' "
+        f"data-admin-timestamp='{html.escape(iso, quote=True)}'>"
+        f"{html.escape(format_timestamp(parsed))}</time>"
+    )
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -188,9 +207,10 @@ def _admin_header(user: dict[str, Any], csrf_token: str, *, active: str = "evide
     username = html.escape(str(user.get("username") or ""))
     evidence_class = " class='active'" if active == "evidence" else ""
     campaign_class = " class='active'" if active == "campaigns" else ""
+    devices_class = " class='active'" if active == "devices" else ""
     return f"""<header class="admin-topbar"><div class="admin-topbar-inner">{_admin_brand()}
-      <nav class="admin-section-nav" aria-label="Admin sections"><a{evidence_class} href="/admin">Installation evidence</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a></nav>
-      <nav class="admin-nav" aria-label="Admin navigation"><a href="/admin/account">Account</a><span class="admin-user">{username}</span>
+      <nav class="admin-section-nav" aria-label="Admin sections"><a{evidence_class} href="/admin">Installation evidence</a><a{devices_class} href="/admin/devices">Garmin devices</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a></nav>
+      <nav class="admin-nav" aria-label="Admin navigation"><label class="timezone-control"><span>Time zone</span><select id="admin-timezone" aria-label="Time zone"><option value="browser">Automatic (browser)</option><option value="UTC">UTC</option><option value="Europe/Vilnius">Europe/Vilnius</option><option value="Europe/London">Europe/London</option><option value="Europe/Berlin">Europe/Berlin</option><option value="America/New_York">America/New_York</option><option value="America/Los_Angeles">America/Los_Angeles</option><option value="Asia/Tokyo">Asia/Tokyo</option></select></label><a href="/admin/account">Account</a><span class="admin-user">{username}</span>
       <form method="post" action="/admin/logout"><input type="hidden" name="csrf_token" value="{html.escape(csrf_token)}"><button class="link-button" type="submit">Sign out</button></form></nav>
     </div></header>"""
 
@@ -262,20 +282,20 @@ def dashboard_page(
     )
     table_rows = "".join(_statistics_row(row) for row in rows)
     empty = "<p class='empty'>No installation evidence reports yet.</p>" if not rows else ""
-    latest_copy = f"Updated {format_timestamp(latest)}" if latest else "No reports received yet"
+    latest_copy = f"Updated {_timestamp_markup(latest)}" if latest else "No reports received yet"
     content = f"""
       {_admin_header(user, csrf_token)}
       <main class="dashboard" id="main-content">
-        <div class="heading-row"><div><p class="eyebrow">Admin</p><h1>Installation evidence</h1><p class="lede">Compatibility reports received from Terento installations.</p></div><p class="updated-at">{html.escape(latest_copy)}</p></div>
+        <div class="heading-row"><div><p class="eyebrow">Admin</p><h1>Installation evidence</h1><p class="lede">Compatibility reports received from Terento installations.</p></div><p class="updated-at">{latest_copy}</p></div>
         <section class="metrics" aria-label="Evidence summary">{cards}</section>{empty}
         <section class="evidence-section" aria-labelledby="evidence-title">
-          <div class="section-heading"><div><p class="section-kicker">Evidence</p><h2 id="evidence-title">Installation reports</h2></div><p class="table-help">Times shown in UTC</p></div>
+          <div class="section-heading"><div><p class="section-kicker">Evidence</p><h2 id="evidence-title">Installation reports</h2></div><p class="table-help">Times follow the selected time zone</p></div>
           <form class="filter-bar" id="evidence-filters" role="search">
             <label class="filter-search"> <span class="sr-only">Search models</span><input id="evidence-search" type="search" placeholder="Search models" autocomplete="off"></label>
             <label><span class="sr-only">Filter by status</span><select id="evidence-status"><option value="all">All statuses</option>{status_options}</select></label>
             <label><span class="sr-only">Sort reports</span><select id="evidence-sort"><option value="reports">Most reports</option><option value="latest">Latest activity</option></select></label>
           </form>
-          <p class="results-count" id="results-count" aria-live="polite">{len(rows)} {"report" if len(rows) == 1 else "reports"}</p>
+          <p class="results-count" id="results-count" aria-live="polite">{len(rows)} {"model" if len(rows) == 1 else "models"}</p>
           <div class="table-wrap"><table><caption class="sr-only">Installation evidence reports by exact device identity</caption><thead><tr><th scope="col">Model</th><th scope="col">Variant</th><th scope="col">Firmware</th><th scope="col">Reports</th><th scope="col">Successful</th><th scope="col">Failed</th><th scope="col">Success rate</th><th scope="col">Status</th><th scope="col">Last success</th><th scope="col">Errors</th></tr></thead><tbody id="evidence-rows">{table_rows}</tbody></table></div>
         </section>
         <section class="status-guide" aria-labelledby="status-guide-title"><div class="section-heading"><div><p class="section-kicker">Canonical rules</p><h2 id="status-guide-title">Compatibility statuses</h2></div><p class="table-help">Exact model and variant; successful shared installations only</p></div><div class="status-guide-grid">{''.join(f"<div class='status-guide-row'>{_status_badge(status)}<span>{html.escape(STATUS_PUBLIC_COPY[CompatibilityStatus(status)])}</span></div>" for status in status_values)}</div></section>
@@ -284,6 +304,239 @@ def dashboard_page(
       <script>{_dashboard_script()}</script>
     """
     return _layout("Installation evidence", content)
+
+
+def _admin_map_capability(value: Any) -> tuple[str, str]:
+    if value is True:
+        return "Yes", "yes"
+    if value is False:
+        return "No", "no"
+    return "Unknown", "unknown"
+
+
+def _admin_support_status(value: Any) -> tuple[str, str]:
+    status = str(value or "NOT_EVALUATED").upper()
+    labels = {
+        "SUPPORTED": ("Supported", "supported"),
+        "UNSUPPORTED": ("Unsupported", "unsupported"),
+        "NOT_EVALUATED": ("Not evaluated", "not-evaluated"),
+    }
+    return labels.get(status, ("Not evaluated", "not-evaluated"))
+
+
+def _admin_device_payload(
+    rows: list[dict[str, Any]], sync: dict[str, Any] | None,
+) -> dict[str, Any]:
+    def sync_count(key: str) -> int | None:
+        value = (sync or {}).get(key)
+        return int(value) if value is not None else None
+
+    devices: list[dict[str, Any]] = []
+    for row in rows:
+        attempts = int(row.get("attempted_install_count") or 0)
+        successful = int(row.get("successful_install_count") or 0)
+        failed = int(row.get("failed_install_count") or 0)
+        asset_url = row.get("asset_url")
+        if not (
+            row.get("asset_status") == "AVAILABLE"
+            and isinstance(asset_url, str)
+            and asset_url.startswith("https://api.terento.app/assets/devices/")
+        ):
+            asset_url = None
+        source_image_url = _official_source_image_url(row.get("source_image_url"))
+        stored_map_capable = row.get("map_capable")
+        classified_map_capable = classify_map_capable(
+            row.get("canonical_model") or row.get("model"),
+            row.get("manufacturer") or "Garmin",
+        )
+        map_capable = (
+            stored_map_capable if stored_map_capable is not None else classified_map_capable
+        )
+        evidence_status = calculate_compatibility_status(
+            successful_install_count=successful,
+            recognized_map_capable_evidence=map_capable is not False,
+        )
+        if asset_url:
+            image = {"url": asset_url, "origin": "controlled", "status": "AVAILABLE"}
+        elif source_image_url:
+            image = {"url": source_image_url, "origin": "garmin-source", "status": "SOURCE"}
+        else:
+            image = {"url": None, "origin": "missing", "status": "MISSING"}
+        usb_identities = row.get("usb_identities") or []
+        devices.append({
+            "id": row.get("device_id"),
+            "manufacturer": row.get("manufacturer") or "Garmin",
+            "family": row.get("family_canonical_name"),
+            "familyName": row.get("family_name"),
+            "model": row.get("model"),
+            "canonicalModel": row.get("canonical_model"),
+            "variant": row.get("variant"),
+            "caseSizeMm": row.get("case_size_mm"),
+            "displayType": row.get("display_type"),
+            "partNumber": row.get("part_number"),
+            "productURL": row.get("product_url"),
+            "active": bool(row.get("active", True)),
+            "mapCapable": map_capable,
+            "supportStatus": str(row.get("support_status") or "NOT_EVALUATED").upper(),
+            "evidenceStatus": evidence_status.value if evidence_status else None,
+            "recordSource": str(row.get("record_source") or "CURRENT_RETAIL").upper(),
+            "collectorManaged": bool(row.get("collector_managed", True)),
+            "asset": {"status": "AVAILABLE", "url": asset_url} if asset_url else {"status": "MISSING"},
+            "sourceAsset": {"url": source_image_url, "scope": "MODEL"} if source_image_url else None,
+            "image": image,
+            "usbIdentities": usb_identities,
+            "installationStats": {
+                "attempts": attempts,
+                "successful": successful,
+                "failed": failed,
+                "successRate": round(successful * 100 / attempts, 1) if attempts else None,
+                "firstSuccessfulAt": _timestamp_iso(row.get("first_success")) or None,
+                "lastSuccessfulAt": _timestamp_iso(row.get("last_success")) or None,
+                "lastEvidenceAt": _timestamp_iso(row.get("last_evidence")) or None,
+            },
+            "catalog": {
+                "firstSeenAt": _timestamp_iso(row.get("first_seen_at")) or None,
+                "createdAt": _timestamp_iso(row.get("created_at")) or None,
+                "updatedAt": _timestamp_iso(row.get("updated_at")) or None,
+                "lastSeenAt": _timestamp_iso(row.get("last_seen_at")) or None,
+                "newInLatestSync": bool(
+                    sync and row.get("first_seen_collection_run_id") == sync.get("id")
+                ),
+                "firstSeenSyncId": row.get("first_seen_collection_run_id"),
+                "lastSeenSyncId": row.get("last_seen_collection_run_id"),
+            },
+        })
+
+    attempts = sum(device["installationStats"]["attempts"] for device in devices)
+    successful = sum(device["installationStats"]["successful"] for device in devices)
+    return {
+        "schemaVersion": 1,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "models": len(devices),
+            "mapCapable": sum(device["mapCapable"] is True for device in devices),
+            "supported": sum(device["supportStatus"] == "SUPPORTED" for device in devices),
+            "tested": sum(device["installationStats"]["successful"] > 0 for device in devices),
+            "installAttempts": attempts,
+            "successfulInstalls": successful,
+            "successRate": round(successful * 100 / attempts, 1) if attempts else None,
+            "newThisSync": sync_count("records_added"),
+        },
+        "sync": {
+            "id": sync.get("id") if sync else None,
+            "status": sync.get("status") if sync else None,
+            "startedAt": _timestamp_iso(sync.get("started_at")) or None if sync else None,
+            "completedAt": _timestamp_iso(sync.get("finished_at")) or None if sync else None,
+            "recordsTotalBefore": sync_count("records_total_before"),
+            "recordsTotalAfter": sync_count("records_total_after"),
+            "recordsAdded": sync_count("records_added"),
+            "recordsUpdated": sync_count("records_updated"),
+        },
+        "devices": devices,
+    }
+
+
+def _admin_status_badge(label: str, kind: str) -> str:
+    return f"<span class='admin-state admin-state-{html.escape(kind)}'>{html.escape(label)}</span>"
+
+
+def _admin_device_row(device: dict[str, Any], index: int) -> str:
+    model = str(device.get("model") or "Unknown Garmin model")
+    variant = str(device.get("variant") or "—")
+    family = str(device.get("familyName") or device.get("family") or "")
+    map_label, map_kind = _admin_map_capability(device.get("mapCapable"))
+    support_label, support_kind = _admin_support_status(device.get("supportStatus"))
+    evidence_status = str(device.get("evidenceStatus") or "").upper()
+    stats = device["installationStats"]
+    catalog = device["catalog"]
+    search = " ".join(str(value or "") for value in (
+        model, device.get("canonicalModel"), family, variant,
+        device.get("caseSizeMm"), device.get("partNumber"), device.get("displayType"),
+    )).strip()
+    image_url = (device.get("image") or {}).get("url") or device.get("asset", {}).get("url")
+    image = (
+        f"<img class='device-thumb' src='{html.escape(image_url, quote=True)}' alt='' loading='lazy'>"
+        if image_url else
+        "<span class='device-thumb device-thumb-placeholder' aria-hidden='true'></span>"
+    )
+    new_badge = "<span class='new-badge'>New</span>" if catalog.get("newInLatestSync") else ""
+    last_tested = _timestamp_markup(stats.get("lastSuccessfulAt")) if stats.get("lastSuccessfulAt") else "—"
+    return f"""<tr data-device-index='{index}' data-search='{html.escape(search, quote=True)}' data-model='{html.escape(model.lower(), quote=True)}' data-updated='{html.escape(str(catalog.get('updatedAt') or ''), quote=True)}' data-installs='{stats['attempts']}' data-tested='{str(stats['successful'] > 0).lower()}' tabindex='0'>
+      <td><button class='device-model-button' type='button' data-device-index='{index}'>{image}<span class='device-model-copy'><strong>{html.escape(model)}</strong>{new_badge}</span></button></td>
+      <td>{html.escape(variant)}</td>
+      <td>{_admin_status_badge(map_label, f'map-{map_kind}')}</td>
+      <td>{_admin_status_badge(support_label, f'support-{support_kind}')}</td>
+      <td>{_status_badge(evidence_status) if evidence_status else _admin_status_badge('Unavailable', 'unavailable')}</td>
+      <td class='numeric'>{stats['attempts']}</td>
+      <td class='numeric'>{stats['successful']}</td>
+      <td>{last_tested}</td>
+    </tr>"""
+
+
+def devices_page(
+    rows: list[dict[str, Any]], sync: dict[str, Any] | None,
+    user: dict[str, Any], csrf_token: str,
+) -> bytes:
+    payload = _admin_device_payload(rows, sync)
+    summary = payload["summary"]
+    rate = _format_rate(summary["successRate"])
+    sync_data = payload["sync"]
+    completed = _timestamp_markup(sync_data["completedAt"]) if sync_data["completedAt"] else "No successful sync recorded"
+    sync_line = (
+        f"Last sync: {sync_data['recordsAdded']} new · {sync_data['recordsUpdated']} updated"
+        if sync_data["id"] is not None and sync_data["recordsAdded"] is not None
+        else ("Last sync: counts unavailable for this historical run" if sync_data["id"] is not None else "Last sync: —")
+    )
+    family_values = sorted({
+        str(device.get("familyName") or device.get("family") or "").strip()
+        for device in payload["devices"]
+        if str(device.get("familyName") or device.get("family") or "").strip()
+    }, key=str.casefold)
+    family_options = "".join(
+        f"<option value='{html.escape(value, quote=True)}'>{html.escape(value)}</option>"
+        for value in family_values
+    )
+    rows_html = "".join(
+        _admin_device_row(device, index)
+        for index, device in enumerate(payload["devices"])
+    )
+    empty = "<p class='empty'>No Garmin device records are available.</p>" if not rows_html else ""
+    payload_json = json.dumps({**payload, "csrfToken": csrf_token}, ensure_ascii=False).replace("<", "\\u003c")
+    content = f"""
+      {_admin_header(user, csrf_token, active="devices")}
+      <main class="dashboard devices-page" id="main-content">
+        <div class="heading-row"><div><p class="eyebrow">Admin · Garmin</p><h1>Garmin devices</h1><p class="lede">Catalogue health, map capability, Support decision, and real Terento installation evidence.</p></div><p class="updated-at">Catalogue completed {completed}</p></div>
+        <section class="metrics device-metrics" aria-label="Garmin device catalogue summary">
+          <article class='metric'><span>Models</span><strong>{summary['models']}</strong></article>
+          <article class='metric'><span>Map-capable</span><strong>{summary['mapCapable']}</strong></article>
+          <article class='metric'><span>Supported</span><strong>{summary['supported']}</strong></article>
+          <article class='metric'><span>Tested</span><strong>{summary['tested']}</strong></article>
+          <article class='metric'><span>Install attempts</span><strong>{summary['installAttempts']}</strong></article>
+          <article class='metric'><span>Successful installs</span><strong>{summary['successfulInstalls']}</strong></article>
+          <article class='metric'><span>Success rate</span><strong>{html.escape(rate)}</strong></article>
+          <article class='metric'><span>New this sync</span><strong>{summary['newThisSync'] if summary['newThisSync'] is not None else '—'}</strong></article>
+        </section>
+        <section class="catalog-sync" aria-labelledby="catalog-sync-title"><div><p class="section-kicker">Catalogue</p><h2 id="catalog-sync-title">Garmin device catalog</h2><p>Last updated {completed}</p></div><p class="sync-summary">{html.escape(sync_line)}</p></section>
+        <section class="evidence-section" aria-labelledby="device-list-title">
+          <div class="section-heading"><div><p class="section-kicker">Inventory</p><h2 id="device-list-title">Known Garmin models</h2></div><p class="table-help">Times follow the selected time zone</p></div>
+          <form class="filter-bar device-filter-bar" id="device-filters" role="search">
+            <label class="filter-search"><span class="sr-only">Search Garmin devices</span><input id="device-search" type="search" placeholder="Search model, family, variant, case size or part number" autocomplete="off"></label>
+            <label><span class="sr-only">Filter by family</span><select id="device-family"><option value="all">All families</option>{family_options}</select></label>
+            <label><span class="sr-only">Filter by map capability</span><select id="device-map"><option value="all">All map capability</option><option value="yes">Map-capable: Yes</option><option value="no">Map-capable: No</option><option value="unknown">Map-capable: Unknown</option></select></label>
+            <label><span class="sr-only">Filter by Support decision</span><select id="device-support"><option value="all">All Support decisions</option><option value="SUPPORTED">Supported</option><option value="UNSUPPORTED">Unsupported</option><option value="NOT_EVALUATED">Not evaluated</option></select></label>
+            <label><span class="sr-only">Filter by testing</span><select id="device-tested"><option value="all">All tested states</option><option value="yes">Tested: Yes</option><option value="no">Tested: No</option></select></label>
+            <label><span class="sr-only">Sort Garmin devices</span><select id="device-sort"><option value="model">Model name</option><option value="newest">Newest in database</option><option value="updated">Recently updated</option><option value="installs">Most installs</option><option value="tested">Last tested</option></select></label>
+          </form>
+          <p class="results-count" id="device-results-count" aria-live="polite">{len(payload['devices'])} {'model' if len(payload['devices']) == 1 else 'models'}</p>
+          {empty}
+          <div class="table-wrap device-table-wrap"><table><caption class="sr-only">Garmin device catalogue and Terento installation evidence</caption><thead><tr><th scope="col">Model</th><th scope="col">Variant</th><th scope="col">Map-capable</th><th scope="col">Support decision</th><th scope="col">Evidence status</th><th scope="col">Installs</th><th scope="col">Success</th><th scope="col">Last tested</th></tr></thead><tbody id="device-rows">{rows_html}</tbody></table></div>
+          <div class="device-pagination" id="device-pagination" hidden><button type="button" id="device-previous">Previous</button><span id="device-page-status"></span><button type="button" id="device-next">Next</button></div>
+        </section>
+      </main>
+      <dialog class="device-dialog" id="device-dialog" aria-labelledby="device-dialog-title"><div class="device-dialog-inner"><div class="device-dialog-header"><div><p class="section-kicker">Garmin device record</p><h2 id="device-dialog-title">Device details</h2></div><button class="dialog-close" type="button" id="device-dialog-close" aria-label="Close device details">×</button></div><div id="device-dialog-body"></div></div></dialog>
+      <script>const terentoAdminDevices = {payload_json};{_devices_script()}</script>
+    """
+    return _layout("Garmin devices", content)
 
 
 def _campaign_info(control_id: str, title: str, body: str) -> str:
@@ -395,7 +648,7 @@ def _statistics_row(row: dict[str, Any]) -> str:
         html.escape(model), html.escape(variant), html.escape(str(row.get("firmware_versions") or "—")),
         html.escape(str(row.get("attempted_install_count", 0))), html.escape(str(row.get("successful_install_count", 0))),
         html.escape(str(row.get("failed_install_count", 0))), html.escape(_format_rate(row.get("success_rate"))),
-        _status_badge(status), html.escape(format_timestamp(row.get("last_success"))), _error_cell(row),
+        _status_badge(status), _timestamp_markup(row.get("last_success")), _error_cell(row),
     )
     return (
         f"<tr data-search='{html.escape(search_text)}' data-status='{html.escape(status.lower())}' data-activity='{html.escape(activity)}' data-reports='{int(row.get('attempted_install_count') or 0)}'>"
@@ -415,6 +668,175 @@ def _status_badge(value: str) -> str:
         f"aria-label='{html.escape(label)}: {html.escape(STATUS_PUBLIC_COPY[status])}'>"
         f"{html.escape(label)}</span>"
     )
+
+
+def _devices_script() -> str:
+    return r"""(() => {
+      const devices = terentoAdminDevices.devices || [];
+      const body = document.querySelector('#device-rows');
+      const form = document.querySelector('#device-filters');
+      const search = document.querySelector('#device-search');
+      const family = document.querySelector('#device-family');
+      const map = document.querySelector('#device-map');
+      const support = document.querySelector('#device-support');
+      const tested = document.querySelector('#device-tested');
+      const sort = document.querySelector('#device-sort');
+      const count = document.querySelector('#device-results-count');
+      const pagination = document.querySelector('#device-pagination');
+      const previous = document.querySelector('#device-previous');
+      const next = document.querySelector('#device-next');
+      const pageStatus = document.querySelector('#device-page-status');
+      const dialog = document.querySelector('#device-dialog');
+      const dialogTitle = document.querySelector('#device-dialog-title');
+      const dialogBody = document.querySelector('#device-dialog-body');
+      const close = document.querySelector('#device-dialog-close');
+      if (!body || !form || !search || !family || !map || !support || !tested || !sort || !count || !dialog) return;
+
+      const pageSize = 50;
+      let page = 0;
+      const escapeHtml = (value) => String(value ?? '—')
+        .replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;').replaceAll("'", '&#039;');
+      const display = (value) => value === null || value === undefined || value === '' ? '—' : value;
+      const utcDate = (value) => value ? new Intl.DateTimeFormat('en-GB', {
+        day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', timeZone: 'UTC', timeZoneName: 'short'
+      }).format(new Date(value)) : '—';
+      const date = (value) => value ? `<time class="admin-timestamp" data-admin-timestamp="${escapeHtml(value)}">${escapeHtml(window.TerentoAdminTime ? window.TerentoAdminTime.format(value) : utcDate(value))}</time>` : '—';
+      const mapValue = (device) => device.mapCapable === true ? 'yes' : device.mapCapable === false ? 'no' : 'unknown';
+      const supportLabel = (value) => ({SUPPORTED: 'Supported', UNSUPPORTED: 'Unsupported', NOT_EVALUATED: 'Not evaluated'})[value] || 'Not evaluated';
+      const evidenceLabel = (value) => ({TESTING: 'Testing', TESTED: 'Tested', SUPPORTED: 'Supported', VERIFIED: 'Verified'})[value] || 'Unavailable';
+      const deviceSearch = (device) => [device.model, device.canonicalModel, device.family, device.familyName, device.variant, device.caseSizeMm, device.partNumber, device.displayType].filter(Boolean).join(' ').toLocaleLowerCase();
+      const matching = () => {
+        const query = search.value.trim().toLocaleLowerCase();
+        return devices.filter((device) => {
+          const matchesSearch = !query || deviceSearch(device).includes(query);
+          const matchesFamily = family.value === 'all' || family.value === (device.familyName || device.family);
+          const matchesMap = map.value === 'all' || mapValue(device) === map.value;
+          const matchesSupport = support.value === 'all' || (device.supportStatus || 'NOT_EVALUATED') === support.value;
+          const matchesTested = tested.value === 'all' || (device.installationStats.successful > 0 ? 'yes' : 'no') === tested.value;
+          return matchesSearch && matchesFamily && matchesMap && matchesSupport && matchesTested;
+        }).sort((a, b) => {
+          if (sort.value === 'newest') return String(b.catalog.firstSeenAt || '').localeCompare(String(a.catalog.firstSeenAt || ''));
+          if (sort.value === 'updated') return String(b.catalog.updatedAt || '').localeCompare(String(a.catalog.updatedAt || ''));
+          if (sort.value === 'installs') return (b.installationStats.attempts || 0) - (a.installationStats.attempts || 0);
+          if (sort.value === 'tested') return String(b.installationStats.lastSuccessfulAt || '').localeCompare(String(a.installationStats.lastSuccessfulAt || ''));
+          return String(a.model || '').localeCompare(String(b.model || ''), undefined, {sensitivity: 'base', numeric: true})
+            || String(a.variant || '').localeCompare(String(b.variant || ''), undefined, {sensitivity: 'base', numeric: true});
+        });
+      };
+      const openDevice = (device) => {
+        if (!device) return;
+        dialogTitle.textContent = display(device.model);
+        const stats = device.installationStats;
+        const catalog = device.catalog;
+        const mapLabel = device.mapCapable === true ? 'Yes' : device.mapCapable === false ? 'No' : 'Unknown';
+        const image = device.image || {};
+        const assetLabel = image.origin === 'controlled' ? 'Controlled Terento asset' : image.origin === 'garmin-source' ? 'Garmin source image (model match)' : 'Missing';
+        const imageMarkup = image.url ? `<img class="device-detail-image" src="${escapeHtml(image.url)}" alt="">` : '';
+        const usb = (device.usbIdentities || []).map((identity) => `VID ${identity.vendorId} · PID ${identity.productId}`).join(', ') || '—';
+        dialogBody.innerHTML = `
+          ${imageMarkup}
+          <div class="device-detail-grid">
+            <section><p class="detail-kicker">Identity</p><dl>
+              <div><dt>Model</dt><dd>${escapeHtml(device.model)}</dd></div>
+              <div><dt>Canonical model</dt><dd>${escapeHtml(device.canonicalModel)}</dd></div>
+              <div><dt>Family</dt><dd>${escapeHtml(device.familyName || device.family)}</dd></div>
+              <div><dt>Variant</dt><dd>${escapeHtml(device.variant)}</dd></div>
+              <div><dt>Case size</dt><dd>${escapeHtml(device.caseSizeMm ? `${device.caseSizeMm} mm` : null)}</dd></div>
+              <div><dt>Display</dt><dd>${escapeHtml(device.displayType)}</dd></div>
+              <div><dt>Part number</dt><dd>${escapeHtml(device.partNumber)}</dd></div>
+              <div><dt>Record ID</dt><dd class="technical-value">${escapeHtml(device.id)}</dd></div>
+            </dl></section>
+            <section><p class="detail-kicker">Compatibility</p><dl>
+              <div><dt>Map-capable</dt><dd>${escapeHtml(mapLabel)}</dd></div>
+              <div><dt>Support decision</dt><dd>${escapeHtml(supportLabel(device.supportStatus))}</dd></div>
+              <div><dt>Evidence status</dt><dd>${escapeHtml(evidenceLabel(device.evidenceStatus))}</dd></div>
+              <div><dt>Active</dt><dd>${device.active ? 'Yes' : 'No'}</dd></div>
+              <div><dt>USB identities</dt><dd class="technical-value">${escapeHtml(usb)}</dd></div>
+            </dl></section>
+            <section><p class="detail-kicker">Installation evidence</p><dl>
+              <div><dt>Attempts</dt><dd>${stats.attempts}</dd></div>
+              <div><dt>Successful</dt><dd>${stats.successful}</dd></div>
+              <div><dt>Failed</dt><dd>${stats.failed}</dd></div>
+              <div><dt>Success rate</dt><dd>${stats.successRate === null ? '—' : `${stats.successRate}%`}</dd></div>
+              <div><dt>First successful install</dt><dd>${date(stats.firstSuccessfulAt)}</dd></div>
+              <div><dt>Last tested</dt><dd>${date(stats.lastSuccessfulAt)}</dd></div>
+              <div><dt>Last evidence</dt><dd>${date(stats.lastEvidenceAt)}</dd></div>
+            </dl></section>
+            <section><p class="detail-kicker">Catalogue</p><dl>
+              <div><dt>First seen in Terento</dt><dd>${date(catalog.firstSeenAt)}</dd></div>
+              <div><dt>Record created</dt><dd>${date(catalog.createdAt)}</dd></div>
+              <div><dt>Record updated</dt><dd>${date(catalog.updatedAt)}</dd></div>
+              <div><dt>Last seen</dt><dd>${date(catalog.lastSeenAt)}</dd></div>
+              <div><dt>New in latest sync</dt><dd>${catalog.newInLatestSync ? 'Yes' : 'No'}</dd></div>
+              <div><dt>Image</dt><dd>${escapeHtml(assetLabel)}</dd></div>
+              <div><dt>Match source</dt><dd>${escapeHtml(image.origin === 'controlled' ? 'Approved catalog asset' : image.origin === 'garmin-source' ? 'Official Garmin product media URL for this exact catalog row' : 'No image URL stored for this row')}</dd></div>
+            </dl></section>
+          </div>
+          <section class="device-support-review" aria-labelledby="device-support-review-title">
+            <p class="detail-kicker" id="device-support-review-title">Operator review</p>
+            <p class="table-help">This changes the Support decision only. It does not change Evidence status or installation counts.</p>
+            <form method="post" action="/admin/devices/support">
+              <input type="hidden" name="csrf_token" value="${escapeHtml(terentoAdminDevices.csrfToken)}">
+              <input type="hidden" name="device_id" value="${escapeHtml(device.id)}">
+              <label for="support-decision-${escapeHtml(device.id)}">Support decision</label>
+              <select id="support-decision-${escapeHtml(device.id)}" name="support_status">
+                <option value="SUPPORTED"${device.supportStatus === 'SUPPORTED' ? ' selected' : ''}>Supported</option>
+                <option value="UNSUPPORTED"${device.supportStatus === 'UNSUPPORTED' ? ' selected' : ''}>Unsupported</option>
+                <option value="NOT_EVALUATED"${device.supportStatus === 'NOT_EVALUATED' ? ' selected' : ''}>Not evaluated</option>
+              </select>
+              <button type="submit">Save support decision</button>
+            </form>
+          </section>
+          ${device.productURL ? `<p class="device-product-link"><a href="${escapeHtml(device.productURL)}" target="_blank" rel="noreferrer">Open Garmin product page</a></p>` : ''}
+        `;
+        if (typeof dialog.showModal === 'function') dialog.showModal(); else dialog.setAttribute('open', '');
+      };
+      const refresh = () => {
+        const visible = matching();
+        const totalPages = Math.max(1, Math.ceil(visible.length / pageSize));
+        page = Math.min(page, totalPages - 1);
+        const pageRows = visible.slice(page * pageSize, (page + 1) * pageSize);
+        const rowsById = new Map([...body.querySelectorAll('tr[data-device-index]')].map((row) => {
+          const device = devices[Number(row.dataset.deviceIndex)];
+          return [device && device.id, row];
+        }));
+        rowsById.forEach((row) => { row.hidden = true; });
+        pageRows.forEach((device) => {
+          const row = rowsById.get(device.id);
+          if (!row) return;
+          row.hidden = false;
+          body.appendChild(row);
+        });
+        count.textContent = visible.length === devices.length ? `${visible.length} ${visible.length === 1 ? 'model' : 'models'}` : `${visible.length} of ${devices.length} models`;
+        pagination.hidden = visible.length <= pageSize;
+        pageStatus.textContent = `Page ${page + 1} of ${totalPages}`;
+        previous.disabled = page === 0;
+        next.disabled = page >= totalPages - 1;
+      };
+      const reset = () => { page = 0; refresh(); };
+      form.addEventListener('submit', (event) => event.preventDefault());
+      [search, family, map, support, tested, sort].forEach((control) => control.addEventListener(control === search ? 'input' : 'change', reset));
+      previous.addEventListener('click', () => { page -= 1; refresh(); });
+      next.addEventListener('click', () => { page += 1; refresh(); });
+      body.addEventListener('click', (event) => {
+        const button = event.target.closest('button[data-device-index]');
+        const row = event.target.closest('tr[data-device-index]');
+        if (button || !row) return;
+        openDevice(devices[Number(row.dataset.deviceIndex)]);
+      });
+      body.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        const row = event.target.closest('tr[data-device-index]');
+        if (!row) return;
+        event.preventDefault();
+        openDevice(devices[Number(row.dataset.deviceIndex)]);
+      });
+      body.querySelectorAll('button[data-device-index]').forEach((button) => button.addEventListener('click', () => openDevice(devices[Number(button.dataset.deviceIndex)])));
+      close.addEventListener('click', () => dialog.close());
+      dialog.addEventListener('click', (event) => { if (event.target === dialog) dialog.close(); });
+      refresh();
+    })();"""
 
 
 def _campaign_links_script() -> str:
@@ -597,12 +1019,83 @@ def _dashboard_script() -> str:
           ? (b.dataset.activity || '').localeCompare(a.dataset.activity || '')
           : Number(b.dataset.reports || 0) - Number(a.dataset.reports || 0));
         visible.forEach((row) => body.appendChild(row));
-        const label = visible.length === 1 ? 'report' : 'reports';
+        const label = visible.length === 1 ? 'model' : 'models';
         count.textContent = visible.length === rows.length ? `${visible.length} ${label}` : `${visible.length} of ${rows.length} ${label}`;
       };
       form.addEventListener('submit', (event) => event.preventDefault());
       [search, status, sort].forEach((control) => control.addEventListener('input', refresh));
       refresh();
+    })();"""
+
+
+def _admin_timezone_script() -> str:
+    return r"""(() => {
+      const select = document.querySelector('#admin-timezone');
+      if (!select) return;
+      const storageKey = 'terento.admin.timeZone';
+      const browserTimeZone = (() => {
+        try { return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'; } catch (_) { return 'UTC'; }
+      })();
+      const isValidTimeZone = (value) => {
+        try {
+          new Intl.DateTimeFormat('en-GB', { timeZone: value }).format();
+          return true;
+        } catch (_) {
+          return false;
+        }
+      };
+      const commonTimeZones = [
+        'Europe/Vilnius', 'Europe/Riga', 'Europe/Warsaw', 'Europe/Berlin',
+        'Europe/London', 'America/New_York', 'America/Los_Angeles',
+        'America/Toronto', 'Asia/Tokyo', 'Asia/Singapore', 'Australia/Sydney'
+      ];
+      const supportedTimeZones = typeof Intl.supportedValuesOf === 'function'
+        ? Intl.supportedValuesOf('timeZone') : [];
+      const timeZones = ['browser', 'UTC', browserTimeZone, ...commonTimeZones, ...supportedTimeZones]
+        .filter((value, index, values) => values.indexOf(value) === index)
+        .filter((value) => value === 'browser' || isValidTimeZone(value));
+      const readStoredTimeZone = () => {
+        try { return localStorage.getItem(storageKey) || 'browser'; } catch (_) { return 'browser'; }
+      };
+      const storedTimeZone = readStoredTimeZone();
+      const selectedTimeZone = timeZones.includes(storedTimeZone) ? storedTimeZone : 'browser';
+      const activeTimeZone = () => select.value === 'browser' ? browserTimeZone : select.value;
+      const format = (value) => {
+        if (!value) return '—';
+        const date = new Date(value);
+        if (Number.isNaN(date.getTime())) return String(value);
+        try {
+          return new Intl.DateTimeFormat('en-GB', {
+            day: '2-digit', month: 'short', year: 'numeric',
+            hour: '2-digit', minute: '2-digit', timeZone: activeTimeZone(), timeZoneName: 'short'
+          }).format(date);
+        } catch (_) {
+          return date.toISOString();
+        }
+      };
+      const render = () => {
+        const zone = activeTimeZone();
+        document.querySelectorAll('[data-admin-timestamp]').forEach((element) => {
+          element.textContent = format(element.dataset.adminTimestamp);
+          element.title = `${element.textContent} · ${zone}`;
+        });
+        select.title = zone;
+        select.setAttribute('aria-label', `Time zone: ${select.value === 'browser' ? `Automatic (${browserTimeZone})` : select.value}`);
+      };
+      select.replaceChildren(...timeZones.map((value) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = value === 'browser' ? `Automatic (browser) · ${browserTimeZone}` : value;
+        return option;
+      }));
+      select.value = selectedTimeZone;
+      window.TerentoAdminTime = { format, render, timeZone: activeTimeZone };
+      select.addEventListener('change', () => {
+        try { localStorage.setItem(storageKey, select.value); } catch (_) { /* local preference is optional */ }
+        render();
+        window.dispatchEvent(new Event('terento-admin-timezone-change'));
+      });
+      render();
     })();"""
 
 
@@ -629,6 +1122,8 @@ button{cursor:pointer}
 .admin-nav a{text-decoration:none}
 .admin-nav a:hover{color:var(--interactive)}
 .admin-user{color:var(--graphite);font-weight:650}
+.timezone-control{display:flex;align-items:center;gap:7px;color:var(--secondary);font-size:11px;font-weight:650;white-space:nowrap}
+.timezone-control select{max-width:205px;min-height:32px;padding:5px 8px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--graphite);font-size:11px}
 .admin-nav form{margin:0}
 .link-button{padding:0;border:0;background:none;color:var(--interactive);font-weight:650;text-decoration:underline;text-underline-offset:3px}
 .dashboard{width:min(calc(100% - 48px),var(--max-width));margin:0 auto;padding:40px 0 64px}
@@ -727,9 +1222,56 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 .preview-grid div{padding:10px 12px;background:var(--surface-muted);border-radius:8px}
 .preview-grid dt{color:var(--secondary);font-size:11px;font-weight:650}
 .preview-grid dd{margin:2px 0 0;overflow-wrap:anywhere;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px}
+.devices-page .device-metrics{grid-template-columns:repeat(4,minmax(0,1fr));margin-bottom:18px}
+.catalog-sync{display:flex;align-items:center;justify-content:space-between;gap:24px;margin:0 0 28px;padding:16px 20px;background:var(--surface);border:1px solid var(--border);border-radius:14px}
+.catalog-sync h2{font-size:20px}
+.catalog-sync p{margin:5px 0 0;color:var(--secondary);font-size:13px}
+.catalog-sync .section-kicker{margin:0 0 4px}
+.sync-summary{font-weight:700!important;color:var(--interactive)!important;white-space:nowrap}
+.device-filter-bar{align-items:stretch}
+.device-filter-bar .filter-search{flex:1 1 310px}
+.device-filter-bar input{width:100%}
+.device-table-wrap table{min-width:900px}
+.device-table-wrap tbody tr{cursor:pointer}
+.device-table-wrap tbody tr:hover{background:color-mix(in srgb,var(--surface-muted) 52%,white)}
+.device-table-wrap tbody tr:focus-visible{outline:3px solid color-mix(in srgb,var(--sky) 58%,white);outline-offset:-3px}
+.device-model-button{display:flex;align-items:center;gap:10px;width:100%;padding:0;border:0;background:none;color:inherit;text-align:left}
+.device-model-button strong{display:block;font-weight:700}
+.device-model-copy{display:flex;align-items:center;gap:8px}
+.device-thumb{display:block;width:38px;height:38px;flex:0 0 38px;object-fit:contain;border-radius:8px;background:var(--surface-muted)}
+.device-detail-image{display:block;width:120px;height:120px;object-fit:contain;border-radius:16px;background:var(--surface-muted);margin:0 0 16px}
+.device-thumb-placeholder{position:relative;border:1px solid var(--border)}
+.device-thumb-placeholder:before{content:"";position:absolute;left:10px;top:8px;width:16px;height:21px;border:2px solid var(--sky);border-radius:5px}
+.device-thumb-placeholder:after{content:"";position:absolute;left:15px;top:13px;width:6px;height:2px;border-radius:2px;background:var(--sky);box-shadow:0 8px 0 var(--sky)}
+.new-badge{display:inline-flex;align-items:center;min-height:20px;padding:2px 7px;border:1px solid color-mix(in srgb,var(--lichen) 65%,var(--border));border-radius:999px;background:#EEF2E9;color:#52624C;font-size:10px;font-weight:750;letter-spacing:.06em;text-transform:uppercase}
+.admin-state{display:inline-flex;align-items:center;min-height:26px;padding:5px 9px;border:1px solid transparent;border-radius:999px;font-size:11px;font-weight:750;line-height:1;white-space:nowrap}
+.admin-state-map-yes,.admin-state-support-supported{background:#E7EEE2;border-color:#B4C6A7;color:#4B6142}
+.admin-state-map-no,.admin-state-support-unsupported{background:#F0E9E5;border-color:#D6BDB2;color:#7A493D}
+.admin-state-map-unknown,.admin-state-support-not-evaluated{background:var(--surface-muted);border-color:var(--border);color:var(--secondary)}
+.numeric{font-variant-numeric:tabular-nums}
+.device-pagination{display:flex;align-items:center;justify-content:center;gap:16px;margin:14px 0 0;color:var(--secondary);font-size:13px}
+.device-pagination button,.dialog-close{min-height:34px;padding:7px 11px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--interactive);font-weight:700}
+.device-pagination button:hover,.dialog-close:hover{border-color:var(--interactive);background:var(--success-bg)}
+.device-pagination button:disabled{cursor:not-allowed;opacity:.45}
+.device-dialog{width:min(860px,calc(100% - 32px));max-height:min(820px,calc(100% - 32px));padding:0;border:0;border-radius:16px;background:var(--surface);color:var(--graphite);box-shadow:0 24px 80px rgba(34,42,43,.24)}
+.device-dialog::backdrop{background:rgba(34,42,43,.34)}
+.device-dialog-inner{padding:24px}
+.device-dialog-header{display:flex;align-items:flex-start;justify-content:space-between;gap:18px;margin-bottom:22px}
+.device-dialog-header h2{font-size:28px}
+.dialog-close{width:34px;padding:0;font-size:23px;line-height:1}
+.device-detail-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:22px 26px}
+.device-detail-grid section{min-width:0;padding-top:2px}
+.detail-kicker{margin:0 0 8px;color:var(--interactive);font-size:11px;font-weight:750;letter-spacing:.12em;text-transform:uppercase}
+.device-detail-grid dl{margin:0;border-top:1px solid var(--border)}
+.device-detail-grid dl div{display:grid;grid-template-columns:minmax(120px,.8fr) minmax(0,1.2fr);gap:12px;padding:8px 0;border-bottom:1px solid color-mix(in srgb,var(--border) 70%,transparent)}
+.device-detail-grid dt{color:var(--secondary);font-size:12px}
+.device-detail-grid dd{margin:0;overflow-wrap:anywhere;font-size:13px;font-weight:650;text-align:right}
+.technical-value{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px!important}
+.device-product-link{margin:22px 0 0;padding-top:16px;border-top:1px solid var(--border);font-size:13px;font-weight:700}
+.device-product-link a{color:var(--interactive);text-underline-offset:3px}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-@media(max-width:800px){.admin-topbar-inner,.dashboard{width:min(calc(100% - 32px),var(--max-width))}.admin-section-nav{margin-left:0}.heading-row{align-items:flex-start;flex-direction:column;gap:12px}.updated-at{margin:0}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.filter-bar input{width:min(100%,360px)}.filter-bar{align-items:stretch}.filter-bar label,.filter-bar select,.filter-bar input{flex:1 1 170px}.public-status{align-items:flex-start;flex-direction:column}.public-status-value{width:100%;justify-content:space-between}.status-guide-grid{grid-template-columns:1fr}.campaign-fields{grid-template-columns:1fr}.campaign-field-wide{grid-column:auto}.attribution-preview{grid-template-columns:1fr}}
-@media(max-width:560px){.admin-topbar-inner{align-items:flex-start;flex-direction:column;padding:14px 0}.admin-section-nav{width:100%;overflow:auto}.admin-section-nav a{white-space:nowrap}.admin-nav{width:100%;justify-content:space-between;gap:10px}.dashboard{padding-top:28px}.metrics{gap:8px}.metric{min-height:92px;padding:14px}.metric strong{font-size:26px}.auth-card{width:calc(100% - 32px);padding:24px}.section-heading{align-items:flex-start;flex-direction:column;gap:4px}.campaign-card{padding:16px}.campaign-preset-row{grid-template-columns:1fr;gap:8px}.generated-url-row{grid-template-columns:1fr}.copy-button{width:100%}.copy-status{min-height:18px}}
+@media(max-width:800px){.admin-topbar-inner,.dashboard{width:min(calc(100% - 32px),var(--max-width))}.admin-section-nav{margin-left:0}.heading-row{align-items:flex-start;flex-direction:column;gap:12px}.updated-at{margin:0}.metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.devices-page .device-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.filter-bar input{width:min(100%,360px)}.filter-bar{align-items:stretch}.filter-bar label,.filter-bar select,.filter-bar input{flex:1 1 170px}.public-status{align-items:flex-start;flex-direction:column}.public-status-value{width:100%;justify-content:space-between}.status-guide-grid{grid-template-columns:1fr}.campaign-fields{grid-template-columns:1fr}.campaign-field-wide{grid-column:auto}.attribution-preview{grid-template-columns:1fr}.catalog-sync{align-items:flex-start;flex-direction:column;gap:4px}.sync-summary{white-space:normal!important}.device-detail-grid{grid-template-columns:1fr}}
+@media(max-width:560px){.admin-topbar-inner{align-items:flex-start;flex-direction:column;padding:14px 0}.admin-section-nav{width:100%;overflow:auto}.admin-section-nav a{white-space:nowrap}.admin-nav{width:100%;justify-content:space-between;gap:10px;flex-wrap:wrap}.timezone-control{width:100%;justify-content:space-between}.timezone-control select{max-width:none;flex:1}.dashboard{padding-top:28px}.metrics{gap:8px}.metric{min-height:92px;padding:14px}.metric strong{font-size:26px}.auth-card{width:calc(100% - 32px);padding:24px}.section-heading{align-items:flex-start;flex-direction:column;gap:4px}.campaign-card{padding:16px}.campaign-preset-row{grid-template-columns:1fr;gap:8px}.generated-url-row{grid-template-columns:1fr}.copy-button{width:100%}.copy-status{min-height:18px}.device-dialog-inner{padding:18px}.device-detail-grid dl div{grid-template-columns:1fr;gap:2px}.device-detail-grid dd{text-align:left}}
 """
 
 
@@ -739,6 +1281,9 @@ def _error(message: str | None) -> str:
 
 def _layout(title: str, content: str) -> bytes:
     nonce = secrets.token_urlsafe(18)
+    content = content.replace("<script>", f"<script nonce=\"{nonce}\">")
+    timezone_script = _admin_timezone_script()
+    content = f"{content}<script>{timezone_script}</script>"
     content = content.replace("<script>", f"<script nonce=\"{nonce}\">")
     return f"""<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>{html.escape(title)} · Terento</title><style>{ADMIN_STYLES}</style></head><body>{content}</body></html>""".encode("utf-8")
 

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -193,7 +193,12 @@ def _error_cell(row: dict[str, Any]) -> str:
         return "<span class='muted-value'>—</span>"
     count = sum(int(value) for value in errors.values() if str(value).isdigit())
     detail = ", ".join(f"{html.escape(str(key))}: {html.escape(str(value))}" for key, value in sorted(errors.items()))
-    return f"<span class='error-count' title='{detail}' aria-label='{count} errors'>{count}</span>"
+    target = _diagnostics_id(str(row.get("compatibility_identity") or row.get("model") or "unknown"))
+    return f"<a class='error-count' href='#{target}' title='{detail}' aria-label='View {count} errors'>{count}</a>"
+
+
+def _diagnostics_id(identity: str) -> str:
+    return "diagnostics-" + hashlib.sha256(identity.encode("utf-8")).hexdigest()[:16]
 
 
 def _admin_brand() -> str:
@@ -259,7 +264,7 @@ def login_page(*, error: str | None = None) -> bytes:
 
 def dashboard_page(
     rows: list[dict[str, Any]], user: dict[str, Any], csrf_token: str,
-    *, public_stats_enabled: bool = False,
+    *, operations: list[dict[str, Any]] | None = None, public_stats_enabled: bool = False,
 ) -> bytes:
     attempts = sum(int(row.get("attempted_install_count") or 0) for row in rows)
     successes = sum(int(row.get("successful_install_count") or 0) for row in rows)
@@ -278,11 +283,12 @@ def dashboard_page(
     )
     cards = "".join(
         f"<article class='metric'><span>{label}</span><strong>{value}</strong></article>"
-        for label, value in (("Models", len(rows)), ("Reports", attempts), ("Successful", successes), ("Failed", failures))
+        for label, value in (("Models", len(rows)), ("Write attempts", attempts), ("Successful operations", successes), ("Failed operations", failures))
     )
     table_rows = "".join(_statistics_row(row) for row in rows)
     empty = "<p class='empty'>No installation evidence reports yet.</p>" if not rows else ""
     latest_copy = f"Updated {_timestamp_markup(latest)}" if latest else "No reports received yet"
+    diagnostic_details = _diagnostic_details(rows, operations or [])
     content = f"""
       {_admin_header(user, csrf_token)}
       <main class="dashboard" id="main-content">
@@ -296,7 +302,9 @@ def dashboard_page(
             <label><span class="sr-only">Sort reports</span><select id="evidence-sort"><option value="reports">Most reports</option><option value="latest">Latest activity</option></select></label>
           </form>
           <p class="results-count" id="results-count" aria-live="polite">{len(rows)} {"model" if len(rows) == 1 else "models"}</p>
-          <div class="table-wrap"><table><caption class="sr-only">Installation evidence reports by exact device identity</caption><thead><tr><th scope="col">Model</th><th scope="col">Variant</th><th scope="col">Firmware</th><th scope="col">Reports</th><th scope="col">Successful</th><th scope="col">Failed</th><th scope="col">Success rate</th><th scope="col">Status</th><th scope="col">Last success</th><th scope="col">Errors</th></tr></thead><tbody id="evidence-rows">{table_rows}</tbody></table></div>
+          <div class="table-wrap"><table><caption class="sr-only">Installation evidence by exact device identity</caption><thead><tr><th scope="col">Model</th><th scope="col">Variant</th><th scope="col">Firmware</th><th scope="col">Write attempts</th><th scope="col">Successful operations</th><th scope="col">Failed operations</th><th scope="col">Success rate</th><th scope="col">Status</th><th scope="col">Last success</th><th scope="col">Errors</th></tr></thead><tbody id="evidence-rows">{table_rows}</tbody></table></div>
+          <p class="table-help">Compatibility rates count distinct write-started operations. Operation details list every selected-map result and pre-write failure.</p>
+          {diagnostic_details}
         </section>
         <section class="status-guide" aria-labelledby="status-guide-title"><div class="section-heading"><div><p class="section-kicker">Canonical rules</p><h2 id="status-guide-title">Compatibility statuses</h2></div><p class="table-help">Exact model and variant; successful shared installations only</p></div><div class="status-guide-grid">{''.join(f"<div class='status-guide-row'>{_status_badge(status)}<span>{html.escape(STATUS_PUBLIC_COPY[CompatibilityStatus(status)])}</span></div>" for status in status_values)}</div></section>
         <section class="public-status" aria-labelledby="public-status-title"><div><p class="section-kicker">Publication</p><h2 id="public-status-title">Public compatibility</h2></div><div class="public-status-value"><span class="status-badge status-{('enabled' if public_stats_enabled else 'disabled')}">{'Enabled' if public_stats_enabled else 'Disabled'}</span><span>{published} {'model' if published == 1 else 'models'} published</span></div></section>
@@ -304,6 +312,51 @@ def dashboard_page(
       <script>{_dashboard_script()}</script>
     """
     return _layout("Installation evidence", content)
+
+
+def _diagnostic_details(rows: list[dict[str, Any]], events: list[dict[str, Any]]) -> str:
+    by_identity: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    for event in events:
+        identity = str(event.get("compatibility_identity") or event.get("model") or "Unknown")
+        operation = str(event.get("operation_key") or event.get("operation_id") or event.get("event_id"))
+        by_identity.setdefault(identity, {}).setdefault(operation, []).append(event)
+    sections: list[str] = []
+    for row in rows:
+        identity = str(row.get("compatibility_identity") or row.get("model") or "Unknown")
+        operations = by_identity.get(identity, {})
+        if not operations:
+            continue
+        operation_cards: list[str] = []
+        for operation_key, results in operations.items():
+            first = results[0]
+            map_rows = "".join(
+                "<tr>" + "".join(f"<td>{html.escape(str(value if value not in (None, '') else '—'))}</td>" for value in (
+                    result.get("region"), result.get("phase_outcome"), result.get("failure_stage"),
+                    result.get("failure_code"), result.get("native_failure_code"),
+                    str(bool(result.get("write_started"))).lower(),
+                    str(bool(result.get("remote_object_created"))).lower(),
+                    ("not attempted" if not result.get("cleanup_attempted") else
+                     ("succeeded" if result.get("cleanup_succeeded") else "failed")),
+                    result.get("transfer_progress_bucket"),
+                )) + "</tr>"
+                for result in sorted(results, key=lambda item: int(item.get("map_result_index") or 0))
+            )
+            release = first.get("release_label") or first.get("terento_version") or "legacy"
+            build = first.get("app_build") or "legacy"
+            operation_cards.append(f"""
+              <article class='diagnostic-operation'>
+                <h4>{html.escape(str(operation_key))}</h4>
+                <p>{_timestamp_markup(first.get('occurred_at'))} · {html.escape(str(release))} (build {html.escape(str(build))}) · write started: {str(bool(first.get('write_started'))).lower()}</p>
+                <div class='table-wrap'><table><thead><tr><th>Region</th><th>Result</th><th>Stage</th><th>Code</th><th>Native code</th><th>Write</th><th>Object created</th><th>Cleanup</th><th>Progress</th></tr></thead><tbody>{map_rows}</tbody></table></div>
+              </article>""")
+        sections.append(f"""
+          <details class='diagnostic-details' id='{_diagnostics_id(identity)}'>
+            <summary>{html.escape(identity)} · {len(operations)} operation{'s' if len(operations) != 1 else ''}</summary>
+            {''.join(operation_cards)}
+          </details>""")
+    if not sections:
+        return ""
+    return "<section class='diagnostics-list' aria-label='Installation operation diagnostics'><h3>Operation diagnostics</h3>" + "".join(sections) + "</section>"
 
 
 def _admin_map_capability(value: Any) -> tuple[str, str]:
@@ -1024,6 +1077,12 @@ def _dashboard_script() -> str:
       };
       form.addEventListener('submit', (event) => event.preventDefault());
       [search, status, sort].forEach((control) => control.addEventListener('input', refresh));
+      document.querySelectorAll('a.error-count[href^="#diagnostics-"]').forEach((link) => {
+        link.addEventListener('click', () => {
+          const target = document.querySelector(link.getAttribute('href'));
+          if (target instanceof HTMLDetailsElement) target.open = true;
+        });
+      });
       refresh();
     })();"""
 
@@ -1159,6 +1218,7 @@ td:nth-child(1){font-weight:650}
 td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-numeric:tabular-nums}
 .muted-value{color:var(--secondary)}
 .error-count{display:inline-flex;align-items:center;justify-content:center;min-width:24px;min-height:24px;padding:2px 7px;border:1px solid color-mix(in srgb,var(--danger) 35%,var(--border));border-radius:999px;color:var(--danger);font-weight:700}
+.diagnostics-list{margin-top:24px}.diagnostics-list h3{margin-bottom:12px}.diagnostic-details{margin:8px 0;padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:12px;scroll-margin-top:20px}.diagnostic-details summary{cursor:pointer;font-weight:700}.diagnostic-operation{margin-top:16px}.diagnostic-operation h4{margin:0;font:650 13px ui-monospace,SFMono-Regular,Menlo,monospace}.diagnostic-operation p{margin:5px 0 9px;color:var(--secondary);font-size:12px}.diagnostic-operation table{min-width:920px}
 .status-badge{display:inline-flex;align-items:center;justify-content:center;min-width:74px;min-height:28px;padding:6px 10px;border:1px solid transparent;border-radius:999px;font-size:11px;font-weight:750;letter-spacing:.03em;line-height:1;text-transform:uppercase}
 .status-tested{background:#EDE8DF;border-color:#CFC2AE;color:#5B5144}
 .status-supported{background:#E3EDF0;border-color:#ABC3CD;color:#375E6D}

--- a/backend/catalog-api/src/terento_catalog/collect_devices.py
+++ b/backend/catalog-api/src/terento_catalog/collect_devices.py
@@ -28,7 +28,7 @@ def collect_devices_once(
         raise
 
     if not dry_run:
-        database.upsert_collected_devices(
+        changes = database.upsert_collected_devices(
             result.records,
             collection_complete=result.complete,
         )
@@ -41,6 +41,12 @@ def collect_devices_once(
             canonical_count=result.canonical_devices,
             warning_count=len(result.warnings),
             diagnostics={"warnings": list(result.warnings)},
+            records_total_before=changes["records_total_before"],
+            records_total_after=changes["records_total_after"],
+            records_added=changes["records_added"],
+            records_updated=changes["records_updated"],
+            added_ids=changes["added_ids"],
+            seen_ids=changes["seen_ids"],
         )
 
     for warning in result.warnings:

--- a/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
+++ b/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
@@ -14,6 +14,10 @@ ALLOWED_KEYS = {
     "mapRelease", "terentoVersion", "macOSVersion", "phaseOutcome",
     "automaticFinishingResult", "reconnectVerified", "mapVisibleAfterReconnect",
     "errorCategory", "userConfirmed", "deletionToken",
+    "operationId", "mapResultIndex", "selectedMapCount", "appBuild", "releaseLabel",
+    "failureStage", "failureCode", "nativeFailureCode", "writeStarted",
+    "remoteObjectCreated", "cleanupAttempted", "cleanupSucceeded",
+    "transferProgressBucket",
 }
 FORBIDDEN_KEY_PARTS = ("serial", "unitid", "unit_id", "path", "manifest", "username", "token", "password")
 
@@ -45,7 +49,7 @@ def validate_event(raw: bytes) -> dict[str, Any]:
     }
     if required - set(event):
         raise EvidenceValidationError("missing_fields")
-    if event["schemaVersion"] not in {1, 2}:
+    if event["schemaVersion"] not in {1, 2, 3}:
         raise EvidenceValidationError("unsupported_schema")
     if not re.fullmatch(r"[0-9a-fA-F-]{36}", str(event["id"])):
         raise EvidenceValidationError("invalid_event_id")
@@ -54,7 +58,8 @@ def validate_event(raw: bytes) -> dict[str, Any]:
             raise EvidenceValidationError(f"invalid_{key}")
         if "/Users/" in event[key] or "file://" in event[key]:
             raise EvidenceValidationError("local_path")
-    if event["phaseOutcome"] not in {"SUCCEEDED", "FAILED"}:
+    allowed_outcomes = {"SUCCEEDED", "FAILED", "NOT_STARTED"} if event["schemaVersion"] == 3 else {"SUCCEEDED", "FAILED"}
+    if event["phaseOutcome"] not in allowed_outcomes:
         raise EvidenceValidationError("invalid_outcome")
     if event["automaticFinishingResult"] not in {"VERIFIED", "FAILED", "NOT_REACHED"}:
         raise EvidenceValidationError("invalid_finishing_result")
@@ -62,6 +67,8 @@ def validate_event(raw: bytes) -> dict[str, Any]:
         raise EvidenceValidationError("inconsistent_success")
     if event["phaseOutcome"] == "FAILED" and event["automaticFinishingResult"] == "VERIFIED":
         raise EvidenceValidationError("inconsistent_failure")
+    if event["phaseOutcome"] == "NOT_STARTED" and event["automaticFinishingResult"] != "NOT_REACHED":
+        raise EvidenceValidationError("inconsistent_not_started")
     if event.get("errorCategory") not in {
         None, "acquisition", "transport", "verification", "storage",
         "deviceDisconnected", "sourceValidation", "unknown",
@@ -109,7 +116,79 @@ def validate_event(raw: bytes) -> dict[str, Any]:
         raise EvidenceValidationError("invalid_confirmation")
     if not re.fullmatch(r"[0-9a-fA-F]{64}", str(event["deletionToken"])):
         raise EvidenceValidationError("invalid_deletion_token")
+    if event["schemaVersion"] == 3:
+        _validate_v3(event)
     return event
+
+
+def _validate_v3(event: dict[str, Any]) -> None:
+    required = {
+        "operationId", "mapResultIndex", "selectedMapCount", "appBuild", "releaseLabel",
+        "writeStarted", "remoteObjectCreated", "cleanupAttempted", "cleanupSucceeded",
+        "transferProgressBucket",
+    }
+    if required - set(event):
+        raise EvidenceValidationError("missing_diagnostic_fields")
+    if not re.fullmatch(r"[0-9a-fA-F-]{36}", str(event["operationId"])):
+        raise EvidenceValidationError("invalid_operation_id")
+    if not isinstance(event["mapResultIndex"], int) or isinstance(event["mapResultIndex"], bool):
+        raise EvidenceValidationError("invalid_map_result_index")
+    if not isinstance(event["selectedMapCount"], int) or isinstance(event["selectedMapCount"], bool):
+        raise EvidenceValidationError("invalid_selected_map_count")
+    if not 0 <= event["mapResultIndex"] < event["selectedMapCount"] <= 100:
+        raise EvidenceValidationError("invalid_map_result_position")
+    for key in ("appBuild", "releaseLabel"):
+        if (
+            not isinstance(event[key], str)
+            or not event[key].strip()
+            or len(event[key]) > 80
+            or "/Users/" in event[key]
+            or "file://" in event[key]
+        ):
+            raise EvidenceValidationError(f"invalid_{key}")
+    for key in ("writeStarted", "remoteObjectCreated", "cleanupAttempted", "cleanupSucceeded"):
+        if not isinstance(event[key], bool):
+            raise EvidenceValidationError(f"invalid_{key}")
+    if event["transferProgressBucket"] not in {"0", "1-24", "25-99", "100"}:
+        raise EvidenceValidationError("invalid_transfer_progress_bucket")
+    stages = {"download", "extract", "source-validation", "preflight", "write", "verify", "cleanup", "manifest"}
+    if event.get("failureStage") not in stages | {None}:
+        raise EvidenceValidationError("invalid_failure_stage")
+    failure_codes = {
+        "INSTALL_BLOCKED_EXISTING_MAP_CONFLICT", "INSTALL_BLOCKED_SOURCE_ARTIFACT_INVALID",
+        "INSTALL_BLOCKED_INSUFFICIENT_SPACE", "INSTALL_BLOCKED_UNKNOWN_INSTALL_SIZE",
+        "INSTALL_BLOCKED_UNKNOWN_TARGET", "INSTALL_BLOCKED_MAP_IDENTITY_AMBIGUOUS",
+        "INSTALL_BLOCKED_BACKUP_FAILED", "INSTALL_BLOCKED_DOWNLOAD_FAILED",
+        "INSTALL_BLOCKED_SOURCE_VALIDATION_FAILED", "INSTALL_FAILED_DEVICE_DISCONNECTED",
+        "INSTALL_FAILED_WRITE", "INSTALL_FAILED_SIZE_MISMATCH", "INSTALL_FAILED_HASH_MISMATCH",
+        "INSTALL_FAILED_REMOTE_FILE_MISSING", "INSTALL_FAILED_METADATA_MISMATCH",
+        "INSTALL_FAILED_MANIFEST", "INSTALL_FAILED_PROTECTION_VIOLATION",
+        "INSTALL_FAILED_CLEANUP", "INSTALL_BLOCKED_TRANSACTION_ALREADY_RUNNING",
+        "INSTALL_FAILED_INVALID_STATE_TRANSITION", "INSTALL_BLOCKED_VERIFICATION_REQUIRED",
+        "INSTALL_NOT_STARTED_AFTER_EARLIER_FAILURE",
+    }
+    if event.get("failureCode") not in failure_codes | {None}:
+        raise EvidenceValidationError("invalid_failure_code")
+    native_codes = {
+        "TARGET_ALREADY_EXISTS", "REMOTE_FILE_MISSING", "OBJECT_ID_MISMATCH",
+        "UNSUPPORTED_DEVICE", "DEVICE_DISCONNECTED", "SEND_OBJECT_FAILED",
+        "READBACK_FAILED", "DELETE_FAILED", "MTP_OPEN_FAILED", "GARMIN_ROOT_COUNT_INVALID",
+        "PREFLIGHT_MTP_READ_FAILED",
+    }
+    if event.get("nativeFailureCode") not in native_codes | {None}:
+        raise EvidenceValidationError("invalid_native_failure_code")
+    if event["phaseOutcome"] == "SUCCEEDED" and any(event.get(key) is not None for key in ("failureStage", "failureCode", "nativeFailureCode")):
+        raise EvidenceValidationError("inconsistent_success_diagnostics")
+    if event["phaseOutcome"] in {"FAILED", "NOT_STARTED"} and (
+        event.get("failureStage") is None or event.get("failureCode") is None
+    ):
+        raise EvidenceValidationError("missing_failure_diagnostics")
+    if event["phaseOutcome"] == "NOT_STARTED" and event["writeStarted"]:
+        raise EvidenceValidationError("inconsistent_not_started")
+    if event["remoteObjectCreated"] and not event["writeStarted"]:
+        raise EvidenceValidationError("inconsistent_remote_object")
+    if event["cleanupSucceeded"] and not event["cleanupAttempted"]:
+        raise EvidenceValidationError("inconsistent_cleanup")
 
 
 def validate_deletion_request(raw: bytes) -> tuple[str, str]:

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -9,6 +9,8 @@ from typing import Any, Iterator
 
 from .models import CollectedDevice, CollectedMap
 from .asset_attribution import normalize_asset_source
+from .historical_devices import historical_device_for_event
+from .map_capability import classify_map_capable
 
 
 class Database:
@@ -76,8 +78,55 @@ class Database:
             "deletionTokenHash": self._token_hash(event.get("deletionToken")),
         }
         with self.connection() as connection:
+            # The client contract remains unchanged: canonicalDeviceId is
+            # optional. Resolve a reviewed historical identity server-side so
+            # an installed fēnix 7 can be recorded even when retail collection
+            # no longer returns it. An unknown/stale client ID is ignored
+            # rather than allowing a foreign-key failure to drop the report.
+            requested_id = values.get("canonicalDeviceId")
+            canonical_id = None
+            if requested_id:
+                existing = connection.execute(
+                    "SELECT id FROM device_model WHERE id = %s",
+                    (requested_id,),
+                ).fetchone()
+                canonical_id = (existing.get("id") or requested_id) if existing else None
+            historical = historical_device_for_event(event)
+            if canonical_id is None and historical is not None:
+                self._ensure_historical_device(connection, historical)
+                canonical_id = historical.id
+            values["canonicalDeviceId"] = canonical_id
             inserted = connection.execute(query, values).fetchone() is not None
         return inserted
+
+    @staticmethod
+    def _ensure_historical_device(connection: Any, spec: Any) -> None:
+        connection.execute(
+            """
+            INSERT INTO device_family (id, manufacturer, name, canonical_name, source_url)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (spec.family_id, spec.manufacturer, spec.family_name, spec.canonical_model.split()[0], spec.source_url),
+        )
+        connection.execute(
+            """
+            INSERT INTO device_model (
+                id, family_id, manufacturer, model, canonical_model, variant,
+                case_size_mm, display_type, product_url, source_url,
+                source_image_url, active, map_capable, support_status,
+                record_source, collector_managed
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, TRUE,
+                       'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (
+                spec.id, spec.family_id, spec.manufacturer, spec.model,
+                spec.canonical_model, spec.variant, spec.case_size_mm,
+                spec.display_type, spec.product_url, spec.source_url,
+                spec.source_image_url,
+            ),
+        )
 
     def delete_compatibility_event(self, event_id: str, deletion_token: str) -> bool:
         query = """
@@ -138,6 +187,82 @@ class Database:
         with self.connection() as connection:
             return list(connection.execute(query, (limit,)).fetchall())
 
+    def public_compatibility_models(self, limit: int) -> list[dict[str, Any]]:
+        """Return an additive, evidence-first public model projection.
+
+        This deliberately does not replace ``public_compatibility_statistics``
+        because the latter is consumed by existing native/web clients.
+        """
+        query = """
+            SELECT
+                s.public_display_name AS model,
+                s.model AS evidence_model,
+                s.compatibility_identity,
+                s.variant,
+                s.case_size_mm,
+                s.display_type,
+                s.canonical_device_model_id,
+                s.attempted_install_count,
+                s.successful_install_count,
+                s.reconnect_verified_install_count,
+                s.failed_install_count,
+                s.success_rate,
+                s.calculated_status,
+                s.last_success,
+                s.last_evidence,
+                s.recognized_map_capable_evidence,
+                dm.family_id,
+                f.canonical_name AS family,
+                f.name AS family_name,
+                dm.canonical_model,
+                dm.model AS catalog_model,
+                dm.source_image_url,
+                asset.asset_type,
+                asset.status AS asset_status,
+                asset.url AS asset_url,
+                asset.scope AS asset_scope,
+                asset.sha256 AS asset_sha256,
+                asset.mime_type AS asset_mime_type,
+                asset.width AS asset_width,
+                asset.height AS asset_height,
+                asset.asset_version,
+                asset.source_type AS asset_source_type,
+                asset.source_brand AS asset_source_brand,
+                asset.attribution_required AS asset_attribution_required,
+                asset.storage_key AS asset_storage_key
+            FROM compatibility_model_statistics AS s
+            LEFT JOIN device_model AS dm
+                ON dm.id = s.canonical_device_model_id
+            LEFT JOIN device_family AS f
+                ON f.id = dm.family_id
+            LEFT JOIN LATERAL (
+                SELECT da.*
+                FROM device_asset AS da
+                WHERE da.device_model_id = dm.id
+                  AND da.status = 'AVAILABLE'
+                ORDER BY
+                    CASE da.scope
+                        WHEN 'EXACT_VARIANT' THEN 0
+                        WHEN 'MODEL_SIZE' THEN 1
+                        WHEN 'MODEL' THEN 2
+                        WHEN 'FAMILY' THEN 3
+                        ELSE 4
+                    END,
+                    da.updated_at DESC,
+                    da.id DESC
+                LIMIT 1
+            ) AS asset ON TRUE
+            WHERE s.public_statistics_enabled = true
+              AND s.review_status = 'APPROVED'
+              AND s.calculated_status IN ('TESTING', 'TESTED', 'SUPPORTED', 'VERIFIED')
+            ORDER BY s.successful_install_count DESC,
+                     s.attempted_install_count DESC,
+                     s.public_display_name
+            LIMIT %s
+        """
+        with self.connection() as connection:
+            return list(connection.execute(query, (limit,)).fetchall())
+
     def admin_user_count(self) -> int:
         with self.connection() as connection:
             row = connection.execute("SELECT count(*) AS count FROM admin_user").fetchone()
@@ -193,6 +318,29 @@ class Database:
         with self.connection() as connection:
             row = connection.execute(query, (username, password_hash, user_id)).fetchone()
         return dict(row)
+
+    def update_device_support_status(self, device_id: str, support_status: str) -> bool:
+        """Update only the operator's support decision.
+
+        Evidence counts/statuses are computed from compatibility events and are
+        intentionally absent from this UPDATE. In particular, this method is
+        never used as a device write authorization gate.
+        """
+        allowed = {"SUPPORTED", "UNSUPPORTED", "NOT_EVALUATED"}
+        normalized = support_status.strip().upper()
+        if normalized not in allowed:
+            raise ValueError("unsupported support decision")
+        with self.connection() as connection:
+            row = connection.execute(
+                """
+                UPDATE device_model
+                SET support_status = %s, updated_at = now()
+                WHERE id = %s
+                RETURNING id
+                """,
+                (normalized, device_id),
+            ).fetchone()
+        return row is not None
 
     def catalog_snapshot(self) -> tuple[list[dict[str, Any]], datetime]:
         query = """
@@ -608,6 +756,7 @@ class Database:
                     da.id DESC
                 LIMIT 1
             ) AS asset ON TRUE
+            WHERE dm.collector_managed = TRUE
             ORDER BY dm.id
         """
         updated_at_query = """
@@ -615,7 +764,9 @@ class Database:
             FROM (
                 SELECT updated_at AS changed_at FROM device_family
                 UNION ALL
-                SELECT updated_at AS changed_at FROM device_model
+                SELECT updated_at AS changed_at
+                FROM device_model
+                WHERE collector_managed = TRUE
                 UNION ALL
                 SELECT updated_at AS changed_at FROM device_asset
             ) AS changes
@@ -629,12 +780,138 @@ class Database:
             updated_at = updated_at.replace(tzinfo=timezone.utc)
         return rows, updated_at
 
+    def admin_device_snapshot(self) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        """Return one aggregate row per exact Garmin catalog record.
+
+        Compatibility evidence is joined only through the canonical catalog
+        device ID. Legacy/model-string joins are deliberately excluded so a
+        47 mm and 51 mm variant can never inherit one another's counts.
+        """
+        query = """
+            SELECT
+                f.id AS family_id,
+                f.name AS family_name,
+                f.canonical_name AS family_canonical_name,
+                dm.id AS device_id,
+                dm.manufacturer,
+                dm.model,
+                dm.canonical_model,
+                dm.variant,
+                dm.case_size_mm,
+                dm.display_type,
+                dm.part_number,
+                dm.product_url,
+                dm.source_url,
+                dm.source_image_url,
+                dm.active,
+                dm.record_source,
+                dm.collector_managed,
+                dm.first_seen_at,
+                dm.last_seen_at,
+                dm.created_at,
+                dm.updated_at,
+                dm.map_capable,
+                dm.support_status,
+                dm.first_seen_collection_run_id,
+                dm.last_seen_collection_run_id,
+                asset.asset_type,
+                asset.status AS asset_status,
+                asset.url AS asset_url,
+                asset.sha256 AS asset_sha256,
+                asset.width AS asset_width,
+                asset.height AS asset_height,
+                asset.mime_type AS asset_mime_type,
+                asset.asset_version,
+                COALESCE(usb.identities, '[]'::jsonb) AS usb_identities,
+                COALESCE(evidence.attempts, 0) AS attempted_install_count,
+                COALESCE(evidence.successful, 0) AS successful_install_count,
+                COALESCE(evidence.failed, 0) AS failed_install_count,
+                evidence.first_success,
+                evidence.last_success,
+                evidence.last_evidence,
+                latest.id AS latest_successful_sync_id,
+                latest.started_at AS latest_successful_sync_started_at,
+                latest.finished_at AS latest_successful_sync_finished_at,
+                latest.status AS latest_successful_sync_status,
+                latest.records_total_before AS latest_records_total_before,
+                latest.records_total_after AS latest_records_total_after,
+                latest.records_added AS latest_records_added,
+                latest.records_updated AS latest_records_updated
+            FROM device_model AS dm
+            JOIN device_family AS f ON f.id = dm.family_id
+            LEFT JOIN LATERAL (
+                SELECT da.asset_type, da.status, da.url, da.sha256,
+                       da.width, da.height, da.mime_type, da.asset_version
+                FROM device_asset AS da
+                WHERE da.device_model_id = dm.id
+                  AND da.status = 'AVAILABLE'
+                ORDER BY da.updated_at DESC, da.id DESC
+                LIMIT 1
+            ) AS asset ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT jsonb_agg(
+                    jsonb_build_object(
+                        'vendorId', ui.vendor_id,
+                        'productId', ui.product_id,
+                        'source', ui.source,
+                        'confidence', ui.confidence
+                    ) ORDER BY ui.vendor_id, ui.product_id
+                ) AS identities
+                FROM device_usb_identity AS ui
+                WHERE ui.device_model_id = dm.id
+            ) AS usb ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT
+                    count(*) AS attempts,
+                    count(*) FILTER (
+                        WHERE e.phase_outcome = 'SUCCEEDED'
+                          AND e.automatic_finishing_result = 'VERIFIED'
+                    ) AS successful,
+                    count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed,
+                    min(e.occurred_at) FILTER (
+                        WHERE e.phase_outcome = 'SUCCEEDED'
+                          AND e.automatic_finishing_result = 'VERIFIED'
+                    ) AS first_success,
+                    max(e.occurred_at) FILTER (
+                        WHERE e.phase_outcome = 'SUCCEEDED'
+                          AND e.automatic_finishing_result = 'VERIFIED'
+                    ) AS last_success,
+                    max(e.occurred_at) AS last_evidence
+                FROM compatibility_evidence_event AS e
+                WHERE e.canonical_device_model_id = dm.id
+            ) AS evidence ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT r.*
+                FROM device_collection_run AS r
+                WHERE r.status = 'SUCCEEDED'
+                ORDER BY r.finished_at DESC NULLS LAST, r.id DESC
+                LIMIT 1
+            ) AS latest ON TRUE
+            ORDER BY dm.model, dm.case_size_mm NULLS LAST, dm.variant, dm.id
+        """
+        with self.connection() as connection:
+            rows = list(connection.execute(query).fetchall())
+            latest = connection.execute(
+                """
+                SELECT id, started_at, finished_at, status,
+                       records_total_before, records_total_after,
+                       records_added, records_updated
+                FROM device_collection_run
+                WHERE status = 'SUCCEEDED'
+                ORDER BY finished_at DESC NULLS LAST, id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+
+        sync = dict(latest) if latest else None
+        return rows, sync
+
     def upsert_collected_devices(
         self,
         records: list[CollectedDevice],
         *,
         collection_complete: bool = True,
-    ) -> None:
+    ) -> dict[str, Any]:
         if not records:
             raise ValueError("Garmin collector returned no records")
 
@@ -666,8 +943,8 @@ class Database:
             INSERT INTO device_model (
                 id, family_id, manufacturer, model, canonical_model, variant,
                 case_size_mm, display_type, part_number, product_url, source_url,
-                source_image_url
-            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                source_image_url, map_capable, record_source, collector_managed
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'CURRENT_RETAIL', TRUE)
             ON CONFLICT (id) DO UPDATE SET
                 family_id = EXCLUDED.family_id,
                 manufacturer = EXCLUDED.manufacturer,
@@ -680,6 +957,9 @@ class Database:
                 product_url = EXCLUDED.product_url,
                 source_url = EXCLUDED.source_url,
                 source_image_url = EXCLUDED.source_image_url,
+                map_capable = COALESCE(device_model.map_capable, EXCLUDED.map_capable),
+                record_source = 'CURRENT_RETAIL',
+                collector_managed = TRUE,
                 active = TRUE,
                 consecutive_missed_collections = 0,
                 last_seen_at = now(),
@@ -716,7 +996,50 @@ class Database:
 
         seen_ids = [record.id for record in records]
         with self.connection() as connection:
+            total_before = int(
+                connection.execute("SELECT count(*) AS count FROM device_model").fetchone()["count"]
+            )
+            existing_rows = {
+                row["id"]: row
+                for row in connection.execute(
+                    """
+                    SELECT id, family_id, manufacturer, model, canonical_model, variant,
+                           case_size_mm, display_type, part_number, product_url,
+                           source_url, source_image_url, active
+                    FROM device_model
+                    WHERE id = ANY(%s)
+                    """,
+                    (seen_ids,),
+                ).fetchall()
+            }
+            added_ids: list[str] = []
+            updated_ids: list[str] = []
             for record in records:
+                existing = existing_rows.get(record.id)
+                if existing is None:
+                    added_ids.append(record.id)
+                else:
+                    incoming_part_number = record.part_number or existing["part_number"]
+                    incoming_values = (
+                        record.family_id,
+                        record.manufacturer,
+                        record.model,
+                        record.canonical_model,
+                        record.variant,
+                        record.case_size_mm,
+                        record.display_type,
+                        incoming_part_number,
+                        record.product_url,
+                        record.source_url,
+                        record.source_image_url,
+                    )
+                    existing_values = tuple(existing[key] for key in (
+                        "family_id", "manufacturer", "model", "canonical_model", "variant",
+                        "case_size_mm", "display_type", "part_number", "product_url",
+                        "source_url", "source_image_url",
+                    ))
+                    if existing["active"] is False or incoming_values != existing_values:
+                        updated_ids.append(record.id)
                 connection.execute(
                     family_query,
                     (
@@ -743,6 +1066,7 @@ class Database:
                         record.product_url,
                         record.source_url,
                         record.source_image_url,
+                        classify_map_capable(record.canonical_model, record.manufacturer),
                     ),
                 )
 
@@ -757,6 +1081,20 @@ class Database:
                 )
 
             if collection_complete:
+                deactivated_ids = [
+                    row["id"]
+                    for row in connection.execute(
+                        """
+                        SELECT id
+                        FROM device_model
+                        WHERE id <> ALL(%s)
+                          AND collector_managed = TRUE
+                          AND active = TRUE
+                          AND consecutive_missed_collections + 1 >= 3
+                        """,
+                        (seen_ids,),
+                    ).fetchall()
+                ]
                 connection.execute(
                     """
                     UPDATE device_model
@@ -777,10 +1115,28 @@ class Database:
                             THEN now()
                             ELSE updated_at
                         END
-                    WHERE TRUE
+                    WHERE collector_managed = TRUE
                     """,
                     (seen_ids, seen_ids, seen_ids),
                 )
+                updated_ids.extend(
+                    device_id for device_id in deactivated_ids
+                    if device_id not in updated_ids
+                )
+
+            total_after = int(
+                connection.execute("SELECT count(*) AS count FROM device_model").fetchone()["count"]
+            )
+
+        return {
+            "records_total_before": total_before,
+            "records_total_after": total_after,
+            "records_added": len(added_ids),
+            "records_updated": len(updated_ids),
+            "added_ids": added_ids,
+            "updated_ids": updated_ids,
+            "seen_ids": seen_ids,
+        }
 
     def record_device_collection_run(
         self,
@@ -793,17 +1149,25 @@ class Database:
         canonical_count: int,
         warning_count: int,
         diagnostics: dict[str, Any],
+        records_total_before: int = 0,
+        records_total_after: int = 0,
+        records_added: int = 0,
+        records_updated: int = 0,
+        added_ids: list[str] | None = None,
+        seen_ids: list[str] | None = None,
     ) -> None:
         import json
 
         with self.connection() as connection:
-            connection.execute(
+            run = connection.execute(
                 """
                 INSERT INTO device_collection_run (
                     source_url, started_at, finished_at, status,
                     discovered_count, canonical_count, warning_count,
-                    diagnostics_json
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                    diagnostics_json, records_total_before, records_total_after,
+                    records_added, records_updated
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
+                RETURNING id
                 """,
                 (
                     source_url,
@@ -814,8 +1178,31 @@ class Database:
                     canonical_count,
                     warning_count,
                     json.dumps(diagnostics, ensure_ascii=False),
+                    records_total_before,
+                    records_total_after,
+                    records_added,
+                    records_updated,
                 ),
-            )
+            ).fetchone()
+            run_id = run["id"]
+            if seen_ids:
+                connection.execute(
+                    """
+                    UPDATE device_model
+                    SET last_seen_collection_run_id = %s
+                    WHERE id = ANY(%s)
+                    """,
+                    (run_id, seen_ids),
+                )
+            if added_ids:
+                connection.execute(
+                    """
+                    UPDATE device_model
+                    SET first_seen_collection_run_id = COALESCE(first_seen_collection_run_id, %s)
+                    WHERE id = ANY(%s)
+                    """,
+                    (run_id, added_ids),
+                )
 
     def upsert_device_asset(
         self,

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -49,7 +49,10 @@ class Database:
                 usb_vendor_id, usb_product_id, transport, provider, region,
                 map_release, terento_version, macos_version, phase_outcome,
                 automatic_finishing_result, reconnect_verified, map_visible_after_reconnect,
-                error_category, deletion_token_hash
+                error_category, deletion_token_hash, operation_id, map_result_index,
+                selected_map_count, app_build, release_label, failure_stage, failure_code,
+                native_failure_code, write_started, remote_object_created,
+                cleanup_attempted, cleanup_succeeded, transfer_progress_bucket
             ) VALUES (
                 %(id)s, %(timestamp)s, %(model)s, %(compatibilityIdentity)s, %(variant)s, %(caseSizeMm)s,
                 %(displayType)s, %(canonicalDeviceId)s,
@@ -57,7 +60,11 @@ class Database:
                 %(usbVendorID)s, %(usbProductID)s, %(transport)s, %(provider)s, %(region)s,
                 %(mapRelease)s, %(terentoVersion)s, %(macOSVersion)s, %(phaseOutcome)s,
                 %(automaticFinishingResult)s, %(reconnectVerified)s, %(mapVisibleAfterReconnect)s,
-                %(errorCategory)s, %(deletionTokenHash)s
+                %(errorCategory)s, %(deletionTokenHash)s, %(operationId)s, %(mapResultIndex)s,
+                %(selectedMapCount)s, %(appBuild)s, %(releaseLabel)s, %(failureStage)s,
+                %(failureCode)s, %(nativeFailureCode)s, %(writeStarted)s,
+                %(remoteObjectCreated)s, %(cleanupAttempted)s, %(cleanupSucceeded)s,
+                %(transferProgressBucket)s
             ) ON CONFLICT (event_id) DO NOTHING
             RETURNING event_id
         """
@@ -76,6 +83,19 @@ class Database:
             "mapVisibleAfterReconnect": bool(event.get("mapVisibleAfterReconnect", False)),
             "errorCategory": event.get("errorCategory"),
             "deletionTokenHash": self._token_hash(event.get("deletionToken")),
+            "operationId": event.get("operationId"),
+            "mapResultIndex": event.get("mapResultIndex"),
+            "selectedMapCount": event.get("selectedMapCount"),
+            "appBuild": event.get("appBuild"),
+            "releaseLabel": event.get("releaseLabel"),
+            "failureStage": event.get("failureStage"),
+            "failureCode": event.get("failureCode"),
+            "nativeFailureCode": event.get("nativeFailureCode"),
+            "writeStarted": event.get("writeStarted"),
+            "remoteObjectCreated": event.get("remoteObjectCreated"),
+            "cleanupAttempted": event.get("cleanupAttempted"),
+            "cleanupSucceeded": event.get("cleanupSucceeded"),
+            "transferProgressBucket": event.get("transferProgressBucket"),
         }
         with self.connection() as connection:
             # The client contract remains unchanged: canonicalDeviceId is
@@ -158,6 +178,25 @@ class Database:
         query = "SELECT * FROM compatibility_model_statistics ORDER BY model"
         with self.connection() as connection:
             return list(connection.execute(query).fetchall())
+
+    def compatibility_operation_details(self, limit: int = 500) -> list[dict[str, Any]]:
+        query = """
+            SELECT
+                COALESCE(operation_id::text, 'legacy:' || event_id::text) AS operation_key,
+                operation_id, event_id, occurred_at, model, compatibility_identity,
+                variant, firmware_version, region, map_release, terento_version,
+                app_build, release_label, map_result_index, selected_map_count,
+                phase_outcome, failure_stage, failure_code, native_failure_code,
+                COALESCE(write_started, true) AS write_started,
+                COALESCE(remote_object_created, false) AS remote_object_created,
+                COALESCE(cleanup_attempted, false) AS cleanup_attempted,
+                cleanup_succeeded, transfer_progress_bucket, error_category
+            FROM compatibility_evidence_event
+            ORDER BY occurred_at DESC, operation_key, map_result_index NULLS FIRST
+            LIMIT %s
+        """
+        with self.connection() as connection:
+            return list(connection.execute(query, (limit,)).fetchall())
 
     def public_compatibility_statistics(self, limit: int) -> list[dict[str, Any]]:
         query = """

--- a/backend/catalog-api/src/terento_catalog/historical_devices.py
+++ b/backend/catalog-api/src/terento_catalog/historical_devices.py
@@ -1,0 +1,159 @@
+"""Reviewed historical Garmin identities used to resolve compatibility evidence.
+
+The retail collector is intentionally not the source of truth for this list.
+These records describe models that can still be encountered in the native app
+even after Garmin removes them from its current retail category.  The registry
+is an identity/provenance aid only: it never grants permission to write to a
+device.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import unicodedata
+
+
+HISTORICAL_REGISTRY_VERSION = 1
+REGISTRY_SOURCE_URL = "https://developer.garmin.com/connect-iq/compatible-devices/"
+GARMIN_CATEGORY_URL = "https://www.garmin.com/en-US/c/wearables-smartwatches/"
+
+
+@dataclass(frozen=True)
+class HistoricalDeviceSpec:
+    id: str
+    family_id: str
+    family_name: str
+    manufacturer: str
+    model: str
+    canonical_model: str
+    variant: str
+    case_size_mm: int | None
+    display_type: str | None
+    product_url: str
+    source_url: str = REGISTRY_SOURCE_URL
+    source_image_url: str | None = None
+    aliases: tuple[str, ...] = ()
+
+
+def _spec(
+    id: str,
+    model: str,
+    canonical_model: str,
+    variant: str,
+    case_size_mm: int | None,
+    *,
+    family_id: str = "garmin-fenix",
+    family_name: str = "fēnix",
+    display_type: str | None = None,
+    aliases: tuple[str, ...] = (),
+) -> HistoricalDeviceSpec:
+    return HistoricalDeviceSpec(
+        id=id,
+        family_id=family_id,
+        family_name=family_name,
+        manufacturer="Garmin",
+        model=model,
+        canonical_model=canonical_model,
+        variant=variant,
+        case_size_mm=case_size_mm,
+        display_type=display_type,
+        product_url=GARMIN_CATEGORY_URL,
+        aliases=(canonical_model, *aliases),
+    )
+
+
+# Keep this list small, explicit, and reviewable.  It is deliberately not
+# generated from the current Garmin retail category.
+HISTORICAL_DEVICE_REGISTRY: tuple[HistoricalDeviceSpec, ...] = (
+    _spec("garmin-fenix-7-47", "fēnix 7", "fenix 7", "47 mm", 47),
+    _spec(
+        "garmin-fenix-7s-42", "fēnix 7S", "fenix 7s", "42 mm", 42,
+        aliases=("fenix 7s",),
+    ),
+    _spec(
+        "garmin-fenix-7x-51", "fēnix 7X", "fenix 7x", "51 mm", 51,
+        aliases=("fenix 7x",),
+    ),
+    _spec("garmin-fenix-6-47", "fēnix 6", "fenix 6", "47 mm", 47),
+    _spec(
+        "garmin-fenix-6s-42", "fēnix 6S", "fenix 6s", "42 mm", 42,
+        aliases=("fenix 6s",),
+    ),
+    _spec(
+        "garmin-fenix-6x-51", "fēnix 6X", "fenix 6x", "51 mm", 51,
+        aliases=("fenix 6x",),
+    ),
+    _spec(
+        "garmin-epix-gen-2-47",
+        "epix (Gen 2)",
+        "epix gen 2",
+        "47 mm",
+        47,
+        family_id="garmin-epix",
+        family_name="epix",
+        aliases=("epix", "epix gen 2"),
+    ),
+    _spec(
+        "garmin-forerunner-955",
+        "Forerunner 955",
+        "forerunner 955",
+        "Standard",
+        None,
+        family_id="garmin-forerunner",
+        family_name="Forerunner",
+        aliases=("forerunner 955",),
+    ),
+)
+
+_BY_ID = {spec.id: spec for spec in HISTORICAL_DEVICE_REGISTRY}
+
+
+def normalize_identity(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = unicodedata.normalize("NFKD", value)
+    text = "".join(char for char in text if not unicodedata.combining(char))
+    text = re.sub(r"[^a-z0-9]+", " ", text.lower())
+    text = " ".join(text.split())
+    if text.startswith("garmin "):
+        text = text[len("garmin "):]
+    return text
+
+
+def historical_device_spec(device_id: str | None) -> HistoricalDeviceSpec | None:
+    return _BY_ID.get(device_id or "")
+
+
+def historical_device_for_event(event: dict[str, object]) -> HistoricalDeviceSpec | None:
+    """Resolve a report to a reviewed historical identity without fuzzy joins."""
+
+    model = normalize_identity(event.get("model"))
+    if not model:
+        return None
+    case_size = event.get("caseSizeMm")
+    try:
+        case_size = int(case_size) if case_size is not None else None
+    except (TypeError, ValueError):
+        case_size = None
+
+    candidates: list[HistoricalDeviceSpec] = []
+    for spec in HISTORICAL_DEVICE_REGISTRY:
+        aliases = {normalize_identity(alias) for alias in spec.aliases}
+        if model not in aliases:
+            continue
+        if spec.case_size_mm is not None and case_size is not None and spec.case_size_mm != case_size:
+            continue
+        candidates.append(spec)
+
+    exact_size = [spec for spec in candidates if spec.case_size_mm == case_size]
+    if exact_size:
+        return exact_size[0]
+    unspecified_size = [spec for spec in candidates if spec.case_size_mm is None]
+    if unspecified_size:
+        return unspecified_size[0]
+    return candidates[0] if candidates else None
+
+
+def all_historical_device_specs() -> tuple[HistoricalDeviceSpec, ...]:
+    return HISTORICAL_DEVICE_REGISTRY

--- a/backend/catalog-api/src/terento_catalog/historical_devices.py
+++ b/backend/catalog-api/src/terento_catalog/historical_devices.py
@@ -128,19 +128,33 @@ def historical_device_spec(device_id: str | None) -> HistoricalDeviceSpec | None
 def historical_device_for_event(event: dict[str, object]) -> HistoricalDeviceSpec | None:
     """Resolve a report to a reviewed historical identity without fuzzy joins."""
 
-    model = normalize_identity(event.get("model"))
-    if not model:
+    identities = [
+        normalize_identity(event.get("model")),
+        normalize_identity(event.get("compatibilityIdentity")),
+    ]
+    identities = [identity for identity in identities if identity]
+    if not identities:
         return None
     case_size = event.get("caseSizeMm")
     try:
         case_size = int(case_size) if case_size is not None else None
     except (TypeError, ValueError):
         case_size = None
+    if case_size is None:
+        for identity in identities:
+            size_match = re.search(r"\b(\d{2})\s*mm\b", identity)
+            if size_match:
+                case_size = int(size_match.group(1))
+                break
 
     candidates: list[HistoricalDeviceSpec] = []
     for spec in HISTORICAL_DEVICE_REGISTRY:
         aliases = {normalize_identity(alias) for alias in spec.aliases}
-        if model not in aliases:
+        if not any(
+            identity == alias or identity.startswith(f"{alias} ")
+            for identity in identities
+            for alias in aliases
+        ):
             continue
         if spec.case_size_mm is not None and case_size is not None and spec.case_size_mm != case_size:
             continue

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -19,6 +19,8 @@ from .admin import (
     account_page,
     campaign_links_page,
     dashboard_page,
+    devices_page,
+    _admin_device_payload,
     hash_password,
     login_page,
     new_token,
@@ -29,9 +31,12 @@ from .admin import (
     verify_password,
 )
 from .asset_storage import AssetStorage
+from .asset_attribution import public_asset_source
 from .catalog import build_catalog, catalog_etag, serialize_catalog
 from .db import Database
 from .device_catalog import (
+    CONTROLLED_ASSET_PREFIX,
+    _official_source_image_url,
     build_device_catalog,
     device_catalog_etag,
     serialize_device_catalog,
@@ -88,6 +93,13 @@ class CatalogService:
     def compatibility_statistics(self) -> list[dict[str, Any]]:
         return self._canonicalize_statistics(self.database.compatibility_statistics())
 
+    def admin_devices(self) -> dict[str, Any]:
+        rows, sync = self.database.admin_device_snapshot()
+        return _admin_device_payload(rows, sync)
+
+    def update_device_support_status(self, device_id: str, support_status: str) -> bool:
+        return self.database.update_device_support_status(device_id, support_status)
+
     def admin_is_configured(self) -> bool:
         return self.database.admin_user_count() > 0
 
@@ -141,6 +153,11 @@ class CatalogService:
         if not self.public_compatibility_stats_enabled:
             raise LookupError("disabled")
         return self._canonicalize_statistics(self.database.public_compatibility_statistics(limit))
+
+    def public_models(self, limit: int) -> list[dict[str, Any]]:
+        if not self.public_compatibility_stats_enabled:
+            raise LookupError("disabled")
+        return self._canonicalize_statistics(self.database.public_compatibility_models(limit))
 
     @staticmethod
     def _canonicalize_statistics(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -211,6 +228,9 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 return
             if request_path == "/compatibility/public/top-models.json":
                 self._handle_public_statistics(send_body=send_body)
+                return
+            if request_path == "/compatibility/public/models.json":
+                self._handle_public_models(send_body=send_body)
                 return
             if request_path == "/internal/compatibility/":
                 self._redirect("/admin", send_body=send_body)
@@ -324,6 +344,23 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     return
                 self._send_admin_html(body, send_body=send_body)
                 return
+            if request_path in {"/admin/devices", "/admin/devices/"}:
+                try:
+                    rows, sync = service.database.admin_device_snapshot()
+                    body = devices_page(rows, sync, session, csrf_token)
+                except Exception:
+                    LOGGER.exception("admin device catalog failed")
+                    self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "admin_devices_unavailable"}, send_body=send_body, cache_control="no-store")
+                    return
+                self._send_admin_html(body, send_body=send_body)
+                return
+            if request_path in {"/admin/devices.json", "/admin/devices.json/"}:
+                try:
+                    self._send_json(HTTPStatus.OK, service.admin_devices(), send_body=send_body, cache_control="no-store")
+                except Exception:
+                    LOGGER.exception("admin device API failed")
+                    self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "admin_devices_unavailable"}, send_body=send_body, cache_control="no-store")
+                return
             if request_path in {"/admin/campaign-links", "/admin/campaign-links/"}:
                 self._send_admin_html(campaign_links_page(session, csrf_token), send_body=send_body)
                 return
@@ -367,6 +404,20 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     return
                 body = account_page(updated, self._csrf_cookie() or "", success="Account details updated.")
                 self._send_admin_html(body, send_body=True)
+                return
+            if request_path == "/admin/devices/support":
+                try:
+                    device_id = form.get("device_id", "").strip()
+                    support_status = form.get("support_status", "").strip().upper()
+                    if not device_id or support_status not in {"SUPPORTED", "UNSUPPORTED", "NOT_EVALUATED"}:
+                        raise ValueError("invalid support decision")
+                    if not service.update_device_support_status(device_id, support_status):
+                        self._send_json(HTTPStatus.NOT_FOUND, {"error": "device_not_found"}, send_body=True, cache_control="no-store")
+                        return
+                except ValueError:
+                    self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_support_decision"}, send_body=True, cache_control="no-store")
+                    return
+                self._redirect("/admin/devices", send_body=True)
                 return
             self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"}, send_body=True, cache_control="no-store")
 
@@ -437,6 +488,67 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
             } for row in rows]
             self._send_json(HTTPStatus.OK, {"schemaVersion": 2, "generatedAt": datetime.now(timezone.utc).isoformat(), "models": models}, send_body=send_body, cache_control="public, max-age=300, stale-while-revalidate=3600")
 
+        def _handle_public_models(self, *, send_body: bool) -> None:
+            try:
+                query = parse_qs(urlsplit(self.path).query)
+                limit = max(1, min(500, int(query.get("limit", ["500"])[0])))
+                rows = service.public_models(limit)
+            except (ValueError, LookupError):
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"}, send_body=send_body, cache_control="no-store")
+                return
+            except Exception:
+                LOGGER.exception("public compatibility model projection failed")
+                self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "statistics_unavailable"}, send_body=send_body, cache_control="no-store")
+                return
+
+            models = []
+            for row in rows:
+                image = None
+                asset_url = row.get("asset_url")
+                if (
+                    row.get("asset_status") == "AVAILABLE"
+                    and isinstance(asset_url, str)
+                    and asset_url.startswith(CONTROLLED_ASSET_PREFIX)
+                    and isinstance(row.get("asset_storage_key"), str)
+                    and public_asset_source(row) is not None
+                ):
+                    image = {
+                        "url": asset_url,
+                        "origin": "controlled",
+                        "status": "AVAILABLE",
+                        "scope": row.get("asset_scope") or "MODEL",
+                    }
+                if image is None:
+                    source_image_url = _official_source_image_url(row.get("source_image_url"))
+                    if source_image_url:
+                        image = {"url": source_image_url, "origin": "garmin-source", "status": "SOURCE"}
+                models.append({
+                    "model": row.get("model") or row.get("evidence_model"),
+                    "canonicalModel": row.get("canonical_model") or row.get("evidence_model"),
+                    "family": row.get("family") or "other",
+                    "familyName": row.get("family_name") or row.get("family") or "Other",
+                    "compatibilityIdentity": row.get("compatibility_identity"),
+                    "variant": row.get("variant"),
+                    "caseSizeMm": row.get("case_size_mm"),
+                    "displayType": row.get("display_type"),
+                    "canonicalDeviceId": row.get("canonical_device_model_id"),
+                    "attemptedInstallations": int(row.get("attempted_install_count") or 0),
+                    "successfulInstallations": int(row.get("successful_install_count") or 0),
+                    "reconnectVerifiedInstallations": int(row.get("reconnect_verified_install_count") or 0),
+                    "failedInstallations": int(row.get("failed_install_count") or 0),
+                    "successRate": float(row["success_rate"]) if row.get("success_rate") is not None else None,
+                    "evidenceStatus": row.get("calculated_status"),
+                    "lastSuccessfulInstallation": row["last_success"].isoformat() if isinstance(row.get("last_success"), datetime) else row.get("last_success"),
+                    "lastEvidence": row["last_evidence"].isoformat() if isinstance(row.get("last_evidence"), datetime) else row.get("last_evidence"),
+                    "image": image,
+                })
+            self._send_json(
+                HTTPStatus.OK,
+                {"schemaVersion": 1, "generatedAt": datetime.now(timezone.utc).isoformat(), "models": models},
+                send_body=send_body,
+                cache_control="public, max-age=300, stale-while-revalidate=3600",
+            )
+
         def _read_form(self) -> dict[str, str] | None:
             try:
                 length = int(self.headers.get("Content-Length", "0"))
@@ -496,7 +608,7 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
             script_policy = f"script-src 'nonce-{nonce_match.group(1).decode('ascii')}'" if nonce_match else "script-src 'none'"
             self.send_header(
                 "Content-Security-Policy",
-                f"default-src 'none'; {script_policy}; style-src 'unsafe-inline' https://terento.app; font-src https://terento.app; img-src https://terento.app data:; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+                f"default-src 'none'; {script_policy}; style-src 'unsafe-inline' https://terento.app; font-src https://terento.app; img-src https://terento.app https://api.terento.app https://res.garmin.com data:; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
             )
             self.send_header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -93,6 +93,9 @@ class CatalogService:
     def compatibility_statistics(self) -> list[dict[str, Any]]:
         return self._canonicalize_statistics(self.database.compatibility_statistics())
 
+    def compatibility_operation_details(self) -> list[dict[str, Any]]:
+        return self.database.compatibility_operation_details()
+
     def admin_devices(self) -> dict[str, Any]:
         rows, sync = self.database.admin_device_snapshot()
         return _admin_device_payload(rows, sync)
@@ -336,6 +339,7 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 try:
                     body = dashboard_page(
                         service.compatibility_statistics(), session, csrf_token,
+                        operations=service.compatibility_operation_details(),
                         public_stats_enabled=service.public_compatibility_stats_enabled,
                     )
                 except Exception:

--- a/backend/catalog-api/src/terento_catalog/map_capability.py
+++ b/backend/catalog-api/src/terento_catalog/map_capability.py
@@ -1,0 +1,100 @@
+"""Map Manager capability classification shared with the native client.
+
+This is not compatibility evidence and does not authorize a device write.
+It answers only whether Garmin Map Manager lists the model for additional
+maps. The prefix lists must stay aligned with
+`GarminMapCapabilityRegistry` in the macOS client.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+
+
+SUPPORTED_PREFIXES = (
+    "d2 mach 1",
+    "d2 mach 2",
+    "descent mk1",
+    "descent mk2",
+    "descent mk3",
+    "enduro 2",
+    "enduro 3",
+    "epix gen 2",
+    "epix pro gen 2",
+    "fenix 5x",
+    "fenix 5 plus",
+    "fenix 6",
+    "fenix 7",
+    "fenix 8",
+    "fenix e",
+    "forerunner 945",
+    "forerunner 955",
+    "forerunner 965",
+    "forerunner 970",
+    "marq",
+    "quatix 6",
+    "quatix 7",
+    "quatix 8",
+    "tactix charlie",
+    "tactix delta",
+    "tactix 7",
+    "tactix 8",
+    "venu x1",
+)
+
+KNOWN_NON_MAP_PREFIXES = (
+    "approach",
+    "descent g1",
+    "descent g2",
+    "forerunner 55",
+    "forerunner 165",
+    "forerunner 255",
+    "forerunner 265",
+    "forerunner 570",
+    "instinct",
+    "lily",
+    "venu",
+    "vivoactive",
+    "vivomove",
+)
+
+
+def classify_map_capable(
+    model: Any,
+    manufacturer: Any = "Garmin",
+) -> bool | None:
+    """Return True, False, or None when the model is unrecognized."""
+
+    if not _is_garmin(manufacturer):
+        return None
+
+    normalized = _normalize_model(model)
+    if not normalized:
+        return None
+    if normalized.startswith("approach s70"):
+        return False
+    if any(normalized.startswith(prefix) for prefix in SUPPORTED_PREFIXES):
+        return True
+    if any(normalized.startswith(prefix) for prefix in KNOWN_NON_MAP_PREFIXES):
+        return False
+    return None
+
+
+def _is_garmin(value: Any) -> bool:
+    return "garmin" in _normalize_model(value)
+
+
+def _normalize_model(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    normalized = unicodedata.normalize("NFKD", value)
+    normalized = "".join(
+        character for character in normalized if not unicodedata.combining(character)
+    )
+    normalized = re.sub(r"[^a-z0-9]+", " ", normalized.lower())
+    normalized = " ".join(normalized.split())
+    if normalized.startswith("garmin "):
+        normalized = normalized[len("garmin "):]
+    return normalized

--- a/backend/catalog-api/src/terento_catalog/migrations/014_admin_device_observability.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/014_admin_device_observability.sql
@@ -1,0 +1,31 @@
+-- Additive fields for the private Garmin device observability surface. These
+-- values are intentionally separate from public catalog and evidence status.
+ALTER TABLE device_model
+    ADD COLUMN map_capable BOOLEAN,
+    ADD COLUMN support_status TEXT NOT NULL DEFAULT 'NOT_EVALUATED',
+    ADD COLUMN first_seen_collection_run_id BIGINT REFERENCES device_collection_run(id) ON DELETE SET NULL,
+    ADD COLUMN last_seen_collection_run_id BIGINT REFERENCES device_collection_run(id) ON DELETE SET NULL;
+
+ALTER TABLE device_model
+    ADD CONSTRAINT device_model_support_status_check
+    CHECK (support_status IN ('SUPPORTED', 'UNSUPPORTED', 'NOT_EVALUATED'));
+
+-- Carry forward the one exact write-capable device profile already validated
+-- by the native client. Other discovered records remain NOT_EVALUATED and
+-- map capability stays NULL until it has explicit evidence.
+UPDATE device_model
+SET map_capable = TRUE,
+    support_status = 'SUPPORTED'
+WHERE id = 'garmin-fenix-8-47-amoled';
+
+ALTER TABLE device_collection_run
+    ADD COLUMN records_total_before INTEGER CHECK (records_total_before IS NULL OR records_total_before >= 0),
+    ADD COLUMN records_total_after INTEGER CHECK (records_total_after IS NULL OR records_total_after >= 0),
+    ADD COLUMN records_added INTEGER CHECK (records_added IS NULL OR records_added >= 0),
+    ADD COLUMN records_updated INTEGER CHECK (records_updated IS NULL OR records_updated >= 0);
+
+CREATE INDEX device_model_first_seen_run_idx
+    ON device_model(first_seen_collection_run_id);
+
+CREATE INDEX device_model_last_seen_run_idx
+    ON device_model(last_seen_collection_run_id);

--- a/backend/catalog-api/src/terento_catalog/migrations/015_canonical_compatibility_aggregation.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/015_canonical_compatibility_aggregation.sql
@@ -1,0 +1,122 @@
+-- Aggregate compatibility evidence by the exact canonical Garmin catalog
+-- record whenever the client supplied one. Textual compatibilityIdentity is
+-- retained only as the backward-compatible key for older uncanonicalized
+-- events. This prevents formatting changes between app versions from creating
+-- duplicate rows for the same physical model variant.
+
+-- Correct the exact beta.6 payload shape observed during the owner test. The
+-- map-capable 47 mm AMOLED identity, size, VID and PID make this deterministic;
+-- 51 mm and any future Solar record cannot satisfy the predicate.
+UPDATE compatibility_evidence_event
+SET
+    compatibility_identity = 'fēnix 8 · 47 mm AMOLED',
+    display_type = 'AMOLED',
+    canonical_device_model_id = 'garmin-fenix-8-47-amoled'
+WHERE canonical_device_model_id IS NULL
+  AND model = 'fēnix 8'
+  AND compatibility_identity = 'fēnix 8 · 47 mm, AMOLED'
+  AND variant = '47 mm, AMOLED'
+  AND case_size_mm = 47
+  AND usb_vendor_id = 2334
+  AND usb_product_id = 20920;
+
+DROP VIEW compatibility_model_statistics;
+
+CREATE VIEW compatibility_model_statistics AS
+WITH event_stats AS (
+    SELECT
+        COALESCE(
+            e.canonical_device_model_id,
+            'identity:' || e.compatibility_identity
+        ) AS aggregate_key,
+        min(e.compatibility_identity) AS compatibility_identity,
+        min(e.model) AS model,
+        min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
+        min(e.case_size_mm) FILTER (WHERE e.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(e.display_type) FILTER (WHERE e.display_type IS NOT NULL AND btrim(e.display_type) <> '') AS display_type,
+        min(e.canonical_device_model_id) FILTER (WHERE e.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        string_agg(DISTINCT COALESCE(NULLIF(e.firmware_version, ''), 'unknown'), ', ' ORDER BY COALESCE(NULLIF(e.firmware_version, ''), 'unknown')) AS firmware_versions,
+        count(*) AS attempted_install_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS successful_install_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED' AND e.reconnect_verified) AS reconnect_verified_install_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed_install_count,
+        count(DISTINCT NULLIF(e.firmware_version, '')) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS firmware_version_count,
+        round(100.0 * count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') / NULLIF(count(*), 0), 1) AS success_rate,
+        max(e.occurred_at) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS last_success,
+        max(e.occurred_at) FILTER (WHERE e.phase_outcome = 'FAILED') AS last_failure,
+        max(e.occurred_at) AS last_evidence,
+        COALESCE((
+            SELECT jsonb_object_agg(COALESCE(category, 'unknown'), category_count)
+            FROM (
+                SELECT x.error_category AS category, count(*) AS category_count
+                FROM compatibility_evidence_event x
+                WHERE COALESCE(
+                    x.canonical_device_model_id,
+                    'identity:' || x.compatibility_identity
+                ) = COALESCE(
+                    e.canonical_device_model_id,
+                    'identity:' || e.compatibility_identity
+                )
+                  AND x.phase_outcome = 'FAILED'
+                GROUP BY x.error_category
+            ) category_counts
+        ), '{}'::jsonb) AS error_categories
+    FROM compatibility_evidence_event e
+    GROUP BY COALESCE(
+        e.canonical_device_model_id,
+        'identity:' || e.compatibility_identity
+    )
+)
+SELECT
+    COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
+    e.model,
+    e.variant,
+    e.case_size_mm,
+    e.display_type,
+    e.canonical_device_model_id,
+    e.firmware_versions,
+    e.attempted_install_count,
+    e.successful_install_count,
+    e.reconnect_verified_install_count,
+    e.failed_install_count,
+    e.firmware_version_count,
+    e.success_rate,
+    e.last_success,
+    e.last_failure,
+    e.last_evidence,
+    e.error_categories,
+    CASE
+        WHEN e.successful_install_count = 0 THEN 'TESTING'
+        WHEN e.successful_install_count < 3 THEN 'TESTED'
+        WHEN e.successful_install_count < 5 THEN 'SUPPORTED'
+        ELSE 'VERIFIED'
+    END AS calculated_status,
+    true AS recognized_map_capable_evidence,
+    COALESCE(r.physical_device_evidence_count, 0) AS physical_device_evidence_count,
+    COALESCE(r.review_notes, '') AS review_notes,
+    COALESCE(r.review_status, 'PENDING') AS review_status,
+    COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
+    COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
+FROM event_stats e
+LEFT JOIN LATERAL (
+    SELECT review.*
+    FROM compatibility_model_review review
+    WHERE COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity
+       OR (
+            e.canonical_device_model_id IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM compatibility_evidence_event linked_event
+                WHERE linked_event.canonical_device_model_id = e.canonical_device_model_id
+                  AND linked_event.compatibility_identity = COALESCE(
+                      NULLIF(review.identity_key, ''),
+                      review.model
+                  )
+            )
+       )
+    ORDER BY
+        (COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity) DESC,
+        (review.review_status = 'APPROVED') DESC,
+        review.updated_at DESC
+    LIMIT 1
+) r ON true;

--- a/backend/catalog-api/src/terento_catalog/migrations/015_canonical_compatibility_aggregation.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/015_canonical_compatibility_aggregation.sql
@@ -23,12 +23,18 @@ WHERE canonical_device_model_id IS NULL
 DROP VIEW compatibility_model_statistics;
 
 CREATE VIEW compatibility_model_statistics AS
-WITH event_stats AS (
+WITH normalized_events AS (
     SELECT
+        e.*,
         COALESCE(
             e.canonical_device_model_id,
             'identity:' || e.compatibility_identity
-        ) AS aggregate_key,
+        ) AS aggregate_key
+    FROM compatibility_evidence_event e
+),
+event_stats AS (
+    SELECT
+        e.aggregate_key,
         min(e.compatibility_identity) AS compatibility_identity,
         min(e.model) AS model,
         min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
@@ -44,28 +50,27 @@ WITH event_stats AS (
         round(100.0 * count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') / NULLIF(count(*), 0), 1) AS success_rate,
         max(e.occurred_at) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS last_success,
         max(e.occurred_at) FILTER (WHERE e.phase_outcome = 'FAILED') AS last_failure,
-        max(e.occurred_at) AS last_evidence,
-        COALESCE((
-            SELECT jsonb_object_agg(COALESCE(category, 'unknown'), category_count)
-            FROM (
-                SELECT x.error_category AS category, count(*) AS category_count
-                FROM compatibility_evidence_event x
-                WHERE COALESCE(
-                    x.canonical_device_model_id,
-                    'identity:' || x.compatibility_identity
-                ) = COALESCE(
-                    e.canonical_device_model_id,
-                    'identity:' || e.compatibility_identity
-                )
-                  AND x.phase_outcome = 'FAILED'
-                GROUP BY x.error_category
-            ) category_counts
-        ), '{}'::jsonb) AS error_categories
-    FROM compatibility_evidence_event e
-    GROUP BY COALESCE(
-        e.canonical_device_model_id,
-        'identity:' || e.compatibility_identity
-    )
+        max(e.occurred_at) AS last_evidence
+    FROM normalized_events e
+    GROUP BY e.aggregate_key
+),
+error_stats AS (
+    SELECT
+        category_counts.aggregate_key,
+        jsonb_object_agg(
+            COALESCE(category_counts.error_category, 'unknown'),
+            category_counts.category_count
+        ) AS error_categories
+    FROM (
+        SELECT
+            e.aggregate_key,
+            e.error_category,
+            count(*) AS category_count
+        FROM normalized_events e
+        WHERE e.phase_outcome = 'FAILED'
+        GROUP BY e.aggregate_key, e.error_category
+    ) category_counts
+    GROUP BY category_counts.aggregate_key
 )
 SELECT
     COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
@@ -84,7 +89,7 @@ SELECT
     e.last_success,
     e.last_failure,
     e.last_evidence,
-    e.error_categories,
+    COALESCE(errors.error_categories, '{}'::jsonb) AS error_categories,
     CASE
         WHEN e.successful_install_count = 0 THEN 'TESTING'
         WHEN e.successful_install_count < 3 THEN 'TESTED'
@@ -98,6 +103,8 @@ SELECT
     COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
     COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
 FROM event_stats e
+LEFT JOIN error_stats errors
+    ON errors.aggregate_key = e.aggregate_key
 LEFT JOIN LATERAL (
     SELECT review.*
     FROM compatibility_model_review review

--- a/backend/catalog-api/src/terento_catalog/migrations/016_historical_device_registry.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/016_historical_device_registry.sql
@@ -1,0 +1,60 @@
+-- Reviewed historical device identities are additive records.  They are not
+-- collector-owned retail inventory and therefore are never deactivated by a
+-- current Garmin retail collection.
+ALTER TABLE device_model
+    ADD COLUMN IF NOT EXISTS record_source TEXT NOT NULL DEFAULT 'CURRENT_RETAIL',
+    ADD COLUMN IF NOT EXISTS collector_managed BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE device_model
+    ADD CONSTRAINT device_model_record_source_check
+    CHECK (record_source IN ('CURRENT_RETAIL', 'HISTORICAL_REVIEWED', 'EVIDENCE_DISCOVERED'));
+
+CREATE INDEX device_model_record_source_idx
+    ON device_model(record_source, active);
+
+CREATE INDEX device_model_collector_managed_idx
+    ON device_model(collector_managed, active);
+
+INSERT INTO device_family (id, manufacturer, name, canonical_name, source_url)
+VALUES
+    ('garmin-fenix', 'Garmin', 'fēnix', 'fenix', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-epix', 'Garmin', 'epix', 'epix', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-forerunner', 'Garmin', 'Forerunner', 'forerunner', 'https://developer.garmin.com/connect-iq/compatible-devices/')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO device_model (
+    id, family_id, manufacturer, model, canonical_model, variant,
+    case_size_mm, display_type, product_url, source_url,
+    source_image_url, active, map_capable, support_status,
+    record_source, collector_managed
+)
+VALUES
+    ('garmin-fenix-7-47', 'garmin-fenix', 'Garmin', 'fēnix 7', 'fenix 7', '47 mm', 47, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-7s-42', 'garmin-fenix', 'Garmin', 'fēnix 7S', 'fenix 7s', '42 mm', 42, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-7x-51', 'garmin-fenix', 'Garmin', 'fēnix 7X', 'fenix 7x', '51 mm', 51, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-6-47', 'garmin-fenix', 'Garmin', 'fēnix 6', 'fenix 6', '47 mm', 47, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-6s-42', 'garmin-fenix', 'Garmin', 'fēnix 6S', 'fenix 6s', '42 mm', 42, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-6x-51', 'garmin-fenix', 'Garmin', 'fēnix 6X', 'fenix 6x', '51 mm', 51, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-epix-gen-2-47', 'garmin-epix', 'Garmin', 'epix (Gen 2)', 'epix gen 2', '47 mm', 47, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-forerunner-955', 'garmin-forerunner', 'Garmin', 'Forerunner 955', 'forerunner 955', 'Standard', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE)
+ON CONFLICT (id) DO NOTHING;
+
+-- A historical record is intentionally not made write-capable by this seed.
+-- map_capable means only that the native Map Manager registry recognizes the
+-- family; device writes still require the native write profile and safety gate.

--- a/backend/catalog-api/src/terento_catalog/migrations/017_structured_installation_diagnostics.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/017_structured_installation_diagnostics.sql
@@ -1,0 +1,149 @@
+ALTER TABLE compatibility_evidence_event
+    DROP CONSTRAINT compatibility_evidence_event_phase_outcome_check;
+
+ALTER TABLE compatibility_evidence_event
+    ADD CONSTRAINT compatibility_evidence_event_phase_outcome_check
+        CHECK (phase_outcome IN ('SUCCEEDED', 'FAILED', 'NOT_STARTED')),
+    ADD COLUMN operation_id UUID,
+    ADD COLUMN map_result_index INTEGER CHECK (map_result_index IS NULL OR map_result_index >= 0),
+    ADD COLUMN selected_map_count INTEGER CHECK (selected_map_count IS NULL OR selected_map_count > 0),
+    ADD COLUMN app_build TEXT,
+    ADD COLUMN release_label TEXT,
+    ADD COLUMN failure_stage TEXT CHECK (failure_stage IS NULL OR failure_stage IN (
+        'download', 'extract', 'source-validation', 'preflight', 'write', 'verify', 'cleanup', 'manifest'
+    )),
+    ADD COLUMN failure_code TEXT,
+    ADD COLUMN native_failure_code TEXT,
+    ADD COLUMN write_started BOOLEAN,
+    ADD COLUMN remote_object_created BOOLEAN,
+    ADD COLUMN cleanup_attempted BOOLEAN,
+    ADD COLUMN cleanup_succeeded BOOLEAN,
+    ADD COLUMN transfer_progress_bucket TEXT CHECK (
+        transfer_progress_bucket IS NULL OR transfer_progress_bucket IN ('0', '1-24', '25-99', '100')
+    );
+
+CREATE INDEX compatibility_evidence_operation_idx
+    ON compatibility_evidence_event(operation_id)
+    WHERE operation_id IS NOT NULL;
+
+DROP VIEW compatibility_model_statistics;
+
+CREATE VIEW compatibility_model_statistics AS
+WITH normalized_events AS (
+    SELECT
+        e.*,
+        COALESCE(e.canonical_device_model_id, 'identity:' || e.compatibility_identity) AS aggregate_key,
+        COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text) AS operation_key,
+        COALESCE(e.write_started, true) AS compatibility_write_started
+    FROM compatibility_evidence_event e
+),
+operation_stats AS (
+    SELECT
+        e.aggregate_key,
+        e.operation_key,
+        min(e.compatibility_identity) AS compatibility_identity,
+        min(e.model) AS model,
+        min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
+        min(e.case_size_mm) FILTER (WHERE e.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(e.display_type) FILTER (WHERE e.display_type IS NOT NULL AND btrim(e.display_type) <> '') AS display_type,
+        min(e.canonical_device_model_id) FILTER (WHERE e.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        bool_or(e.compatibility_write_started) AS write_started,
+        bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED')
+            AND count(*) = max(COALESCE(e.selected_map_count, 1)) AS operation_succeeded,
+        bool_or(e.reconnect_verified) AS reconnect_verified,
+        min(NULLIF(e.firmware_version, '')) AS successful_firmware_version,
+        min(e.occurred_at) AS occurred_at,
+        count(*) AS map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS successful_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'NOT_STARTED') AS not_started_map_result_count
+    FROM normalized_events e
+    GROUP BY e.aggregate_key, e.operation_key
+),
+event_stats AS (
+    SELECT
+        o.aggregate_key,
+        min(o.compatibility_identity) AS compatibility_identity,
+        min(o.model) AS model,
+        min(o.variant) FILTER (WHERE o.variant IS NOT NULL) AS variant,
+        min(o.case_size_mm) FILTER (WHERE o.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(o.display_type) FILTER (WHERE o.display_type IS NOT NULL) AS display_type,
+        min(o.canonical_device_model_id) FILTER (WHERE o.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        string_agg(DISTINCT COALESCE(o.successful_firmware_version, 'unknown'), ', ' ORDER BY COALESCE(o.successful_firmware_version, 'unknown')) AS firmware_versions,
+        count(*) FILTER (WHERE o.write_started) AS attempted_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded) AS successful_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded AND o.reconnect_verified) AS reconnect_verified_install_count,
+        count(*) FILTER (WHERE o.write_started AND NOT o.operation_succeeded) AS failed_install_count,
+        count(DISTINCT o.successful_firmware_version) FILTER (WHERE o.write_started AND o.operation_succeeded) AS firmware_version_count,
+        round(100.0 * count(*) FILTER (WHERE o.write_started AND o.operation_succeeded)
+            / NULLIF(count(*) FILTER (WHERE o.write_started), 0), 1) AS success_rate,
+        max(o.occurred_at) FILTER (WHERE o.write_started AND o.operation_succeeded) AS last_success,
+        max(o.occurred_at) FILTER (WHERE NOT o.operation_succeeded) AS last_failure,
+        max(o.occurred_at) AS last_evidence,
+        sum(o.map_result_count) AS map_result_count,
+        sum(o.successful_map_result_count) AS successful_map_result_count,
+        sum(o.failed_map_result_count) AS failed_map_result_count,
+        sum(o.not_started_map_result_count) AS not_started_map_result_count,
+        count(*) FILTER (WHERE NOT o.write_started) AS prewrite_failure_count
+    FROM operation_stats o
+    GROUP BY o.aggregate_key
+),
+error_stats AS (
+    SELECT
+        e.aggregate_key,
+        jsonb_object_agg(e.error_key, e.error_count) AS error_categories
+    FROM (
+        SELECT
+            n.aggregate_key,
+            COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown') AS error_key,
+            count(*) AS error_count
+        FROM normalized_events n
+        WHERE n.phase_outcome = 'FAILED'
+        GROUP BY n.aggregate_key, COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown')
+    ) e
+    GROUP BY e.aggregate_key
+)
+SELECT
+    COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
+    e.model, e.variant, e.case_size_mm, e.display_type, e.canonical_device_model_id,
+    e.firmware_versions, e.attempted_install_count, e.successful_install_count,
+    e.reconnect_verified_install_count, e.failed_install_count, e.firmware_version_count,
+    e.success_rate, e.last_success, e.last_failure, e.last_evidence,
+    e.map_result_count, e.successful_map_result_count, e.failed_map_result_count,
+    e.not_started_map_result_count, e.prewrite_failure_count,
+    COALESCE(errors.error_categories, '{}'::jsonb) AS error_categories,
+    CASE
+        WHEN e.successful_install_count = 0 THEN 'TESTING'
+        WHEN e.successful_install_count < 3 THEN 'TESTED'
+        WHEN e.successful_install_count < 5 THEN 'SUPPORTED'
+        ELSE 'VERIFIED'
+    END AS calculated_status,
+    true AS recognized_map_capable_evidence,
+    COALESCE(r.physical_device_evidence_count, 0) AS physical_device_evidence_count,
+    COALESCE(r.review_notes, '') AS review_notes,
+    COALESCE(r.review_status, 'PENDING') AS review_status,
+    COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
+    COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
+FROM event_stats e
+LEFT JOIN error_stats errors ON errors.aggregate_key = e.aggregate_key
+LEFT JOIN LATERAL (
+    SELECT review.*
+    FROM compatibility_model_review review
+    WHERE COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity
+       OR (
+            e.canonical_device_model_id IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM compatibility_evidence_event linked_event
+                WHERE linked_event.canonical_device_model_id = e.canonical_device_model_id
+                  AND linked_event.compatibility_identity = COALESCE(
+                      NULLIF(review.identity_key, ''), review.model
+                  )
+            )
+       )
+    ORDER BY
+        (COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity) DESC,
+        (review.review_status = 'APPROVED') DESC,
+        review.updated_at DESC
+    LIMIT 1
+) r ON true;

--- a/backend/catalog-api/tests/test_admin_devices.py
+++ b/backend/catalog-api/tests/test_admin_devices.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from terento_catalog.admin import _admin_device_payload, devices_page
+
+
+UTC = timezone.utc
+
+
+def device_row(**changes):
+    row = {
+        "device_id": "garmin-fenix-8-47-amoled",
+        "manufacturer": "Garmin",
+        "family_canonical_name": "fenix",
+        "family_name": "fēnix",
+        "model": "fēnix 8",
+        "canonical_model": "fenix 8",
+        "variant": "47 mm, AMOLED",
+        "case_size_mm": 47,
+        "display_type": "AMOLED",
+        "part_number": "010-02904-10",
+        "product_url": "https://www.garmin.com/en-US/p/1228429/",
+        "active": True,
+        "map_capable": True,
+        "support_status": "SUPPORTED",
+        "asset_status": "MISSING",
+        "asset_url": None,
+        "source_image_url": None,
+        "attempted_install_count": 3,
+        "successful_install_count": 2,
+        "failed_install_count": 1,
+        "first_success": datetime(2026, 8, 20, tzinfo=UTC),
+        "last_success": datetime(2026, 8, 25, tzinfo=UTC),
+        "last_evidence": datetime(2026, 8, 25, tzinfo=UTC),
+        "first_seen_at": datetime(2026, 8, 19, tzinfo=UTC),
+        "created_at": datetime(2026, 8, 19, tzinfo=UTC),
+        "updated_at": datetime(2026, 8, 25, tzinfo=UTC),
+        "last_seen_at": datetime(2026, 8, 25, tzinfo=UTC),
+        "first_seen_collection_run_id": 7,
+        "last_seen_collection_run_id": 7,
+        "usb_identities": [{"vendorId": 2334, "productId": 20920}],
+    }
+    row.update(changes)
+    return row
+
+
+class AdminDevicesTests(unittest.TestCase):
+    def test_summary_counts_use_independent_capability_support_and_evidence(self):
+        payload = _admin_device_payload(
+            [
+                device_row(),
+                device_row(
+                    device_id="garmin-venu-3",
+                    model="Venu 3",
+                    canonical_model="venu 3",
+                    variant="",
+                    case_size_mm=None,
+                    display_type=None,
+                    part_number=None,
+                    map_capable=False,
+                    support_status="NOT_EVALUATED",
+                    attempted_install_count=0,
+                    successful_install_count=0,
+                    failed_install_count=0,
+                    first_success=None,
+                    last_success=None,
+                    last_evidence=None,
+                    first_seen_collection_run_id=None,
+                    last_seen_collection_run_id=7,
+                ),
+                device_row(
+                    device_id="garmin-new-watch",
+                    model="New watch",
+                    canonical_model="new watch",
+                    variant=None,
+                    case_size_mm=None,
+                    display_type=None,
+                    map_capable=None,
+                    support_status="UNSUPPORTED",
+                    attempted_install_count=1,
+                    successful_install_count=0,
+                    failed_install_count=1,
+                    first_success=None,
+                    last_success=None,
+                    last_evidence=datetime(2026, 8, 26, tzinfo=UTC),
+                    first_seen_collection_run_id=7,
+                ),
+            ],
+            {
+                "id": 7,
+                "status": "SUCCEEDED",
+                "started_at": datetime(2026, 8, 26, tzinfo=UTC),
+                "finished_at": datetime(2026, 8, 26, 1, tzinfo=UTC),
+                "records_total_before": 2,
+                "records_total_after": 3,
+                "records_added": 1,
+                "records_updated": 1,
+            },
+        )
+
+        self.assertEqual(
+            payload["summary"],
+            {
+                "models": 3,
+                "mapCapable": 1,
+                "supported": 1,
+                "tested": 1,
+                "installAttempts": 4,
+                "successfulInstalls": 2,
+                "successRate": 50.0,
+                "newThisSync": 1,
+            },
+        )
+        self.assertEqual(payload["devices"][0]["installationStats"]["successRate"], 66.7)
+        self.assertTrue(payload["devices"][2]["catalog"]["newInLatestSync"])
+        self.assertIsNone(payload["devices"][1]["installationStats"]["lastSuccessfulAt"])
+        self.assertFalse(payload["devices"][1]["mapCapable"])
+        self.assertEqual(payload["devices"][1]["image"]["origin"], "missing")
+
+    def test_null_map_capable_is_classified_from_the_native_prefix_list(self) -> None:
+        payload = _admin_device_payload(
+            [
+                device_row(map_capable=None),
+                device_row(
+                    device_id="garmin-fenix-7-47",
+                    model="fēnix 7",
+                    canonical_model="fenix 7",
+                    variant="47 mm",
+                    map_capable=None,
+                    support_status="NOT_EVALUATED",
+                    attempted_install_count=0,
+                    successful_install_count=0,
+                    failed_install_count=0,
+                    first_success=None,
+                    last_success=None,
+                    last_evidence=None,
+                ),
+                device_row(
+                    device_id="garmin-unknown-watch",
+                    model="Future Watch",
+                    canonical_model="future watch",
+                    map_capable=None,
+                    support_status="NOT_EVALUATED",
+                    attempted_install_count=0,
+                    successful_install_count=0,
+                    failed_install_count=0,
+                    first_success=None,
+                    last_success=None,
+                    last_evidence=None,
+                ),
+            ],
+            None,
+        )
+        self.assertTrue(payload["devices"][0]["mapCapable"])
+        self.assertTrue(payload["devices"][1]["mapCapable"])
+        self.assertIsNone(payload["devices"][2]["mapCapable"])
+        self.assertEqual(payload["summary"]["mapCapable"], 2)
+
+    def test_fenix_8_51mm_has_independent_tested_evidence_status(self) -> None:
+        payload = _admin_device_payload(
+            [device_row(
+                device_id="garmin-fenix-8-51-amoled",
+                variant="51 mm, AMOLED",
+                case_size_mm=51,
+                support_status="NOT_EVALUATED",
+                successful_install_count=1,
+                attempted_install_count=1,
+                failed_install_count=0,
+            )],
+            None,
+        )
+        device = payload["devices"][0]
+        self.assertEqual(device["supportStatus"], "NOT_EVALUATED")
+        self.assertEqual(device["evidenceStatus"], "TESTED")
+        self.assertEqual(device["installationStats"]["successful"], 1)
+
+    def test_garmin_source_image_is_used_when_controlled_asset_is_missing(self) -> None:
+        source = "https://res.garmin.com/en/products/010-02905-10/v/cf-lg.jpg"
+        payload = _admin_device_payload(
+            [
+                device_row(
+                    asset_status="MISSING",
+                    asset_url=None,
+                    source_image_url=source,
+                )
+            ],
+            None,
+        )
+        self.assertEqual(payload["devices"][0]["asset"]["status"], "MISSING")
+        self.assertEqual(payload["devices"][0]["sourceAsset"]["url"], source)
+        self.assertEqual(payload["devices"][0]["image"]["origin"], "garmin-source")
+        self.assertEqual(payload["devices"][0]["image"]["url"], source)
+        body = devices_page(
+            [device_row(asset_status="MISSING", asset_url=None, source_image_url=source)],
+            None,
+            {"username": "operator"},
+            "csrf",
+        ).decode()
+        self.assertIn(source, body)
+        self.assertIn("device-thumb", body)
+
+    def test_controlled_asset_wins_over_garmin_source_image(self) -> None:
+        payload = _admin_device_payload(
+            [
+                device_row(
+                    asset_status="AVAILABLE",
+                    asset_url="https://api.terento.app/assets/devices/garmin/fenix-8-47-amoled.webp",
+                    source_image_url="https://res.garmin.com/en/products/010-02904-10/g/cf-lg.jpg",
+                )
+            ],
+            None,
+        )
+        self.assertEqual(payload["devices"][0]["image"]["origin"], "controlled")
+        self.assertTrue(
+            payload["devices"][0]["image"]["url"].startswith(
+                "https://api.terento.app/assets/devices/"
+            )
+        )
+
+    def test_historical_sync_without_counts_is_not_presented_as_zero(self):
+        payload = _admin_device_payload(
+            [device_row(first_seen_collection_run_id=None)],
+            {
+                "id": 3,
+                "status": "SUCCEEDED",
+                "started_at": datetime(2026, 8, 1, tzinfo=UTC),
+                "finished_at": datetime(2026, 8, 1, 1, tzinfo=UTC),
+                "records_total_before": None,
+                "records_total_after": None,
+                "records_added": None,
+                "records_updated": None,
+            },
+        )
+
+        self.assertIsNone(payload["summary"]["newThisSync"])
+        self.assertIsNone(payload["sync"]["recordsAdded"])
+        body = devices_page(
+            [device_row(first_seen_collection_run_id=None)],
+            {
+                "id": 3,
+                "status": "SUCCEEDED",
+                "started_at": datetime(2026, 8, 1, tzinfo=UTC),
+                "finished_at": datetime(2026, 8, 1, 1, tzinfo=UTC),
+                "records_total_before": None,
+                "records_total_after": None,
+                "records_added": None,
+                "records_updated": None,
+            },
+            {"username": "operator"},
+            "csrf",
+        ).decode()
+        self.assertIn("counts unavailable for this historical run", body)
+
+    def test_page_has_required_filters_modal_and_neutral_image_fallback(self):
+        body = devices_page(
+            [device_row()],
+            None,
+            {"username": "operator"},
+            "csrf",
+        ).decode()
+        for value in (
+            "Garmin devices", "Map-capable: Yes", "Map-capable: No",
+            "Map-capable: Unknown", "Supported", "Unsupported", "Not evaluated",
+            "Tested: Yes", "Tested: No", "Newest in database", "Most installs",
+            "Last tested", "Support decision", "Evidence status", "device-dialog", "device-thumb-placeholder", "admin-timezone",
+            "Automatic (browser)", "data-admin-timestamp", "TerentoAdminTime",
+            "selected time zone",
+        ):
+            self.assertIn(value, body)
+        self.assertNotIn("src='None'", body)
+        self.assertIn("does not change Evidence status or installation counts", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/catalog-api/tests/test_compatibility_aggregation.py
+++ b/backend/catalog-api/tests/test_compatibility_aggregation.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+import unittest
+
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "terento_catalog"
+    / "migrations"
+    / "015_canonical_compatibility_aggregation.sql"
+)
+
+
+class CompatibilityAggregationMigrationTests(unittest.TestCase):
+    def test_canonical_device_is_primary_aggregate_key(self) -> None:
+        sql = MIGRATION.read_text(encoding="utf-8")
+        canonical_key = (
+            "COALESCE(\n"
+            "        e.canonical_device_model_id,\n"
+            "        'identity:' || e.compatibility_identity\n"
+            "    )"
+        )
+        self.assertIn(canonical_key, sql)
+        self.assertIn("GROUP BY COALESCE(", sql)
+        self.assertNotIn("GROUP BY e.compatibility_identity", sql)
+
+    def test_counts_and_status_are_calculated_after_canonical_grouping(self) -> None:
+        sql = MIGRATION.read_text(encoding="utf-8")
+        group_position = sql.index("GROUP BY COALESCE(")
+        status_position = sql.index("WHEN e.successful_install_count = 0")
+        self.assertLess(group_position, status_position)
+        self.assertIn("count(*) AS attempted_install_count", sql)
+        self.assertIn("WHEN e.successful_install_count < 3 THEN 'TESTED'", sql)
+        self.assertIn("WHEN e.successful_install_count < 5 THEN 'SUPPORTED'", sql)
+        self.assertIn("WHEN e.successful_install_count = 0 THEN 'TESTING'", sql)
+        self.assertIn("ELSE 'VERIFIED'", sql)
+
+    def test_runtime_and_database_status_rules_are_not_support_decisions(self) -> None:
+        sql = MIGRATION.read_text(encoding="utf-8")
+        self.assertNotIn("support_status", sql)
+        self.assertIn("calculated_status", sql)
+
+    def test_observed_beta6_47mm_identity_is_corrected_without_touching_siblings(self) -> None:
+        sql = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("compatibility_identity = 'fēnix 8 · 47 mm, AMOLED'", sql)
+        self.assertIn("canonical_device_model_id = 'garmin-fenix-8-47-amoled'", sql)
+        self.assertIn("case_size_mm = 47", sql)
+        self.assertIn("usb_product_id = 20920", sql)
+        self.assertNotIn("garmin-fenix-8-51-amoled'\nWHERE", sql)
+
+    def test_dashboard_result_count_describes_aggregate_rows_as_models(self) -> None:
+        admin_source = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "terento_catalog"
+            / "admin.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("visible.length === 1 ? 'model' : 'models'", admin_source)
+        self.assertNotIn("visible.length === 1 ? 'report' : 'reports'", admin_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/catalog-api/tests/test_compatibility_aggregation.py
+++ b/backend/catalog-api/tests/test_compatibility_aggregation.py
@@ -16,22 +16,29 @@ class CompatibilityAggregationMigrationTests(unittest.TestCase):
         sql = MIGRATION.read_text(encoding="utf-8")
         canonical_key = (
             "COALESCE(\n"
-            "        e.canonical_device_model_id,\n"
-            "        'identity:' || e.compatibility_identity\n"
-            "    )"
+            "            e.canonical_device_model_id,\n"
+            "            'identity:' || e.compatibility_identity\n"
+            "        ) AS aggregate_key"
         )
         self.assertIn(canonical_key, sql)
-        self.assertIn("GROUP BY COALESCE(", sql)
+        self.assertIn("GROUP BY e.aggregate_key", sql)
         self.assertNotIn("GROUP BY e.compatibility_identity", sql)
 
     def test_counts_and_status_are_calculated_after_canonical_grouping(self) -> None:
         sql = MIGRATION.read_text(encoding="utf-8")
-        group_position = sql.index("GROUP BY COALESCE(")
+        group_position = sql.index("GROUP BY e.aggregate_key")
         status_position = sql.index("WHEN e.successful_install_count = 0")
         self.assertLess(group_position, status_position)
         self.assertIn("count(*) AS attempted_install_count", sql)
         self.assertIn("WHEN e.successful_install_count < 3 THEN 'TESTED'", sql)
         self.assertIn("WHEN e.successful_install_count < 5 THEN 'SUPPORTED'", sql)
+
+    def test_error_categories_use_the_same_materialized_aggregate_key(self) -> None:
+        sql = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("error_stats AS (", sql)
+        self.assertIn("GROUP BY e.aggregate_key, e.error_category", sql)
+        self.assertIn("ON errors.aggregate_key = e.aggregate_key", sql)
+        self.assertNotIn("subquery uses ungrouped column", sql)
         self.assertIn("WHEN e.successful_install_count = 0 THEN 'TESTING'", sql)
         self.assertIn("ELSE 'VERIFIED'", sql)
 

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -45,6 +45,7 @@ class FakeEvidenceDatabase:
         self.events = {}
         self.users = []
         self.sessions = {}
+        self.device_support_status = "SUPPORTED"
 
     def insert_compatibility_event(self, value):
         if value["id"] in self.events:
@@ -70,6 +71,9 @@ class FakeEvidenceDatabase:
             "calculated_status": "TESTED", "physical_device_evidence_count": 1,
             "review_notes": "Owner evidence",
         }]
+
+    def compatibility_operation_details(self):
+        return []
 
     def public_compatibility_statistics(self, limit):
         return [{
@@ -123,7 +127,7 @@ class FakeEvidenceDatabase:
             "product_url": "https://www.garmin.com/en-US/p/1228429/",
             "active": True,
             "map_capable": True,
-            "support_status": "SUPPORTED",
+            "support_status": self.device_support_status,
             "asset_status": "MISSING",
             "asset_url": None,
             "attempted_install_count": 1,
@@ -176,6 +180,12 @@ class FakeEvidenceDatabase:
         user = next(user for user in self.users if user["id"] == user_id)
         user.update(username=username, password_hash=password_hash)
         return user
+
+    def update_device_support_status(self, device_id, support_status):
+        if device_id != "garmin-fenix-8-47-amoled":
+            return False
+        self.device_support_status = support_status
+        return True
 
 
 class CaptureDatabase(Database):
@@ -258,6 +268,20 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertIsNone(database.parameters["canonicalDeviceId"])
         self.assertEqual(len(database.parameters["deletionTokenHash"]), 64)
 
+    def test_historical_fenix_7_evidence_is_canonicalized_without_retail_row(self):
+        database = CaptureDatabase()
+        payload = event(
+            model="fēnix 7",
+            compatibilityIdentity="fēnix 7 · 47 mm",
+            variant="47 mm",
+            caseSizeMm=47,
+        )
+        self.assertTrue(database.insert_compatibility_event(payload))
+        self.assertEqual(
+            database.parameters["canonicalDeviceId"],
+            "garmin-fenix-7-47",
+        )
+
     def test_admin_dashboard_uses_compact_english_evidence_layout(self):
         row = {
             "model": "fēnix 8",
@@ -279,7 +303,7 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         }
         body = dashboard_page([row], {"username": "gediminas"}, "csrf", public_stats_enabled=True).decode()
         self.assertIn("Installation evidence", body)
-        self.assertIn(">Reports<", body)
+        self.assertIn(">Write attempts<", body)
         self.assertIn(">51 mm<", body)
         self.assertIn("Latest activity", body)
         self.assertIn("Public compatibility", body)
@@ -306,6 +330,34 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertIn("Sign in", login_page().decode())
         self.assertIn("Create the first admin account", setup_page().decode())
 
+    def test_admin_dashboard_links_errors_to_structured_operation_details(self):
+        row = {
+            "model": "fēnix 8", "compatibility_identity": "fēnix 8 · 51 mm AMOLED",
+            "variant": "51 mm, AMOLED", "firmware_versions": "2326",
+            "attempted_install_count": 1, "successful_install_count": 0,
+            "failed_install_count": 1, "success_rate": 0,
+            "calculated_status": "TESTING", "last_success": None,
+            "last_failure": datetime(2026, 8, 26, 8, 30, tzinfo=timezone.utc),
+            "error_categories": {"write:INSTALL_FAILED_WRITE": 1},
+        }
+        operation = {
+            "operation_key": "223e4567-e89b-12d3-a456-426614174000",
+            "occurred_at": row["last_failure"], "compatibility_identity": row["compatibility_identity"],
+            "firmware_version": "2326", "region": "LTU", "phase_outcome": "FAILED",
+            "release_label": "1.0.0-beta.6", "app_build": "5", "write_started": True,
+            "failure_stage": "write", "failure_code": "INSTALL_FAILED_WRITE",
+            "native_failure_code": "SEND_OBJECT_FAILED", "transfer_progress_bucket": "25-99",
+            "map_result_index": 0,
+        }
+        body = dashboard_page(
+            [row], {"username": "operator"}, "csrf", operations=[operation]
+        ).decode()
+        self.assertIn("aria-label='View 1 errors'", body)
+        self.assertIn("Operation diagnostics", body)
+        self.assertIn("1.0.0-beta.6 (build 5)", body)
+        self.assertIn("INSTALL_FAILED_WRITE", body)
+        self.assertIn("SEND_OBJECT_FAILED", body)
+
     def test_schema_v2_keeps_exact_variant_and_treats_reconnect_as_optional(self):
         payload = event(
             schemaVersion=2,
@@ -329,6 +381,41 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertFalse(database.parameters["mapVisibleAfterReconnect"])
         self.assertEqual(database.parameters["displayType"], "AMOLED")
         self.assertEqual(database.parameters["canonicalDeviceId"], "garmin-fenix-8-51-amoled")
+
+    def test_schema_v3_accepts_structured_diagnostics_and_rejects_raw_or_inconsistent_data(self):
+        payload = event(
+            schemaVersion=3,
+            phaseOutcome="FAILED",
+            automaticFinishingResult="FAILED",
+            operationId="223e4567-e89b-12d3-a456-426614174000",
+            mapResultIndex=0,
+            selectedMapCount=3,
+            appBuild="5",
+            releaseLabel="1.0.0-beta.6",
+            failureStage="write",
+            failureCode="INSTALL_FAILED_WRITE",
+            nativeFailureCode="SEND_OBJECT_FAILED",
+            writeStarted=True,
+            remoteObjectCreated=False,
+            cleanupAttempted=False,
+            cleanupSucceeded=False,
+            transferProgressBucket="25-99",
+        )
+        validated = validate_event(json.dumps(payload).encode())
+        self.assertEqual(validated["operationId"], payload["operationId"])
+        database = CaptureDatabase()
+        self.assertTrue(database.insert_compatibility_event(validated))
+        self.assertEqual(database.parameters["appBuild"], "5")
+        self.assertEqual(database.parameters["failureStage"], "write")
+
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "nativeFailureCode": "RAW: libmtp failed /Users/me"}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "releaseLabel": "file:///Users/me/build"}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "writeStarted": False, "remoteObjectCreated": True}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "phaseOutcome": "NOT_STARTED", "writeStarted": True}).encode())
 
     def test_privacy_fields_and_local_paths_are_rejected(self):
         without_deletion_token = event()
@@ -388,6 +475,17 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(devices_json.status, 200)
         self.assertEqual(json.loads(devices_json_body)["summary"]["tested"], 1)
 
+        review_body = urlencode({
+            "csrf_token": csrf_token,
+            "device_id": "garmin-fenix-8-47-amoled",
+            "support_status": "SUPPORTED",
+        })
+        reviewed, _ = self.request("POST", "/admin/devices/support", review_body, {
+            "Content-Type": "application/x-www-form-urlencoded", "Cookie": cookie_header,
+        })
+        self.assertEqual(reviewed.status, 303)
+        self.assertEqual(self.database.device_support_status, "SUPPORTED")
+
         unauthenticated_campaign, _ = self.request("GET", "/admin/campaign-links")
         self.assertEqual(unauthenticated_campaign.status, 303)
         self.assertEqual(unauthenticated_campaign.headers["Location"], "/admin/login")
@@ -444,6 +542,17 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(document["models"][0]["successfulInstallations"], 3)
         self.assertEqual(document["models"][0]["mapCapable"], True)
         self.assertNotIn("firmwareVersion", document["models"][0])
+        self.assertEqual(
+            set(document["models"][0]),
+            {
+                "model", "canonicalModel", "compatibilityIdentity", "variant",
+                "caseSizeMm", "displayType", "canonicalDeviceId",
+                "attemptedInstallations", "successfulInstallations",
+                "reconnectVerifiedInstallations", "failedInstallations",
+                "successRate", "evidenceStatus", "lastSuccessfulInstallation",
+                "lastEvidence", "mapCapable",
+            },
+        )
 
     def test_public_models_is_additive_and_evidence_only(self):
         response, body = self.request("GET", "/compatibility/public/models.json?limit=5")

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -94,6 +94,62 @@ class FakeEvidenceDatabase:
             "last_evidence": datetime(2026, 8, 25, tzinfo=timezone.utc),
         }][:limit]
 
+    def public_compatibility_models(self, limit):
+        rows = self.public_compatibility_statistics(limit)
+        for row in rows:
+            row.update({
+                "evidence_model": row["canonical_model"],
+                "family": "fenix",
+                "family_name": "fēnix",
+                "canonical_model": "fenix 8",
+                "asset_status": "MISSING",
+                "asset_url": None,
+                "source_image_url": None,
+            })
+        return rows
+
+    def admin_device_snapshot(self):
+        return [{
+            "device_id": "garmin-fenix-8-47-amoled",
+            "manufacturer": "Garmin",
+            "family_canonical_name": "fenix",
+            "family_name": "fēnix",
+            "model": "fēnix 8",
+            "canonical_model": "fenix 8",
+            "variant": "47 mm, AMOLED",
+            "case_size_mm": 47,
+            "display_type": "AMOLED",
+            "part_number": "010-02904-10",
+            "product_url": "https://www.garmin.com/en-US/p/1228429/",
+            "active": True,
+            "map_capable": True,
+            "support_status": "SUPPORTED",
+            "asset_status": "MISSING",
+            "asset_url": None,
+            "attempted_install_count": 1,
+            "successful_install_count": 1,
+            "failed_install_count": 0,
+            "first_success": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "last_success": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "last_evidence": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "first_seen_at": datetime(2026, 8, 20, tzinfo=timezone.utc),
+            "created_at": datetime(2026, 8, 20, tzinfo=timezone.utc),
+            "updated_at": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "last_seen_at": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "first_seen_collection_run_id": 1,
+            "last_seen_collection_run_id": 1,
+            "usb_identities": [],
+        }], {
+            "id": 1,
+            "status": "SUCCEEDED",
+            "started_at": datetime(2026, 8, 25, tzinfo=timezone.utc),
+            "finished_at": datetime(2026, 8, 25, 1, tzinfo=timezone.utc),
+            "records_total_before": 0,
+            "records_total_after": 1,
+            "records_added": 1,
+            "records_updated": 0,
+        }
+
     def admin_user_count(self):
         return len(self.users)
 
@@ -235,6 +291,9 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertNotIn("Logged in as", body)
         self.assertNotIn("Attempts", body)
         self.assertIn("logo-sky.svg", body)
+        self.assertIn("Times follow the selected time zone", body)
+        self.assertIn("data-admin-timestamp", body)
+        self.assertIn("admin-timezone", body)
         self.assertEqual(format_timestamp(row["last_success"]), "25 Aug 2026, 16:04 UTC")
 
         unknown_variant = dict(row)
@@ -316,6 +375,19 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(allowed.headers["X-Robots-Tag"], "noindex, nofollow")
         self.assertIn(b"f\xc4\x93nix 8", body)
 
+        devices, devices_body = self.request("GET", "/admin/devices", headers={"Cookie": cookie_header})
+        self.assertEqual(devices.status, 200)
+        self.assertIn(b"Garmin devices", devices_body)
+        self.assertIn(b"Map-capable: Yes", devices_body)
+        self.assertIn(
+            "img-src https://terento.app https://api.terento.app https://res.garmin.com data:",
+            devices.headers["Content-Security-Policy"],
+        )
+
+        devices_json, devices_json_body = self.request("GET", "/admin/devices.json", headers={"Cookie": cookie_header})
+        self.assertEqual(devices_json.status, 200)
+        self.assertEqual(json.loads(devices_json_body)["summary"]["tested"], 1)
+
         unauthenticated_campaign, _ = self.request("GET", "/admin/campaign-links")
         self.assertEqual(unauthenticated_campaign.status, 303)
         self.assertEqual(unauthenticated_campaign.headers["Location"], "/admin/login")
@@ -372,6 +444,16 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(document["models"][0]["successfulInstallations"], 3)
         self.assertEqual(document["models"][0]["mapCapable"], True)
         self.assertNotIn("firmwareVersion", document["models"][0])
+
+    def test_public_models_is_additive_and_evidence_only(self):
+        response, body = self.request("GET", "/compatibility/public/models.json?limit=5")
+        document = json.loads(body)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(document["schemaVersion"], 1)
+        self.assertEqual(document["models"][1]["evidenceStatus"], "TESTED")
+        self.assertEqual(document["models"][1]["image"], None)
+        self.assertNotIn("supportStatus", document["models"][1])
+        self.assertNotIn("writeAuthorization", document["models"][1])
 
 
 class PasswordHashTests(unittest.TestCase):

--- a/backend/catalog-api/tests/test_compatibility_status_contract.py
+++ b/backend/catalog-api/tests/test_compatibility_status_contract.py
@@ -1,0 +1,37 @@
+import unittest
+
+from terento_catalog.compatibility_status import (
+    CompatibilityStatus,
+    calculate_compatibility_status,
+)
+
+
+class CompatibilityStatusContractTests(unittest.TestCase):
+    def test_all_threshold_boundaries_are_canonical(self):
+        expected = {
+            0: CompatibilityStatus.TESTING,
+            1: CompatibilityStatus.TESTED,
+            2: CompatibilityStatus.TESTED,
+            3: CompatibilityStatus.SUPPORTED,
+            4: CompatibilityStatus.SUPPORTED,
+            5: CompatibilityStatus.VERIFIED,
+            25: CompatibilityStatus.VERIFIED,
+        }
+        for count, status in expected.items():
+            with self.subTest(count=count):
+                self.assertEqual(
+                    calculate_compatibility_status(successful_install_count=count),
+                    status,
+                )
+
+    def test_non_map_identity_has_no_evidence_status(self):
+        self.assertIsNone(
+            calculate_compatibility_status(
+                successful_install_count=5,
+                recognized_map_capable_evidence=False,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/catalog-api/tests/test_historical_devices.py
+++ b/backend/catalog-api/tests/test_historical_devices.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import unittest
+
+from terento_catalog.historical_devices import (
+    HISTORICAL_DEVICE_REGISTRY,
+    historical_device_for_event,
+    historical_device_spec,
+)
+
+
+MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "terento_catalog"
+    / "migrations"
+    / "016_historical_device_registry.sql"
+)
+
+
+class HistoricalDeviceRegistryTests(unittest.TestCase):
+    def test_fenix_7_is_resolved_without_requiring_retail_catalog_membership(self):
+        spec = historical_device_for_event({
+            "model": "fēnix 7",
+            "compatibilityIdentity": "fēnix 7 · 47 mm",
+            "caseSizeMm": 47,
+        })
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.id, "garmin-fenix-7-47")
+        self.assertEqual(spec.source_image_url, None)
+
+    def test_variant_boundary_does_not_match_fenix_7s_as_fenix_7(self):
+        spec = historical_device_for_event({
+            "model": "fēnix 7S",
+            "caseSizeMm": 42,
+        })
+        self.assertIsNotNone(spec)
+        self.assertEqual(spec.id, "garmin-fenix-7s-42")
+
+    def test_registry_contains_reviewed_source_and_no_write_authorization(self):
+        self.assertGreaterEqual(len(HISTORICAL_DEVICE_REGISTRY), 8)
+        self.assertTrue(all(spec.source_url.startswith("https://") for spec in HISTORICAL_DEVICE_REGISTRY))
+        self.assertFalse(hasattr(historical_device_spec("garmin-fenix-7-47"), "write_profile"))
+
+    def test_migration_seeds_history_and_keeps_it_out_of_collector_deactivation(self):
+        sql = MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("HISTORICAL_REVIEWED", sql)
+        self.assertIn("collector_managed", sql)
+        self.assertIn("garmin-fenix-7-47", sql)
+        self.assertIn("collector_managed BOOLEAN NOT NULL DEFAULT TRUE", sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/catalog-api/tests/test_historical_devices.py
+++ b/backend/catalog-api/tests/test_historical_devices.py
@@ -47,6 +47,14 @@ class HistoricalDeviceRegistryTests(unittest.TestCase):
         self.assertIn("collector_managed", sql)
         self.assertIn("garmin-fenix-7-47", sql)
         self.assertIn("collector_managed BOOLEAN NOT NULL DEFAULT TRUE", sql)
+        db_source = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "terento_catalog"
+            / "db.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("AND collector_managed = TRUE", db_source)
+        self.assertIn("WHERE collector_managed = TRUE", db_source)
 
 
 if __name__ == "__main__":

--- a/backend/catalog-api/tests/test_http_api.py
+++ b/backend/catalog-api/tests/test_http_api.py
@@ -162,6 +162,14 @@ class HTTPAPITests(unittest.TestCase):
                 "attributionRequired": True,
             },
         )
+        self.assertEqual(
+            set(document["devices"][0]),
+            {
+                "id", "manufacturer", "family", "familyName", "model",
+                "canonicalModel", "variant", "caseSizeMm", "displayType",
+                "partNumber", "productURL", "active", "asset", "sourceAsset",
+            },
+        )
         self.assertEqual(document["legal"]["manufacturerNotice"], True)
         self.assertIn("Terento is an independent open-source project", document["legal"]["text"])
         raw_json = json.dumps(document, ensure_ascii=False)

--- a/backend/catalog-api/tests/test_map_capability.py
+++ b/backend/catalog-api/tests/test_map_capability.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import unittest
+
+from terento_catalog.map_capability import classify_map_capable
+
+
+class MapCapabilityTests(unittest.TestCase):
+    def test_map_manager_prefixes_match_the_native_client(self) -> None:
+        self.assertTrue(classify_map_capable("fēnix 7"))
+        self.assertTrue(classify_map_capable("Forerunner 970"))
+        self.assertTrue(classify_map_capable("MARQ Adventurer (Gen 2)"))
+        self.assertTrue(classify_map_capable("fēnix 6 Pro"))
+        self.assertTrue(classify_map_capable("Descent Mk2S"))
+        self.assertTrue(classify_map_capable("Garmin fēnix 8 - 51mm"))
+        self.assertTrue(classify_map_capable("venu x1"))
+        self.assertTrue(classify_map_capable("fēnix 8 Pro"))
+        self.assertFalse(classify_map_capable("Lily 2 Active"))
+        self.assertFalse(classify_map_capable("Approach S70"))
+        self.assertFalse(classify_map_capable("Venu 4"))
+        self.assertFalse(classify_map_capable("Instinct 3"))
+        self.assertIsNone(classify_map_capable("Garmin Future Watch"))
+        self.assertIsNone(classify_map_capable("Forerunner 170"))
+        self.assertIsNone(classify_map_capable("fēnix 9"))
+        self.assertIsNone(classify_map_capable("fenix 7", manufacturer="Suunto"))


### PR DESCRIPTION
## Summary
- retain the canonical compatibility aggregation fixes already running in production
- add backward-compatible compatibility evidence schema v3
- add migration 017 and private per-operation diagnostics
- keep schema v1/v2 ingestion supported

## Verification
- backend test suite: 91 passed
- production deployment: GitHub Actions run 32955581951
- production migration: 017 applied before rollout
- live schema-v3 event: HTTP 201, then deletion HTTP 200
- beta.6 native app and website were not deployed or published