### PR TITLE
Deploy exact Garmin identity diagnostics

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -44,7 +44,9 @@ as optional evidence dimensions and do not promote a status.
 Version 3 groups all map results from one Install press under a random
 `operationId` and records the exact app release/build plus controlled failure
 stage/code, write/remote-object/cleanup booleans, and a coarse transfer
-progress bucket. It never accepts raw native messages, local paths, object
+progress bucket. It may also record the sanitized raw MTP model label and one
+allowlisted identity-source category (`MTP_SERIAL`, `GARMIN_UNIT_ID`, or
+`UNAVAILABLE`) without the identifier value. It never accepts raw native messages, local paths, object
 IDs, manifests, hashes, serials, Unit IDs, or local watch keys. Selected maps
 not reached after an earlier failure use `NOT_STARTED`. Download, extraction,
 source-validation, and preflight failures remain visible in the private
@@ -76,8 +78,8 @@ opaque sessions and CSRF values are stored only as SHA-256 hashes. Cookies are
 Secure, HttpOnly, SameSite=Strict, and scoped to `/admin`. Login/setup attempts
 are rate limited. Pages include no-store, noindex and restrictive CSP headers.
 The error count links to a private per-operation detail with child map results,
-release/build, failure stage and allowlisted codes. Raw event payloads and raw
-diagnostic text are not displayed. `/internal/compatibility/` redirects to
+release/build, raw MTP model label, identity-source category, failure stage and
+allowlisted codes. Raw event payloads and raw diagnostic text are not displayed. `/internal/compatibility/` redirects to
 this route for the earlier local implementation.
 
 ## `GET https://api.terento.app/admin/campaign-links`

--- a/backend/catalog-api/docs/device-api.md
+++ b/backend/catalog-api/docs/device-api.md
@@ -24,10 +24,12 @@ response shape fails closed and preserves the previous catalog.
 
 ## Device catalog versus compatibility
 
-`/devices/catalog.json` answers only: “This Garmin product exists in the
-official current retail catalog.” It does not answer whether Terento can
-connect to it or install maps on it. Compatibility status is deliberately
-absent from this public contract. Retail rows are collector-managed; inactive
+`/devices/catalog.json` primarily answers: “This Garmin product exists in the
+official current retail catalog.” Its additive nullable `mapCapable` field
+reports only the reviewed Garmin Map Manager capability classification used by
+the beta client; it is not public compatibility evidence and does not by
+itself authorize a write. Compatibility status is deliberately absent from
+this public contract. Retail rows are collector-managed; inactive
 retail rows remain in the database for continuity, while reviewed historical
 rows have `record_source = HISTORICAL_REVIEWED` and
 `collector_managed = false` and are intentionally excluded from this endpoint.

--- a/backend/catalog-api/docs/schema.md
+++ b/backend/catalog-api/docs/schema.md
@@ -177,14 +177,16 @@ for syncs recorded after that migration and exact first/last collection-run
 links on `device_model`. Historical runs without those counters remain
 explicitly unknown rather than being presented as zero.
 
-Migration `014` also adds the admin-only `device_model.map_capable` field
+Migration `014` also adds the independently reviewed `device_model.map_capable` field
 (`true`, `false`, or `NULL` for unknown) and the separate operator-controlled
 `device_model.support_status` field (`SUPPORTED`, `UNSUPPORTED`, or
 `NOT_EVALUATED`). Neither field is added to the public device catalog
 contract. Map capability, support state, and installation evidence remain
 independent concepts. The migration carries forward the existing exact
 write-capable `garmin-fenix-8-47-amoled` profile as `map_capable = true` and
-`support_status = 'SUPPORTED'`. For other records, a stored `map_capable`
+`support_status = 'SUPPORTED'`. The public device-catalog v2 contract exposes
+this as additive nullable `mapCapable`; it remains capability metadata, not a
+support status or write grant. For other records, a stored `map_capable`
 value still wins, but a `NULL` column is classified at admin-read time and on
 the next Garmin collection from the same Map Manager prefix list used by the
 native client (`terento_catalog.map_capability`, kept aligned with
@@ -211,6 +213,13 @@ allowlisted failure stage and codes, write/object/cleanup state, and coarse
 progress are stored as separate columns. No raw JSON or error message is
 retained. `NOT_STARTED` is reserved for selected child maps skipped after an
 earlier result stopped the batch.
+
+Migration 018 adds the sanitized `raw_mtp_model` label and the controlled
+`identity_resolution_code` category. It stores neither the MTP serial nor the
+Garmin Unit ID. The migration also quarantines only the issue #32 legacy
+`CHE+` failures (fēnix 8, 51 mm, firmware 2326, 2026-08-26) under an
+identity-pending label; it preserves the rows for diagnosis and prevents their
+lossy base-model identity from affecting public aggregation.
 
 `compatibility_model_statistics` is a live SQL view over the immutable event
 table and model review metadata. Events with a `canonical_device_model_id` are

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -331,7 +331,8 @@ def _diagnostic_details(rows: list[dict[str, Any]], events: list[dict[str, Any]]
             first = results[0]
             map_rows = "".join(
                 "<tr>" + "".join(f"<td>{html.escape(str(value if value not in (None, '') else '—'))}</td>" for value in (
-                    result.get("region"), result.get("phase_outcome"), result.get("failure_stage"),
+                    result.get("region"), result.get("raw_mtp_model"), result.get("identity_resolution_code"),
+                    result.get("phase_outcome"), result.get("failure_stage"),
                     result.get("failure_code"), result.get("native_failure_code"),
                     str(bool(result.get("write_started"))).lower(),
                     str(bool(result.get("remote_object_created"))).lower(),
@@ -347,7 +348,7 @@ def _diagnostic_details(rows: list[dict[str, Any]], events: list[dict[str, Any]]
               <article class='diagnostic-operation'>
                 <h4>{html.escape(str(operation_key))}</h4>
                 <p>{_timestamp_markup(first.get('occurred_at'))} · {html.escape(str(release))} (build {html.escape(str(build))}) · write started: {str(bool(first.get('write_started'))).lower()}</p>
-                <div class='table-wrap'><table><thead><tr><th>Region</th><th>Result</th><th>Stage</th><th>Code</th><th>Native code</th><th>Write</th><th>Object created</th><th>Cleanup</th><th>Progress</th></tr></thead><tbody>{map_rows}</tbody></table></div>
+                <div class='table-wrap'><table><thead><tr><th>Region</th><th>Raw MTP model</th><th>Local identity</th><th>Result</th><th>Stage</th><th>Code</th><th>Native code</th><th>Write</th><th>Object created</th><th>Cleanup</th><th>Progress</th></tr></thead><tbody>{map_rows}</tbody></table></div>
               </article>""")
         sections.append(f"""
           <details class='diagnostic-details' id='{_diagnostics_id(identity)}'>

--- a/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
+++ b/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
@@ -17,7 +17,7 @@ ALLOWED_KEYS = {
     "operationId", "mapResultIndex", "selectedMapCount", "appBuild", "releaseLabel",
     "failureStage", "failureCode", "nativeFailureCode", "writeStarted",
     "remoteObjectCreated", "cleanupAttempted", "cleanupSucceeded",
-    "transferProgressBucket",
+    "transferProgressBucket", "rawMTPModel", "identityResolutionCode",
 }
 FORBIDDEN_KEY_PARTS = ("serial", "unitid", "unit_id", "path", "manifest", "username", "token", "password")
 
@@ -85,6 +85,16 @@ def validate_event(raw: bytes) -> dict[str, Any]:
         value = event.get(key)
         if value is not None and (not isinstance(value, str) or len(value) > 160 or "/Users/" in value or "file://" in value):
             raise EvidenceValidationError(f"invalid_{key}")
+    raw_mtp_model = event.get("rawMTPModel")
+    if raw_mtp_model is not None and (
+        not isinstance(raw_mtp_model, str)
+        or not raw_mtp_model.strip()
+        or len(raw_mtp_model) > 160
+        or "/Users/" in raw_mtp_model
+        or "file://" in raw_mtp_model
+        or any(ord(character) < 32 for character in raw_mtp_model)
+    ):
+        raise EvidenceValidationError("invalid_rawMTPModel")
     compatibility_identity = str(event.get("compatibilityIdentity") or event["model"]).strip()
     if not compatibility_identity:
         raise EvidenceValidationError("invalid_compatibilityIdentity")
@@ -166,6 +176,7 @@ def _validate_v3(event: dict[str, Any]) -> None:
         "INSTALL_FAILED_CLEANUP", "INSTALL_BLOCKED_TRANSACTION_ALREADY_RUNNING",
         "INSTALL_FAILED_INVALID_STATE_TRANSITION", "INSTALL_BLOCKED_VERIFICATION_REQUIRED",
         "INSTALL_NOT_STARTED_AFTER_EARLIER_FAILURE",
+        "INSTALL_BLOCKED_STABLE_WATCH_IDENTITY_UNAVAILABLE",
     }
     if event.get("failureCode") not in failure_codes | {None}:
         raise EvidenceValidationError("invalid_failure_code")
@@ -173,10 +184,15 @@ def _validate_v3(event: dict[str, Any]) -> None:
         "TARGET_ALREADY_EXISTS", "REMOTE_FILE_MISSING", "OBJECT_ID_MISMATCH",
         "UNSUPPORTED_DEVICE", "DEVICE_DISCONNECTED", "SEND_OBJECT_FAILED",
         "READBACK_FAILED", "DELETE_FAILED", "MTP_OPEN_FAILED", "GARMIN_ROOT_COUNT_INVALID",
-        "PREFLIGHT_MTP_READ_FAILED",
+        "PREFLIGHT_MTP_READ_FAILED", "LIVE_IDENTITY_MISMATCH",
+        "STABLE_WATCH_IDENTITY_UNAVAILABLE", "GARMIN_DEVICE_XML_INVALID",
     }
     if event.get("nativeFailureCode") not in native_codes | {None}:
         raise EvidenceValidationError("invalid_native_failure_code")
+    if event.get("identityResolutionCode") not in {
+        None, "MTP_SERIAL", "GARMIN_UNIT_ID", "UNAVAILABLE"
+    }:
+        raise EvidenceValidationError("invalid_identity_resolution_code")
     if event["phaseOutcome"] == "SUCCEEDED" and any(event.get(key) is not None for key in ("failureStage", "failureCode", "nativeFailureCode")):
         raise EvidenceValidationError("inconsistent_success_diagnostics")
     if event["phaseOutcome"] in {"FAILED", "NOT_STARTED"} and (

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -52,7 +52,8 @@ class Database:
                 error_category, deletion_token_hash, operation_id, map_result_index,
                 selected_map_count, app_build, release_label, failure_stage, failure_code,
                 native_failure_code, write_started, remote_object_created,
-                cleanup_attempted, cleanup_succeeded, transfer_progress_bucket
+                cleanup_attempted, cleanup_succeeded, transfer_progress_bucket,
+                raw_mtp_model, identity_resolution_code
             ) VALUES (
                 %(id)s, %(timestamp)s, %(model)s, %(compatibilityIdentity)s, %(variant)s, %(caseSizeMm)s,
                 %(displayType)s, %(canonicalDeviceId)s,
@@ -64,7 +65,7 @@ class Database:
                 %(selectedMapCount)s, %(appBuild)s, %(releaseLabel)s, %(failureStage)s,
                 %(failureCode)s, %(nativeFailureCode)s, %(writeStarted)s,
                 %(remoteObjectCreated)s, %(cleanupAttempted)s, %(cleanupSucceeded)s,
-                %(transferProgressBucket)s
+                %(transferProgressBucket)s, %(rawMTPModel)s, %(identityResolutionCode)s
             ) ON CONFLICT (event_id) DO NOTHING
             RETURNING event_id
         """
@@ -96,6 +97,8 @@ class Database:
             "cleanupAttempted": event.get("cleanupAttempted"),
             "cleanupSucceeded": event.get("cleanupSucceeded"),
             "transferProgressBucket": event.get("transferProgressBucket"),
+            "rawMTPModel": event.get("rawMTPModel"),
+            "identityResolutionCode": event.get("identityResolutionCode"),
         }
         with self.connection() as connection:
             # The client contract remains unchanged: canonicalDeviceId is
@@ -190,7 +193,8 @@ class Database:
                 COALESCE(write_started, true) AS write_started,
                 COALESCE(remote_object_created, false) AS remote_object_created,
                 COALESCE(cleanup_attempted, false) AS cleanup_attempted,
-                cleanup_succeeded, transfer_progress_bucket, error_category
+                cleanup_succeeded, transfer_progress_bucket, error_category,
+                raw_mtp_model, identity_resolution_code
             FROM compatibility_evidence_event
             ORDER BY occurred_at DESC, operation_key, map_result_index NULLS FIRST
             LIMIT %s
@@ -745,6 +749,7 @@ class Database:
                 dm.source_url,
                 dm.source_image_url,
                 dm.active,
+                dm.map_capable,
                 dm.first_seen_at,
                 dm.last_seen_at,
                 asset.asset_type,

--- a/backend/catalog-api/src/terento_catalog/device_catalog.py
+++ b/backend/catalog-api/src/terento_catalog/device_catalog.py
@@ -82,6 +82,7 @@ def build_device_catalog(
                 "partNumber": _clean_text(row["part_number"]),
                 "productURL": _public_https_url(row.get("product_url")),
                 "active": row["active"],
+                "mapCapable": bool(row["map_capable"]) if row.get("map_capable") is not None else None,
                 "asset": asset,
             }
         )

--- a/backend/catalog-api/src/terento_catalog/migrations/018_device_identity_diagnostics.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/018_device_identity_diagnostics.sql
@@ -1,0 +1,25 @@
+ALTER TABLE compatibility_evidence_event
+    ADD COLUMN raw_mtp_model TEXT,
+    ADD COLUMN identity_resolution_code TEXT CHECK (
+        identity_resolution_code IS NULL
+        OR identity_resolution_code IN ('MTP_SERIAL', 'GARMIN_UNIT_ID', 'UNAVAILABLE')
+    );
+
+-- The three legacy failures reported in issue #32 were emitted by a client
+-- that collapsed every "fenix 8 ..." value to "fēnix 8" and did not retain
+-- the raw MTP model.  Preserve them for diagnostics, but quarantine their
+-- unprovable identity so they cannot lower or create a public base-model row.
+UPDATE compatibility_evidence_event
+SET
+    model = 'Identity pending',
+    compatibility_identity = 'Identity pending · issue #32 · fēnix 8 Pro 51 mm',
+    variant = 'Reported fēnix 8 Pro, 51 mm',
+    display_type = NULL,
+    canonical_device_model_id = NULL
+WHERE phase_outcome = 'FAILED'
+  AND model IN ('fēnix 8', 'fenix 8')
+  AND case_size_mm = 51
+  AND firmware_version = '2326'
+  AND region = 'CHE+'
+  AND occurred_at >= TIMESTAMPTZ '2026-08-26 00:00:00+00'
+  AND occurred_at < TIMESTAMPTZ '2026-08-27 00:00:00+00';

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -347,6 +347,7 @@ class CompatibilityEvidenceTests(unittest.TestCase):
             "release_label": "1.0.0-beta.6", "app_build": "5", "write_started": True,
             "failure_stage": "write", "failure_code": "INSTALL_FAILED_WRITE",
             "native_failure_code": "SEND_OBJECT_FAILED", "transfer_progress_bucket": "25-99",
+            "raw_mtp_model": "fenix 8 pro - 51mm", "identity_resolution_code": "GARMIN_UNIT_ID",
             "map_result_index": 0,
         }
         body = dashboard_page(
@@ -357,6 +358,22 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertIn("1.0.0-beta.6 (build 5)", body)
         self.assertIn("INSTALL_FAILED_WRITE", body)
         self.assertIn("SEND_OBJECT_FAILED", body)
+        self.assertIn("fenix 8 pro - 51mm", body)
+        self.assertIn("GARMIN_UNIT_ID", body)
+
+    def test_issue_32_quarantine_is_narrow_and_non_destructive(self):
+        from pathlib import Path
+
+        migration = (
+            Path(__file__).parents[1]
+            / "src/terento_catalog/migrations/018_device_identity_diagnostics.sql"
+        ).read_text()
+        self.assertIn("region = 'CHE+'", migration)
+        self.assertIn("firmware_version = '2326'", migration)
+        self.assertIn("case_size_mm = 51", migration)
+        self.assertIn("phase_outcome = 'FAILED'", migration)
+        self.assertIn("Identity pending · issue #32 · fēnix 8 Pro 51 mm", migration)
+        self.assertNotIn("DELETE FROM compatibility_evidence_event", migration)
 
     def test_schema_v2_keeps_exact_variant_and_treats_reconnect_as_optional(self):
         payload = event(
@@ -400,6 +417,8 @@ class CompatibilityEvidenceTests(unittest.TestCase):
             cleanupAttempted=False,
             cleanupSucceeded=False,
             transferProgressBucket="25-99",
+            rawMTPModel="fenix 8 pro - 51mm",
+            identityResolutionCode="GARMIN_UNIT_ID",
         )
         validated = validate_event(json.dumps(payload).encode())
         self.assertEqual(validated["operationId"], payload["operationId"])
@@ -407,11 +426,19 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertTrue(database.insert_compatibility_event(validated))
         self.assertEqual(database.parameters["appBuild"], "5")
         self.assertEqual(database.parameters["failureStage"], "write")
+        self.assertEqual(database.parameters["rawMTPModel"], "fenix 8 pro - 51mm")
+        self.assertEqual(database.parameters["identityResolutionCode"], "GARMIN_UNIT_ID")
 
         with self.assertRaises(EvidenceValidationError):
             validate_event(json.dumps({**payload, "nativeFailureCode": "RAW: libmtp failed /Users/me"}).encode())
         with self.assertRaises(EvidenceValidationError):
             validate_event(json.dumps({**payload, "releaseLabel": "file:///Users/me/build"}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "rawMTPModel": "/Users/me/watch"}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "rawMTPModel": "fenix 8\nserial"}).encode())
+        with self.assertRaises(EvidenceValidationError):
+            validate_event(json.dumps({**payload, "identityResolutionCode": "UNIT_ID:123"}).encode())
         with self.assertRaises(EvidenceValidationError):
             validate_event(json.dumps({**payload, "writeStarted": False, "remoteObjectCreated": True}).encode())
         with self.assertRaises(EvidenceValidationError):
@@ -563,6 +590,41 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(document["models"][1]["image"], None)
         self.assertNotIn("supportStatus", document["models"][1])
         self.assertNotIn("writeAuthorization", document["models"][1])
+
+    def test_fenix_8_pro_identity_is_preserved_for_admin_and_public_web(self):
+        pro_row = {
+            "model": "fēnix 8 Pro · 51 mm AMOLED",
+            "evidence_model": "fēnix 8 Pro",
+            "canonical_model": "fenix 8 pro",
+            "compatibility_identity": "fēnix 8 Pro · 51 mm, AMOLED",
+            "variant": "51 mm, AMOLED", "case_size_mm": 51,
+            "display_type": "AMOLED",
+            "canonical_device_model_id": "garmin-fenix-8-pro-51-amoled",
+            "attempted_install_count": 1, "successful_install_count": 1,
+            "reconnect_verified_install_count": 0, "failed_install_count": 0,
+            "success_rate": 100.0, "calculated_status": "TESTED",
+            "recognized_map_capable_evidence": True,
+            "last_success": datetime(2026, 8, 26, tzinfo=timezone.utc),
+            "last_evidence": datetime(2026, 8, 26, tzinfo=timezone.utc),
+            "family": "fenix", "family_name": "fēnix",
+            "asset_status": "MISSING", "asset_url": None,
+            "source_image_url": None,
+        }
+        self.database.public_compatibility_models = lambda limit: [pro_row][:limit]
+
+        response, body = self.request("GET", "/compatibility/public/models.json?limit=5")
+        public_model = json.loads(body)["models"][0]
+        self.assertEqual(response.status, 200)
+        self.assertEqual(public_model["model"], "fēnix 8 Pro · 51 mm AMOLED")
+        self.assertEqual(public_model["canonicalModel"], "fenix 8 pro")
+        self.assertEqual(
+            public_model["canonicalDeviceId"],
+            "garmin-fenix-8-pro-51-amoled",
+        )
+
+        admin = dashboard_page([pro_row], {"username": "operator"}, "csrf").decode()
+        self.assertIn("fēnix 8 Pro", admin)
+        self.assertNotIn(">fēnix 8<", admin)
 
 
 class PasswordHashTests(unittest.TestCase):

--- a/backend/catalog-api/tests/test_http_api.py
+++ b/backend/catalog-api/tests/test_http_api.py
@@ -65,6 +65,7 @@ class FakeDatabase(Database):
                 "part_number": "010-02904-10",
                 "product_url": "https://www.garmin.com/en-US/p/1228429/",
                 "active": True,
+                "map_capable": True,
                 "asset_status": "AVAILABLE",
                 "asset_url": "https://api.terento.app/assets/devices/garmin/fenix-8.webp",
                 "asset_type": "product-image",
@@ -167,9 +168,10 @@ class HTTPAPITests(unittest.TestCase):
             {
                 "id", "manufacturer", "family", "familyName", "model",
                 "canonicalModel", "variant", "caseSizeMm", "displayType",
-                "partNumber", "productURL", "active", "asset", "sourceAsset",
+                "partNumber", "productURL", "active", "mapCapable", "asset", "sourceAsset",
             },
         )
+        self.assertTrue(document["devices"][0]["mapCapable"])
         self.assertEqual(document["legal"]["manufacturerNotice"], True)
         self.assertIn("Terento is an independent open-source project", document["legal"]["text"])
         raw_json = json.dumps(document, ensure_ascii=False)
@@ -184,6 +186,12 @@ class HTTPAPITests(unittest.TestCase):
         )
         self.assertEqual(cached.status, 304)
         self.assertEqual(cached_body, b"")
+
+    def test_device_catalog_database_projection_includes_map_capability(self) -> None:
+        import inspect
+
+        source = inspect.getsource(Database.device_catalog_snapshot)
+        self.assertIn("dm.map_capable", source)
 
     def test_non_approved_asset_is_not_serialized(self) -> None:
         row = {

--- a/backend/catalog-api/tests/test_map_capability.py
+++ b/backend/catalog-api/tests/test_map_capability.py
@@ -1,11 +1,35 @@
 from __future__ import annotations
 
 import unittest
+from pathlib import Path
+import re
 
-from terento_catalog.map_capability import classify_map_capable
+from terento_catalog.map_capability import (
+    KNOWN_NON_MAP_PREFIXES,
+    SUPPORTED_PREFIXES,
+    classify_map_capable,
+)
 
 
 class MapCapabilityTests(unittest.TestCase):
+    def test_python_and_native_prefix_contracts_are_exactly_aligned(self) -> None:
+        swift_source = (
+            Path(__file__).parents[3]
+            / "lab/native-connectivity-poc/Sources/TerentoPoC/Compatibility/MapCapability.swift"
+        ).read_text()
+
+        def values(name: str) -> set[str]:
+            match = re.search(
+                rf"private let {name}: Set<String> = \[(.*?)\n    \]",
+                swift_source,
+                flags=re.DOTALL,
+            )
+            self.assertIsNotNone(match)
+            return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+        self.assertEqual(values("supportedPrefixes"), set(SUPPORTED_PREFIXES))
+        self.assertEqual(values("knownNonMapPrefixes"), set(KNOWN_NON_MAP_PREFIXES))
+
     def test_map_manager_prefixes_match_the_native_client(self) -> None:
         self.assertTrue(classify_map_capable("fēnix 7"))
         self.assertTrue(classify_map_capable("Forerunner 970"))


### PR DESCRIPTION
Adds the backward-compatible API contract required before the beta.6 issue #32 client candidate. Stores a sanitized raw MTP model label and only the local identity source category, never serial or Garmin Unit ID values. Adds exact Pro-preserving public map-capability metadata and quarantines only the three narrowly matched legacy CHE+ failures under an identity-pending label. Backend test suite: 95 passed. This PR does not publish the macOS beta or enable Safe Update.