### PR TITLE
Fix catalog status migration aggregate type

### DIFF
--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -58,6 +58,11 @@ without erasing the old reports. The old events remain in the database and
 are visible under `Resolved / historical diagnostics`; they do not contribute
 to active failure counts, rates, or public compatibility projections.
 
+Migration `021_canonical_admin_semantics.sql` keeps its SQL
+compatibility-status classifier parameter as `BIGINT`, matching PostgreSQL's
+`count(*)` aggregate type, so the derived view can be rebuilt during a forward
+deployment.
+
 ## Asset review and publication
 
 Asset work is explicit and non-destructive. A candidate is prepared into

--- a/backend/catalog-api/src/terento_catalog/migrations/021_canonical_admin_semantics.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/021_canonical_admin_semantics.sql
@@ -101,7 +101,9 @@ SET map_capable = CASE
 END
 WHERE map_capable IS NULL;
 
-CREATE OR REPLACE FUNCTION terento_compatibility_status(successful_count INTEGER, recognized BOOLEAN)
+-- PostgreSQL count(*) is BIGINT. Keep the function parameter aligned with the
+-- aggregate type so the view can call it without an implicit narrowing cast.
+CREATE OR REPLACE FUNCTION terento_compatibility_status(successful_count BIGINT, recognized BOOLEAN)
 RETURNS TEXT
 LANGUAGE SQL
 IMMUTABLE

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -192,6 +192,10 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("operation_stats AS (", migration)
         self.assertIn("count(*) FILTER (WHERE o.write_started)", migration)
         self.assertIn("terento_compatibility_status(e.successful_install_count, dm.map_capable IS TRUE)", migration)
+        self.assertIn(
+            "terento_compatibility_status(successful_count BIGINT, recognized BOOLEAN)",
+            migration,
+        )
 
     def test_admin_vocabulary_and_accessible_sticky_tables_are_canonical(self):
         admin_source = (ROOT / "src" / "terento_catalog" / "admin.py").read_text(encoding="utf-8")


### PR DESCRIPTION
The catalog API deployment built the image and uploaded it to the VPS, but migration 021 failed because PostgreSQL count(*) returns BIGINT while the SQL classifier accepted INTEGER. Align the classifier parameter with the aggregate type and add a regression assertion. Existing public/native/device API contracts are unchanged. Full backend suite: 115 tests passing.