### PR TITLE
Refresh compatibility page script cache

### DIFF
--- a/site/compatibility/index.html
+++ b/site/compatibility/index.html
@@ -147,6 +147,6 @@
     </footer>
 
     <script defer src="/compatibility/compatibility-data.js?v=20260826-1"></script>
-    <script defer src="/compatibility/compatibility.js?v=20260826-3"></script>
+    <script defer src="/compatibility/compatibility.js?v=20260826-4"></script>
   </body>
 </html>


### PR DESCRIPTION
The fallback image handling is deployed in source and the new fallback asset is live, but Cloudflare retained the older cached compatibility script URL. This changes only the compatibility script query version so browsers fetch the deployed fallback logic.

Validation: public site deploy #32971935124 and catalog API deploy #32971935129 passed; this PR is required because beta is PR-only.