### PR TITLE
Add historical Map Installer models and fallback images

### DIFF
--- a/Tests/compatibility-data-tests.cjs
+++ b/Tests/compatibility-data-tests.cjs
@@ -57,7 +57,8 @@ const compatibilitySource = fs.readFileSync(
   "utf8"
 );
 assert.match(compatibilitySource, /\/compatibility\/public\/models\.json/);
-assert.match(compatibilitySource, /watch-image-placeholder/);
+assert.match(compatibilitySource, /generic-garmin-watch\.svg/);
+assert.doesNotMatch(compatibilitySource, /watch-image-placeholder/);
 assert.doesNotMatch(compatibilitySource, /\/devices\/catalog\.json/);
 
 console.log("Compatibility family/data/API-source tests passed.");

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -169,9 +169,11 @@ review gate as the existing route, but it is a separate contract so the
 website does not need to join the retail device catalog. Historical evidence
 rows can therefore appear even when Garmin no longer lists that model in its
 current retail category. The response contains exact identity, evidence
-counts, `evidenceStatus`, family/variant display metadata, and an optional
-`image` object. `image` follows controlled Terento asset → allowlisted Garmin
-`garmin-source` URL → `null`; a null image is a valid public card state.
+counts, `evidenceStatus`, family/variant display metadata, and an `image`
+object. `image` follows controlled Terento asset → allowlisted Garmin
+`garmin-source` URL → the neutral Terento `fallback` image at
+`https://terento.app/assets/generic-garmin-watch.svg`. The fallback is
+presentation-only and does not indicate a model match or compatibility.
 
 This endpoint does not expose `supportStatus`, operator review decisions,
 transport profiles, write authorization, Unit IDs, or raw event data. The

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from .campaign_links import CAMPAIGN_SUGGESTIONS, MEDIUM_OPTIONS, SOURCE_OPTIONS
+from .asset_attribution import generic_fallback_image
 from .compatibility_status import (
     STATUS_PUBLIC_COPY,
     CompatibilityStatus,
@@ -473,7 +474,7 @@ def _admin_device_payload(
         elif source_image_url:
             image = {"url": source_image_url, "origin": "garmin-source", "status": "SOURCE"}
         else:
-            image = {"url": None, "origin": "missing", "status": "MISSING"}
+            image = generic_fallback_image()
         usb_identities = row.get("usb_identities") or []
         devices.append({
             "id": row.get("device_id"),
@@ -843,7 +844,7 @@ def _devices_script() -> str:
         const catalog = device.catalog;
         const mapLabel = device.mapCapable === true ? 'Yes' : device.mapCapable === false ? 'No' : 'Unknown';
         const image = device.image || {};
-        const assetLabel = image.origin === 'controlled' ? 'Controlled Terento asset' : image.origin === 'garmin-source' ? 'Garmin source image (model match)' : 'Missing';
+        const assetLabel = image.origin === 'controlled' ? 'Controlled Terento asset' : image.origin === 'garmin-source' ? 'Garmin source image (model match)' : image.origin === 'fallback' ? 'Generic Terento fallback' : 'Missing';
         const imageMarkup = image.url ? `<img class="device-detail-image" src="${escapeHtml(image.url)}" alt="">` : '';
         const usb = (device.usbIdentities || []).map((identity) => `VID ${identity.vendorId} · PID ${identity.productId}`).join(', ') || '—';
         dialogBody.innerHTML = `
@@ -882,7 +883,7 @@ def _devices_script() -> str:
               <div><dt>Last seen</dt><dd>${date(catalog.lastSeenAt)}</dd></div>
               <div><dt>New in latest sync</dt><dd>${catalog.newInLatestSync ? 'Yes' : 'No'}</dd></div>
               <div><dt>Image</dt><dd>${escapeHtml(assetLabel)}</dd></div>
-              <div><dt>Match source</dt><dd>${escapeHtml(image.origin === 'controlled' ? 'Approved catalog asset' : image.origin === 'garmin-source' ? 'Official Garmin product media URL for this exact catalog row' : 'No image URL stored for this row')}</dd></div>
+              <div><dt>Match source</dt><dd>${escapeHtml(image.origin === 'controlled' ? 'Approved catalog asset' : image.origin === 'garmin-source' ? 'Official Garmin product media URL for this exact catalog row' : image.origin === 'fallback' ? 'Neutral Terento fallback; no model-specific image available' : 'No image URL stored for this row')}</dd></div>
             </dl></section>
           </div>
           <section class="device-support-review" aria-labelledby="device-support-review-title">

--- a/backend/catalog-api/src/terento_catalog/asset_attribution.py
+++ b/backend/catalog-api/src/terento_catalog/asset_attribution.py
@@ -13,6 +13,7 @@ ASSET_SOURCE_TYPES = frozenset(
 OFFICIAL_PRODUCT_MEDIA = "OFFICIAL_PRODUCT_MEDIA"
 TERENTO_RENDER = "TERENTO_RENDER"
 GENERIC_FALLBACK = "GENERIC_FALLBACK"
+GENERIC_FALLBACK_IMAGE_URL = "https://terento.app/assets/generic-garmin-watch.svg"
 
 LEGAL_METADATA = {
     "manufacturerNotice": True,
@@ -76,4 +77,19 @@ def public_asset_source(row: dict[str, Any]) -> dict[str, Any] | None:
         "type": source_type,
         "brand": brand,
         "attributionRequired": attribution_required,
+    }
+
+
+def generic_fallback_image() -> dict[str, Any]:
+    """Return the stable, neutral image used when no model photo is available."""
+
+    return {
+        "url": GENERIC_FALLBACK_IMAGE_URL,
+        "origin": "fallback",
+        "status": "FALLBACK",
+        "source": {
+            "type": GENERIC_FALLBACK,
+            "brand": "Terento",
+            "attributionRequired": False,
+        },
     }

--- a/backend/catalog-api/src/terento_catalog/historical_devices.py
+++ b/backend/catalog-api/src/terento_catalog/historical_devices.py
@@ -14,7 +14,7 @@ import re
 import unicodedata
 
 
-HISTORICAL_REGISTRY_VERSION = 1
+HISTORICAL_REGISTRY_VERSION = 2
 REGISTRY_SOURCE_URL = "https://developer.garmin.com/connect-iq/compatible-devices/"
 GARMIN_CATEGORY_URL = "https://www.garmin.com/en-US/c/wearables-smartwatches/"
 
@@ -103,6 +103,60 @@ HISTORICAL_DEVICE_REGISTRY: tuple[HistoricalDeviceSpec, ...] = (
         family_id="garmin-forerunner",
         family_name="Forerunner",
         aliases=("forerunner 955",),
+    ),
+    # These families are retained because the native Map Manager registry
+    # recognizes them, even though Garmin no longer lists them in its current
+    # retail smartwatch category. Family-level records intentionally avoid
+    # guessing a discontinued size/display variant.
+    _spec(
+        "garmin-d2-mach-1", "D2 Mach 1", "d2 mach 1", "Historical", None,
+        family_id="garmin-d2", family_name="D2",
+    ),
+    _spec(
+        "garmin-descent-mk1", "Descent Mk1", "descent mk1", "Historical", None,
+        family_id="garmin-descent", family_name="Descent",
+    ),
+    _spec(
+        "garmin-descent-mk2", "Descent Mk2", "descent mk2", "Historical", None,
+        family_id="garmin-descent", family_name="Descent",
+    ),
+    _spec(
+        "garmin-enduro-2", "Enduro 2", "enduro 2", "Historical", None,
+        family_id="garmin-enduro", family_name="Enduro",
+    ),
+    _spec(
+        "garmin-epix-pro-gen-2", "epix Pro (Gen 2)", "epix pro gen 2", "Historical", None,
+        family_id="garmin-epix", family_name="epix",
+    ),
+    _spec("garmin-fenix-5x", "fēnix 5X", "fenix 5x", "Historical", None),
+    _spec("garmin-fenix-5-plus", "fēnix 5 Plus", "fenix 5 plus", "Historical", None),
+    _spec(
+        "garmin-forerunner-945", "Forerunner 945", "forerunner 945", "Historical", None,
+        family_id="garmin-forerunner", family_name="Forerunner",
+    ),
+    _spec(
+        "garmin-forerunner-965", "Forerunner 965", "forerunner 965", "Historical", None,
+        family_id="garmin-forerunner", family_name="Forerunner",
+    ),
+    _spec(
+        "garmin-quatix-6", "quatix 6", "quatix 6", "Historical", None,
+        family_id="garmin-quatix", family_name="quatix",
+    ),
+    _spec(
+        "garmin-quatix-7", "quatix 7", "quatix 7", "Historical", None,
+        family_id="garmin-quatix", family_name="quatix",
+    ),
+    _spec(
+        "garmin-tactix-charlie", "tactix Charlie", "tactix charlie", "Historical", None,
+        family_id="garmin-tactix", family_name="tactix",
+    ),
+    _spec(
+        "garmin-tactix-delta", "tactix Delta", "tactix delta", "Historical", None,
+        family_id="garmin-tactix", family_name="tactix",
+    ),
+    _spec(
+        "garmin-tactix-7", "tactix 7", "tactix 7", "Historical", None,
+        family_id="garmin-tactix", family_name="tactix",
     ),
 )
 

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -31,7 +31,7 @@ from .admin import (
     verify_password,
 )
 from .asset_storage import AssetStorage
-from .asset_attribution import public_asset_source
+from .asset_attribution import generic_fallback_image, public_asset_source
 from .catalog import build_catalog, catalog_etag, serialize_catalog
 from .db import Database
 from .device_catalog import (
@@ -531,6 +531,8 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     source_image_url = _official_source_image_url(row.get("source_image_url"))
                     if source_image_url:
                         image = {"url": source_image_url, "origin": "garmin-source", "status": "SOURCE"}
+                if image is None:
+                    image = generic_fallback_image()
                 models.append({
                     "model": row.get("model") or row.get("evidence_model"),
                     "canonicalModel": row.get("canonical_model") or row.get("evidence_model"),

--- a/backend/catalog-api/src/terento_catalog/migrations/020_historical_map_capable_registry.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/020_historical_map_capable_registry.sql
@@ -1,0 +1,63 @@
+-- Historical Garmin identities recognized by the shared native/server Map
+-- Manager capability registry. These records preserve evidence identity only;
+-- they never authorize a device write and are not collector-managed retail
+-- inventory.
+INSERT INTO device_family (id, manufacturer, name, canonical_name, source_url)
+VALUES
+    ('garmin-d2', 'Garmin', 'D2', 'd2', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-descent', 'Garmin', 'Descent', 'descent', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-enduro', 'Garmin', 'Enduro', 'enduro', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-quatix', 'Garmin', 'quatix', 'quatix', 'https://developer.garmin.com/connect-iq/compatible-devices/'),
+    ('garmin-tactix', 'Garmin', 'tactix', 'tactix', 'https://developer.garmin.com/connect-iq/compatible-devices/')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO device_model (
+    id, family_id, manufacturer, model, canonical_model, variant,
+    case_size_mm, display_type, product_url, source_url,
+    source_image_url, active, map_capable, support_status,
+    record_source, collector_managed
+)
+VALUES
+    ('garmin-d2-mach-1', 'garmin-d2', 'Garmin', 'D2 Mach 1', 'd2 mach 1', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-descent-mk1', 'garmin-descent', 'Garmin', 'Descent Mk1', 'descent mk1', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-descent-mk2', 'garmin-descent', 'Garmin', 'Descent Mk2', 'descent mk2', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-enduro-2', 'garmin-enduro', 'Garmin', 'Enduro 2', 'enduro 2', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-epix-pro-gen-2', 'garmin-epix', 'Garmin', 'epix Pro (Gen 2)', 'epix pro gen 2', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-5x', 'garmin-fenix', 'Garmin', 'fēnix 5X', 'fenix 5x', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-fenix-5-plus', 'garmin-fenix', 'Garmin', 'fēnix 5 Plus', 'fenix 5 plus', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-forerunner-945', 'garmin-forerunner', 'Garmin', 'Forerunner 945', 'forerunner 945', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-forerunner-965', 'garmin-forerunner', 'Garmin', 'Forerunner 965', 'forerunner 965', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-quatix-6', 'garmin-quatix', 'Garmin', 'quatix 6', 'quatix 6', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-quatix-7', 'garmin-quatix', 'Garmin', 'quatix 7', 'quatix 7', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-tactix-charlie', 'garmin-tactix', 'Garmin', 'tactix Charlie', 'tactix charlie', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-tactix-delta', 'garmin-tactix', 'Garmin', 'tactix Delta', 'tactix delta', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE),
+    ('garmin-tactix-7', 'garmin-tactix', 'Garmin', 'tactix 7', 'tactix 7', 'Historical', NULL, NULL,
+     'https://www.garmin.com/en-US/c/wearables-smartwatches/', 'https://developer.garmin.com/connect-iq/compatible-devices/',
+     NULL, TRUE, TRUE, 'NOT_EVALUATED', 'HISTORICAL_REVIEWED', FALSE)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/catalog-api/tests/test_admin_devices.py
+++ b/backend/catalog-api/tests/test_admin_devices.py
@@ -117,7 +117,8 @@ class AdminDevicesTests(unittest.TestCase):
         self.assertTrue(payload["devices"][2]["catalog"]["newInLatestSync"])
         self.assertIsNone(payload["devices"][1]["installationStats"]["lastSuccessfulAt"])
         self.assertFalse(payload["devices"][1]["mapCapable"])
-        self.assertEqual(payload["devices"][1]["image"]["origin"], "missing")
+        self.assertEqual(payload["devices"][1]["image"]["origin"], "fallback")
+        self.assertEqual(payload["devices"][1]["image"]["status"], "FALLBACK")
 
     def test_null_map_capable_is_classified_from_the_native_prefix_list(self) -> None:
         payload = _admin_device_payload(
@@ -219,6 +220,17 @@ class AdminDevicesTests(unittest.TestCase):
             )
         )
 
+    def test_missing_image_uses_neutral_fallback(self) -> None:
+        payload = _admin_device_payload(
+            [device_row(asset_status="MISSING", asset_url=None, source_image_url=None)],
+            None,
+        )
+        image = payload["devices"][0]["image"]
+        self.assertEqual(image["origin"], "fallback")
+        self.assertEqual(image["status"], "FALLBACK")
+        self.assertEqual(image["source"]["type"], "GENERIC_FALLBACK")
+        self.assertTrue(image["url"].endswith("/assets/generic-garmin-watch.svg"))
+
     def test_historical_sync_without_counts_is_not_presented_as_zero(self):
         payload = _admin_device_payload(
             [device_row(first_seen_collection_run_id=None)],
@@ -264,12 +276,13 @@ class AdminDevicesTests(unittest.TestCase):
             "Garmin devices", "Map-capable: Yes", "Map-capable: No",
             "Map-capable: Unknown", "Supported", "Unsupported", "Not evaluated",
             "Tested: Yes", "Tested: No", "Newest in database", "Most installs",
-            "Last tested", "Support decision", "Evidence status", "device-dialog", "device-thumb-placeholder", "admin-timezone",
+            "Last tested", "Support decision", "Evidence status", "device-dialog", "admin-timezone",
             "Automatic (browser)", "data-admin-timestamp", "TerentoAdminTime",
             "selected time zone",
         ):
             self.assertIn(value, body)
         self.assertNotIn("src='None'", body)
+        self.assertIn("generic-garmin-watch.svg", body)
         self.assertIn("does not change Evidence status or installation counts", body)
 
 

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -622,7 +622,9 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(document["schemaVersion"], 1)
         self.assertEqual(document["models"][1]["evidenceStatus"], "TESTED")
-        self.assertEqual(document["models"][1]["image"], None)
+        self.assertEqual(document["models"][1]["image"]["origin"], "fallback")
+        self.assertEqual(document["models"][1]["image"]["status"], "FALLBACK")
+        self.assertEqual(document["models"][1]["image"]["source"]["type"], "GENERIC_FALLBACK")
         self.assertNotIn("supportStatus", document["models"][1])
         self.assertNotIn("writeAuthorization", document["models"][1])
 

--- a/backend/catalog-api/tests/test_historical_devices.py
+++ b/backend/catalog-api/tests/test_historical_devices.py
@@ -3,9 +3,11 @@ import unittest
 
 from terento_catalog.historical_devices import (
     HISTORICAL_DEVICE_REGISTRY,
+    all_historical_device_specs,
     historical_device_for_event,
     historical_device_spec,
 )
+from terento_catalog.map_capability import classify_map_capable
 
 
 MIGRATION = (
@@ -15,6 +17,15 @@ MIGRATION = (
     / "migrations"
     / "016_historical_device_registry.sql"
 )
+EXPANDED_MIGRATION = MIGRATION.parent / "020_historical_map_capable_registry.sql"
+
+EXPECTED_MISSING_MAP_MODELS = {
+    "garmin-d2-mach-1", "garmin-descent-mk1", "garmin-descent-mk2",
+    "garmin-enduro-2", "garmin-epix-pro-gen-2", "garmin-fenix-5x",
+    "garmin-fenix-5-plus", "garmin-forerunner-945", "garmin-forerunner-965",
+    "garmin-quatix-6", "garmin-quatix-7", "garmin-tactix-charlie",
+    "garmin-tactix-delta", "garmin-tactix-7",
+}
 
 
 class HistoricalDeviceRegistryTests(unittest.TestCase):
@@ -37,9 +48,19 @@ class HistoricalDeviceRegistryTests(unittest.TestCase):
         self.assertEqual(spec.id, "garmin-fenix-7s-42")
 
     def test_registry_contains_reviewed_source_and_no_write_authorization(self):
-        self.assertGreaterEqual(len(HISTORICAL_DEVICE_REGISTRY), 8)
+        self.assertEqual(len(HISTORICAL_DEVICE_REGISTRY), 22)
         self.assertTrue(all(spec.source_url.startswith("https://") for spec in HISTORICAL_DEVICE_REGISTRY))
         self.assertFalse(hasattr(historical_device_spec("garmin-fenix-7-47"), "write_profile"))
+
+    def test_registry_covers_missing_map_installer_families(self):
+        specs = {spec.id: spec for spec in all_historical_device_specs()}
+        self.assertTrue(EXPECTED_MISSING_MAP_MODELS <= specs.keys())
+        for device_id in EXPECTED_MISSING_MAP_MODELS:
+            spec = specs[device_id]
+            self.assertTrue(classify_map_capable(spec.canonical_model))
+            resolved = historical_device_for_event({"model": spec.model})
+            self.assertIsNotNone(resolved)
+            self.assertEqual(resolved.id, device_id)
 
     def test_migration_seeds_history_and_keeps_it_out_of_collector_deactivation(self):
         sql = MIGRATION.read_text(encoding="utf-8")
@@ -55,6 +76,14 @@ class HistoricalDeviceRegistryTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("AND collector_managed = TRUE", db_source)
         self.assertIn("WHERE collector_managed = TRUE", db_source)
+
+    def test_expanded_migration_seeds_only_reviewed_map_capable_history(self):
+        sql = EXPANDED_MIGRATION.read_text(encoding="utf-8")
+        for device_id in EXPECTED_MISSING_MAP_MODELS:
+            self.assertIn(device_id, sql)
+        self.assertIn("map_capable, support_status", sql)
+        self.assertIn("'HISTORICAL_REVIEWED', FALSE", sql)
+        self.assertIn("never authorize a device write", sql)
 
 
 if __name__ == "__main__":

--- a/site/assets/generic-garmin-watch.svg
+++ b/site/assets/generic-garmin-watch.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 320" role="img" aria-labelledby="title desc">
+  <title id="title">Generic smartwatch illustration</title>
+  <desc id="desc">A neutral Terento illustration of a smartwatch showing a map.</desc>
+  <rect width="320" height="320" rx="48" fill="#eef4f0"/>
+  <path d="M118 35h84l10 54h-104zM118 285h84l10-54h-104z" fill="#c7d8d0"/>
+  <rect x="75" y="66" width="170" height="188" rx="47" fill="#23453f"/>
+  <rect x="91" y="82" width="138" height="156" rx="34" fill="#f8fbf8"/>
+  <path d="M111 197c24-20 35-35 48-34 13 1 20 20 34 12 10-6 12-23 24-31" fill="none" stroke="#6c9d8a" stroke-width="9" stroke-linecap="round"/>
+  <path d="M108 126h104M108 151h42" fill="none" stroke="#c7d8d0" stroke-width="7" stroke-linecap="round"/>
+  <circle cx="196" cy="175" r="10" fill="#e08b4d"/>
+</svg>

--- a/site/compatibility/compatibility.js
+++ b/site/compatibility/compatibility.js
@@ -2,6 +2,7 @@
   const data = globalThis.TerentoCompatibilityData;
   if (!data) throw new Error("compatibility_data_unavailable");
   const API_ORIGIN = "https://api.terento.app";
+  const FALLBACK_IMAGE_URL = "/assets/generic-garmin-watch.svg";
   const isLocalPreview = ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
   const previewStats = [
     {
@@ -186,9 +187,8 @@
     const lastTestedMarkup = lastTested
       ? `<p class="watch-card-meta">Last tested ${escapeHtml(lastTested)}</p>`
       : "";
-    const imageMarkup = row.imageUrl
-      ? `<img data-remote-src="${escapeHtml(row.imageUrl)}" alt="${escapeHtml(row.model)}" loading="lazy">`
-      : `<div class="watch-image-placeholder" role="img" aria-label="Image unavailable">Image unavailable</div>`;
+    const imageUrl = row.imageUrl || FALLBACK_IMAGE_URL;
+    const imageMarkup = `<img data-remote-src="${escapeHtml(imageUrl)}" alt="${escapeHtml(row.model)}" loading="lazy">`;
     return `
       <article class="watch-card">
         <div class="watch-card-image">
@@ -265,6 +265,7 @@
         ...row,
         family: canonicalFamilyKey(row.family || row.familyName),
         variants: [exactVariantLabel(row)].filter(Boolean),
+        imageUrl: row.imageUrl || FALLBACK_IMAGE_URL,
       }))
       .filter((row) => row.status);
   }


### PR DESCRIPTION
## Summary
- add 14 historical Garmin Map Installer identities without changing the retail device API
- keep historical rows active and collector-independent
- use the neutral Terento fallback image in admin and additive public compatibility cards
- add regression coverage for registry resolution, fallback metadata, and existing site/API boundaries

## Validation
- backend: 101 tests passed
- frontend compatibility tests and JavaScript syntax passed
- native Map Installer registry: 10 tests passed

Migration 020 is additive and will be applied by the existing catalog deploy workflow after merge.