### PR TITLE
Separate resolved legacy diagnostics from current stats

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -79,7 +79,10 @@ Secure, HttpOnly, SameSite=Strict, and scoped to `/admin`. Login/setup attempts
 are rate limited. Pages include no-store, noindex and restrictive CSP headers.
 The error count links to a private per-operation detail with child map results,
 release/build, raw MTP model label, identity-source category, failure stage and
-allowlisted codes. Raw event payloads and raw diagnostic text are not displayed. `/internal/compatibility/` redirects to
+allowlisted codes. Current error counts and compatibility rates exclude
+resolved historical failures. Those events remain available in a separate
+`Resolved / historical diagnostics` section with their resolution reason. Raw
+event payloads and raw diagnostic text are not displayed. `/internal/compatibility/` redirects to
 this route for the earlier local implementation.
 
 ## `GET https://api.terento.app/admin/campaign-links`

--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -49,6 +49,15 @@ The Garmin collector creates a `MISSING` asset baseline for new devices; it
 does not request product-image binaries and it never changes an asset to
 `AVAILABLE`.
 
+## Evidence lifecycle cleanup
+
+Migration `019_resolved_legacy_diagnostics.sql` is applied automatically by
+the normal forward migration command. It marks failed pre-beta.6 events as
+`RESOLVED` so the administrator dashboard shows current compatibility data
+without erasing the old reports. The old events remain in the database and
+are visible under `Resolved / historical diagnostics`; they do not contribute
+to active failure counts, rates, or public compatibility projections.
+
 ## Asset review and publication
 
 Asset work is explicit and non-destructive. A candidate is prepared into

--- a/backend/catalog-api/docs/schema.md
+++ b/backend/catalog-api/docs/schema.md
@@ -221,8 +221,17 @@ Garmin Unit ID. The migration also quarantines only the issue #32 legacy
 identity-pending label; it preserves the rows for diagnosis and prevents their
 lossy base-model identity from affecting public aggregation.
 
-`compatibility_model_statistics` is a live SQL view over the immutable event
-table and model review metadata. Events with a `canonical_device_model_id` are
+Migration 019 adds the internal `diagnostic_status` lifecycle (`ACTIVE` or
+`RESOLVED`) and resolution metadata. Failed events from clients before the
+beta.6 structured-diagnostics rollout are marked `RESOLVED`, not deleted. They
+remain available in the private historical-diagnostics section, but are
+excluded from current compatibility counts, rates, status badges, and public
+evidence projections. New beta.6 and later events remain active by default.
+
+`compatibility_model_statistics` is a live SQL view over the evidence event
+table and model review metadata. It includes only `ACTIVE` diagnostic events;
+resolved historical failures remain queryable through the private operation
+diagnostics path. Events with a `canonical_device_model_id` are
 grouped by that exact Garmin catalog record; textual `compatibility_identity`
 is only the fallback for older uncanonicalized events. Formatting changes
 between app versions therefore increase one variant's report and success

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -264,7 +264,9 @@ def login_page(*, error: str | None = None) -> bytes:
 
 def dashboard_page(
     rows: list[dict[str, Any]], user: dict[str, Any], csrf_token: str,
-    *, operations: list[dict[str, Any]] | None = None, public_stats_enabled: bool = False,
+    *, operations: list[dict[str, Any]] | None = None,
+    resolved_operations: list[dict[str, Any]] | None = None,
+    public_stats_enabled: bool = False,
 ) -> bytes:
     attempts = sum(int(row.get("attempted_install_count") or 0) for row in rows)
     successes = sum(int(row.get("successful_install_count") or 0) for row in rows)
@@ -286,9 +288,17 @@ def dashboard_page(
         for label, value in (("Models", len(rows)), ("Write attempts", attempts), ("Successful operations", successes), ("Failed operations", failures))
     )
     table_rows = "".join(_statistics_row(row) for row in rows)
-    empty = "<p class='empty'>No installation evidence reports yet.</p>" if not rows else ""
-    latest_copy = f"Updated {_timestamp_markup(latest)}" if latest else "No reports received yet"
+    has_resolved_operations = bool(resolved_operations)
+    empty = (
+        "<p class='empty'>No current installation evidence reports yet. Resolved historical reports are shown below.</p>"
+        if not rows and has_resolved_operations
+        else ("<p class='empty'>No installation evidence reports yet.</p>" if not rows else "")
+    )
+    latest_copy = f"Updated {_timestamp_markup(latest)}" if latest else (
+        "No current reports received yet" if has_resolved_operations else "No reports received yet"
+    )
     diagnostic_details = _diagnostic_details(rows, operations or [])
+    resolved_diagnostic_details = _resolved_diagnostic_details(resolved_operations or [])
     content = f"""
       {_admin_header(user, csrf_token)}
       <main class="dashboard" id="main-content">
@@ -303,8 +313,9 @@ def dashboard_page(
           </form>
           <p class="results-count" id="results-count" aria-live="polite">{len(rows)} {"model" if len(rows) == 1 else "models"}</p>
           <div class="table-wrap"><table><caption class="sr-only">Installation evidence by exact device identity</caption><thead><tr><th scope="col">Model</th><th scope="col">Variant</th><th scope="col">Firmware</th><th scope="col">Write attempts</th><th scope="col">Successful operations</th><th scope="col">Failed operations</th><th scope="col">Success rate</th><th scope="col">Status</th><th scope="col">Last success</th><th scope="col">Errors</th></tr></thead><tbody id="evidence-rows">{table_rows}</tbody></table></div>
-          <p class="table-help">Compatibility rates count distinct write-started operations. Operation details list every selected-map result and pre-write failure.</p>
+          <p class="table-help">Compatibility rates count distinct active write-started operations. Resolved historical failures are excluded from current compatibility counts or rates and shown separately below.</p>
           {diagnostic_details}
+          {resolved_diagnostic_details}
         </section>
         <section class="status-guide" aria-labelledby="status-guide-title"><div class="section-heading"><div><p class="section-kicker">Canonical rules</p><h2 id="status-guide-title">Compatibility statuses</h2></div><p class="table-help">Exact model and variant; successful shared installations only</p></div><div class="status-guide-grid">{''.join(f"<div class='status-guide-row'>{_status_badge(status)}<span>{html.escape(STATUS_PUBLIC_COPY[CompatibilityStatus(status)])}</span></div>" for status in status_values)}</div></section>
         <section class="public-status" aria-labelledby="public-status-title"><div><p class="section-kicker">Publication</p><h2 id="public-status-title">Public compatibility</h2></div><div class="public-status-value"><span class="status-badge status-{('enabled' if public_stats_enabled else 'disabled')}">{'Enabled' if public_stats_enabled else 'Disabled'}</span><span>{published} {'model' if published == 1 else 'models'} published</span></div></section>
@@ -315,18 +326,53 @@ def dashboard_page(
 
 
 def _diagnostic_details(rows: list[dict[str, Any]], events: list[dict[str, Any]]) -> str:
+    identities = {
+        str(row.get("compatibility_identity") or row.get("model") or "Unknown")
+        for row in rows
+    }
+    return _render_diagnostic_details(
+        events,
+        identities=identities,
+        heading="Operation diagnostics",
+        summary_prefix="",
+    )
+
+
+def _resolved_diagnostic_details(events: list[dict[str, Any]]) -> str:
+    return _render_diagnostic_details(
+        events,
+        identities=None,
+        heading="Resolved / historical diagnostics",
+        summary_prefix="Resolved / historical · ",
+        note="These records are retained for diagnosis but do not affect current compatibility counts or rates.",
+    )
+
+
+def _render_diagnostic_details(
+    events: list[dict[str, Any]],
+    *,
+    identities: set[str] | None,
+    heading: str,
+    summary_prefix: str,
+    note: str | None = None,
+) -> str:
     by_identity: dict[str, dict[str, list[dict[str, Any]]]] = {}
     for event in events:
         identity = str(event.get("compatibility_identity") or event.get("model") or "Unknown")
+        if identities is not None and identity not in identities:
+            continue
         operation = str(event.get("operation_key") or event.get("operation_id") or event.get("event_id"))
         by_identity.setdefault(identity, {}).setdefault(operation, []).append(event)
     sections: list[str] = []
-    for row in rows:
-        identity = str(row.get("compatibility_identity") or row.get("model") or "Unknown")
+    identities_to_render = identities if identities is not None else set(by_identity)
+    for identity in sorted(identities_to_render):
         operations = by_identity.get(identity, {})
         if not operations:
             continue
         operation_cards: list[str] = []
+        details_id = _diagnostics_id(identity)
+        if summary_prefix:
+            details_id = "resolved-" + details_id
         for operation_key, results in operations.items():
             first = results[0]
             map_rows = "".join(
@@ -344,20 +390,32 @@ def _diagnostic_details(rows: list[dict[str, Any]], events: list[dict[str, Any]]
             )
             release = first.get("release_label") or first.get("terento_version") or "legacy"
             build = first.get("app_build") or "legacy"
+            resolution = ""
+            if str(first.get("diagnostic_status") or "").upper() == "RESOLVED":
+                resolution = " · " + html.escape(
+                    str(first.get("resolution_note") or "Marked resolved")
+                )
             operation_cards.append(f"""
               <article class='diagnostic-operation'>
                 <h4>{html.escape(str(operation_key))}</h4>
-                <p>{_timestamp_markup(first.get('occurred_at'))} · {html.escape(str(release))} (build {html.escape(str(build))}) · write started: {str(bool(first.get('write_started'))).lower()}</p>
+                <p>{_timestamp_markup(first.get('occurred_at'))} · {html.escape(str(release))} (build {html.escape(str(build))}) · write started: {str(bool(first.get('write_started'))).lower()}{resolution}</p>
                 <div class='table-wrap'><table><thead><tr><th>Region</th><th>Raw MTP model</th><th>Local identity</th><th>Result</th><th>Stage</th><th>Code</th><th>Native code</th><th>Write</th><th>Object created</th><th>Cleanup</th><th>Progress</th></tr></thead><tbody>{map_rows}</tbody></table></div>
               </article>""")
         sections.append(f"""
-          <details class='diagnostic-details' id='{_diagnostics_id(identity)}'>
-            <summary>{html.escape(identity)} · {len(operations)} operation{'s' if len(operations) != 1 else ''}</summary>
+          <details class='diagnostic-details' id='{details_id}'>
+            <summary>{html.escape(summary_prefix + identity)} · {len(operations)} operation{'s' if len(operations) != 1 else ''}</summary>
             {''.join(operation_cards)}
           </details>""")
     if not sections:
         return ""
-    return "<section class='diagnostics-list' aria-label='Installation operation diagnostics'><h3>Operation diagnostics</h3>" + "".join(sections) + "</section>"
+    note_markup = f"<p class='table-help'>{html.escape(note)}</p>" if note else ""
+    section_class = "diagnostics-list resolved-diagnostics" if summary_prefix else "diagnostics-list"
+    return (
+        f"<section class='{section_class}' aria-label='{html.escape(heading)}'>"
+        f"<h3>{html.escape(heading)}</h3>{note_markup}"
+        + "".join(sections)
+        + "</section>"
+    )
 
 
 def _admin_map_capability(value: Any) -> tuple[str, str]:
@@ -1219,7 +1277,7 @@ td:nth-child(1){font-weight:650}
 td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-numeric:tabular-nums}
 .muted-value{color:var(--secondary)}
 .error-count{display:inline-flex;align-items:center;justify-content:center;min-width:24px;min-height:24px;padding:2px 7px;border:1px solid color-mix(in srgb,var(--danger) 35%,var(--border));border-radius:999px;color:var(--danger);font-weight:700}
-.diagnostics-list{margin-top:24px}.diagnostics-list h3{margin-bottom:12px}.diagnostic-details{margin:8px 0;padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:12px;scroll-margin-top:20px}.diagnostic-details summary{cursor:pointer;font-weight:700}.diagnostic-operation{margin-top:16px}.diagnostic-operation h4{margin:0;font:650 13px ui-monospace,SFMono-Regular,Menlo,monospace}.diagnostic-operation p{margin:5px 0 9px;color:var(--secondary);font-size:12px}.diagnostic-operation table{min-width:920px}
+.diagnostics-list{margin-top:24px}.diagnostics-list h3{margin-bottom:12px}.diagnostic-details{margin:8px 0;padding:14px 16px;background:var(--surface);border:1px solid var(--border);border-radius:12px;scroll-margin-top:20px}.diagnostic-details summary{cursor:pointer;font-weight:700}.diagnostic-operation{margin-top:16px}.diagnostic-operation h4{margin:0;font:650 13px ui-monospace,SFMono-Regular,Menlo,monospace}.diagnostic-operation p{margin:5px 0 9px;color:var(--secondary);font-size:12px}.diagnostic-operation table{min-width:920px}.resolved-diagnostics{padding-top:18px;border-top:1px solid var(--border)}.resolved-diagnostics .diagnostic-details{background:var(--background)}
 .status-badge{display:inline-flex;align-items:center;justify-content:center;min-width:74px;min-height:28px;padding:6px 10px;border:1px solid transparent;border-radius:999px;font-size:11px;font-weight:750;letter-spacing:.03em;line-height:1;text-transform:uppercase}
 .status-tested{background:#EDE8DF;border-color:#CFC2AE;color:#5B5144}
 .status-supported{background:#E3EDF0;border-color:#ABC3CD;color:#375E6D}

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -183,6 +183,12 @@ class Database:
             return list(connection.execute(query).fetchall())
 
     def compatibility_operation_details(self, limit: int = 500) -> list[dict[str, Any]]:
+        return self._compatibility_operation_details("ACTIVE", limit)
+
+    def compatibility_resolved_operation_details(self, limit: int = 500) -> list[dict[str, Any]]:
+        return self._compatibility_operation_details("RESOLVED", limit)
+
+    def _compatibility_operation_details(self, diagnostic_status: str, limit: int) -> list[dict[str, Any]]:
         query = """
             SELECT
                 COALESCE(operation_id::text, 'legacy:' || event_id::text) AS operation_key,
@@ -194,13 +200,15 @@ class Database:
                 COALESCE(remote_object_created, false) AS remote_object_created,
                 COALESCE(cleanup_attempted, false) AS cleanup_attempted,
                 cleanup_succeeded, transfer_progress_bucket, error_category,
-                raw_mtp_model, identity_resolution_code
+                raw_mtp_model, identity_resolution_code,
+                diagnostic_status, resolution_code, resolution_note, resolved_at
             FROM compatibility_evidence_event
+            WHERE diagnostic_status = %s
             ORDER BY occurred_at DESC, operation_key, map_result_index NULLS FIRST
             LIMIT %s
         """
         with self.connection() as connection:
-            return list(connection.execute(query, (limit,)).fetchall())
+            return list(connection.execute(query, (diagnostic_status, limit)).fetchall())
 
     def public_compatibility_statistics(self, limit: int) -> list[dict[str, Any]]:
         query = """
@@ -923,6 +931,7 @@ class Database:
                     max(e.occurred_at) AS last_evidence
                 FROM compatibility_evidence_event AS e
                 WHERE e.canonical_device_model_id = dm.id
+                  AND e.diagnostic_status = 'ACTIVE'
             ) AS evidence ON TRUE
             LEFT JOIN LATERAL (
                 SELECT r.*

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -96,6 +96,10 @@ class CatalogService:
     def compatibility_operation_details(self) -> list[dict[str, Any]]:
         return self.database.compatibility_operation_details()
 
+    def compatibility_resolved_operation_details(self) -> list[dict[str, Any]]:
+        getter = getattr(self.database, "compatibility_resolved_operation_details", None)
+        return getter() if getter is not None else []
+
     def admin_devices(self) -> dict[str, Any]:
         rows, sync = self.database.admin_device_snapshot()
         return _admin_device_payload(rows, sync)
@@ -340,6 +344,7 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     body = dashboard_page(
                         service.compatibility_statistics(), session, csrf_token,
                         operations=service.compatibility_operation_details(),
+                        resolved_operations=service.compatibility_resolved_operation_details(),
                         public_stats_enabled=service.public_compatibility_stats_enabled,
                     )
                 except Exception:

--- a/backend/catalog-api/src/terento_catalog/migrations/019_resolved_legacy_diagnostics.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/019_resolved_legacy_diagnostics.sql
@@ -1,0 +1,149 @@
+ALTER TABLE compatibility_evidence_event
+    ADD COLUMN diagnostic_status TEXT NOT NULL DEFAULT 'ACTIVE' CHECK (
+        diagnostic_status IN ('ACTIVE', 'RESOLVED')
+    ),
+    ADD COLUMN resolution_code TEXT,
+    ADD COLUMN resolution_note TEXT,
+    ADD COLUMN resolved_at TIMESTAMPTZ;
+
+CREATE INDEX compatibility_evidence_diagnostic_status_idx
+    ON compatibility_evidence_event(diagnostic_status, occurred_at DESC);
+
+-- Beta.5 and older clients did not send the beta release/build fields. Keep
+-- those failures for private history, but do not present them as current
+-- compatibility failures after the beta.6 diagnostic rollout.
+UPDATE compatibility_evidence_event
+SET
+    diagnostic_status = 'RESOLVED',
+    resolution_code = 'LEGACY_PRE_BETA6',
+    resolution_note = 'Historical pre-beta.6 failure; excluded from current compatibility statistics.',
+    resolved_at = now()
+WHERE phase_outcome = 'FAILED'
+  AND (
+      release_label IS NULL
+      OR btrim(release_label) = ''
+      OR release_label IN ('1.0.0', '1.0.0-beta.4', '1.0.0-beta.5')
+  );
+
+DROP VIEW compatibility_model_statistics;
+
+CREATE VIEW compatibility_model_statistics AS
+WITH normalized_events AS (
+    SELECT
+        e.*,
+        COALESCE(e.canonical_device_model_id, 'identity:' || e.compatibility_identity) AS aggregate_key,
+        COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text) AS operation_key,
+        COALESCE(e.write_started, true) AS compatibility_write_started
+    FROM compatibility_evidence_event e
+    WHERE e.diagnostic_status = 'ACTIVE'
+),
+operation_stats AS (
+    SELECT
+        e.aggregate_key,
+        e.operation_key,
+        min(e.compatibility_identity) AS compatibility_identity,
+        min(e.model) AS model,
+        min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
+        min(e.case_size_mm) FILTER (WHERE e.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(e.display_type) FILTER (WHERE e.display_type IS NOT NULL AND btrim(e.display_type) <> '') AS display_type,
+        min(e.canonical_device_model_id) FILTER (WHERE e.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        bool_or(e.compatibility_write_started) AS write_started,
+        bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED')
+            AND count(*) = max(COALESCE(e.selected_map_count, 1)) AS operation_succeeded,
+        bool_or(e.reconnect_verified) AS reconnect_verified,
+        min(NULLIF(e.firmware_version, '')) AS successful_firmware_version,
+        min(e.occurred_at) AS occurred_at,
+        count(*) AS map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS successful_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'NOT_STARTED') AS not_started_map_result_count
+    FROM normalized_events e
+    GROUP BY e.aggregate_key, e.operation_key
+),
+event_stats AS (
+    SELECT
+        o.aggregate_key,
+        min(o.compatibility_identity) AS compatibility_identity,
+        min(o.model) AS model,
+        min(o.variant) FILTER (WHERE o.variant IS NOT NULL) AS variant,
+        min(o.case_size_mm) FILTER (WHERE o.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(o.display_type) FILTER (WHERE o.display_type IS NOT NULL) AS display_type,
+        min(o.canonical_device_model_id) FILTER (WHERE o.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        string_agg(DISTINCT COALESCE(o.successful_firmware_version, 'unknown'), ', ' ORDER BY COALESCE(o.successful_firmware_version, 'unknown')) AS firmware_versions,
+        count(*) FILTER (WHERE o.write_started) AS attempted_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded) AS successful_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded AND o.reconnect_verified) AS reconnect_verified_install_count,
+        count(*) FILTER (WHERE o.write_started AND NOT o.operation_succeeded) AS failed_install_count,
+        count(DISTINCT o.successful_firmware_version) FILTER (WHERE o.write_started AND o.operation_succeeded) AS firmware_version_count,
+        round(100.0 * count(*) FILTER (WHERE o.write_started AND o.operation_succeeded)
+            / NULLIF(count(*) FILTER (WHERE o.write_started), 0), 1) AS success_rate,
+        max(o.occurred_at) FILTER (WHERE o.write_started AND o.operation_succeeded) AS last_success,
+        max(o.occurred_at) FILTER (WHERE NOT o.operation_succeeded) AS last_failure,
+        max(o.occurred_at) AS last_evidence,
+        sum(o.map_result_count) AS map_result_count,
+        sum(o.successful_map_result_count) AS successful_map_result_count,
+        sum(o.failed_map_result_count) AS failed_map_result_count,
+        sum(o.not_started_map_result_count) AS not_started_map_result_count,
+        count(*) FILTER (WHERE NOT o.write_started) AS prewrite_failure_count
+    FROM operation_stats o
+    GROUP BY o.aggregate_key
+),
+error_stats AS (
+    SELECT
+        e.aggregate_key,
+        jsonb_object_agg(e.error_key, e.error_count) AS error_categories
+    FROM (
+        SELECT
+            n.aggregate_key,
+            COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown') AS error_key,
+            count(*) AS error_count
+        FROM normalized_events n
+        WHERE n.phase_outcome = 'FAILED'
+        GROUP BY n.aggregate_key, COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown')
+    ) e
+    GROUP BY e.aggregate_key
+)
+SELECT
+    COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
+    e.model, e.variant, e.case_size_mm, e.display_type, e.canonical_device_model_id,
+    e.firmware_versions, e.attempted_install_count, e.successful_install_count,
+    e.reconnect_verified_install_count, e.failed_install_count, e.firmware_version_count,
+    e.success_rate, e.last_success, e.last_failure, e.last_evidence,
+    e.map_result_count, e.successful_map_result_count, e.failed_map_result_count,
+    e.not_started_map_result_count, e.prewrite_failure_count,
+    COALESCE(errors.error_categories, '{}'::jsonb) AS error_categories,
+    CASE
+        WHEN e.successful_install_count = 0 THEN 'TESTING'
+        WHEN e.successful_install_count < 3 THEN 'TESTED'
+        WHEN e.successful_install_count < 5 THEN 'SUPPORTED'
+        ELSE 'VERIFIED'
+    END AS calculated_status,
+    true AS recognized_map_capable_evidence,
+    COALESCE(r.physical_device_evidence_count, 0) AS physical_device_evidence_count,
+    COALESCE(r.review_notes, '') AS review_notes,
+    COALESCE(r.review_status, 'PENDING') AS review_status,
+    COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
+    COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
+FROM event_stats e
+LEFT JOIN error_stats errors ON errors.aggregate_key = e.aggregate_key
+LEFT JOIN LATERAL (
+    SELECT review.*
+    FROM compatibility_model_review review
+    WHERE COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity
+       OR (
+            e.canonical_device_model_id IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM compatibility_evidence_event linked_event
+                WHERE linked_event.canonical_device_model_id = e.canonical_device_model_id
+                  AND linked_event.compatibility_identity = COALESCE(
+                      NULLIF(review.identity_key, ''), review.model
+                  )
+            )
+       )
+    ORDER BY
+        (COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity) DESC,
+        (review.review_status = 'APPROVED') DESC,
+        review.updated_at DESC
+    LIMIT 1
+) r ON true;

--- a/backend/catalog-api/tests/test_compatibility_aggregation.py
+++ b/backend/catalog-api/tests/test_compatibility_aggregation.py
@@ -65,6 +65,29 @@ class CompatibilityAggregationMigrationTests(unittest.TestCase):
         self.assertIn("visible.length === 1 ? 'model' : 'models'", admin_source)
         self.assertNotIn("visible.length === 1 ? 'report' : 'reports'", admin_source)
 
+    def test_legacy_failures_have_a_non_destructive_resolved_lifecycle(self) -> None:
+        migration = (
+            MIGRATION.parent / "019_resolved_legacy_diagnostics.sql"
+        ).read_text(encoding="utf-8")
+        self.assertIn("diagnostic_status", migration)
+        self.assertIn("'ACTIVE', 'RESOLVED'", migration)
+        self.assertIn("resolution_code = 'LEGACY_PRE_BETA6'", migration)
+        self.assertIn("phase_outcome = 'FAILED'", migration)
+        self.assertIn("release_label IS NULL", migration)
+        self.assertIn("WHERE e.diagnostic_status = 'ACTIVE'", migration)
+        self.assertNotIn("DELETE FROM compatibility_evidence_event", migration)
+
+    def test_admin_has_a_separate_historical_diagnostics_section(self) -> None:
+        admin_source = (
+            Path(__file__).resolve().parents[1]
+            / "src"
+            / "terento_catalog"
+            / "admin.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("Resolved / historical diagnostics", admin_source)
+        self.assertIn("resolved_operations", admin_source)
+        self.assertIn("excluded from current compatibility counts or rates", admin_source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -361,6 +361,41 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertIn("fenix 8 pro - 51mm", body)
         self.assertIn("GARMIN_UNIT_ID", body)
 
+    def test_admin_dashboard_separates_resolved_legacy_failures_from_active_data(self):
+        active_row = {
+            "model": "fēnix 8", "compatibility_identity": "fēnix 8 · 47 mm AMOLED",
+            "variant": "47 mm, AMOLED", "firmware_versions": "2244",
+            "attempted_install_count": 1, "successful_install_count": 1,
+            "failed_install_count": 0, "success_rate": 100,
+            "calculated_status": "TESTED", "last_success": datetime(2026, 8, 26, tzinfo=timezone.utc),
+            "last_failure": None, "error_categories": {},
+        }
+        resolved = {
+            "operation_key": "legacy:issue-32",
+            "occurred_at": datetime(2026, 8, 26, 8, 30, tzinfo=timezone.utc),
+            "compatibility_identity": "Identity pending · issue #32 · fēnix 8 Pro 51 mm",
+            "region": "CHE+", "phase_outcome": "FAILED", "failure_stage": "preflight",
+            "failure_code": "INSTALL_BLOCKED_UNKNOWN_TARGET",
+            "native_failure_code": "UNSUPPORTED_DEVICE", "write_started": False,
+            "remote_object_created": False, "cleanup_attempted": False,
+            "cleanup_succeeded": False, "transfer_progress_bucket": "0",
+            "release_label": "1.0.0", "app_build": None,
+            "raw_mtp_model": None, "identity_resolution_code": "UNAVAILABLE",
+            "diagnostic_status": "RESOLVED",
+            "resolution_note": "Historical pre-beta.6 failure; excluded from current compatibility statistics.",
+            "map_result_index": 0,
+        }
+        body = dashboard_page(
+            [active_row], {"username": "operator"}, "csrf",
+            operations=[], resolved_operations=[resolved],
+        ).decode()
+        self.assertIn("Resolved / historical diagnostics", body)
+        self.assertIn("Resolved / historical · Identity pending", body)
+        self.assertIn("Historical pre-beta.6 failure", body)
+        self.assertIn("INSTALL_BLOCKED_UNKNOWN_TARGET", body)
+        self.assertIn("excluded from current compatibility counts or rates", body)
+        self.assertNotIn("Identity pending</td>", body)
+
     def test_issue_32_quarantine_is_narrow_and_non_destructive(self):
         from pathlib import Path
 


### PR DESCRIPTION
## Summary
- add a non-destructive ACTIVE/RESOLVED lifecycle for compatibility evidence
- mark failed pre-beta.6 events as resolved historical diagnostics without deleting them
- exclude resolved failures from current compatibility statistics, admin device counts, and public projections
- show retained historical operations in a separate admin section with the resolution reason

## Verification
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=backend/catalog-api/src python3 -m unittest discover -s backend/catalog-api/tests -p 'test_*.py'`
- 98 tests passed
- migration statement parser and `git diff --check` passed

The app install/remove/report contracts and public API response schemas are unchanged.
