### PR TITLE
Bust fallback image cache key

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -181,7 +181,8 @@ current retail category. The response contains exact identity, evidence
 counts, `evidenceStatus`, family/variant display metadata, and an `image`
 object. `image` follows controlled Terento asset → allowlisted Garmin
 `garmin-source` URL → the neutral Terento `fallback` image at
-`https://terento.app/assets/generic-garmin-watch.png`. The fallback is
+`https://terento.app/assets/generic-garmin-watch.png` (with a cache-busting
+version query in emitted URLs). The fallback is
 presentation-only and does not indicate a model match or compatibility.
 
 This endpoint does not expose `supportStatus`, operator review decisions,

--- a/backend/catalog-api/src/terento_catalog/asset_attribution.py
+++ b/backend/catalog-api/src/terento_catalog/asset_attribution.py
@@ -13,7 +13,7 @@ ASSET_SOURCE_TYPES = frozenset(
 OFFICIAL_PRODUCT_MEDIA = "OFFICIAL_PRODUCT_MEDIA"
 TERENTO_RENDER = "TERENTO_RENDER"
 GENERIC_FALLBACK = "GENERIC_FALLBACK"
-GENERIC_FALLBACK_IMAGE_URL = "https://terento.app/assets/generic-garmin-watch.png"
+GENERIC_FALLBACK_IMAGE_URL = "https://terento.app/assets/generic-garmin-watch.png?v=20260826-1"
 
 LEGAL_METADATA = {
     "manufacturerNotice": True,

--- a/backend/catalog-api/tests/test_admin_devices.py
+++ b/backend/catalog-api/tests/test_admin_devices.py
@@ -234,7 +234,8 @@ class AdminDevicesTests(unittest.TestCase):
         self.assertEqual(image["origin"], "fallback")
         self.assertEqual(image["status"], "FALLBACK")
         self.assertEqual(image["source"]["type"], "GENERIC_FALLBACK")
-        self.assertTrue(image["url"].endswith("/assets/generic-garmin-watch.png"))
+        self.assertTrue(image["url"].startswith("https://terento.app/assets/generic-garmin-watch.png?"))
+        self.assertIn("v=20260826-1", image["url"])
 
     def test_historical_sync_without_counts_is_not_presented_as_zero(self):
         payload = _admin_device_payload(

--- a/site/compatibility/compatibility.js
+++ b/site/compatibility/compatibility.js
@@ -2,7 +2,7 @@
   const data = globalThis.TerentoCompatibilityData;
   if (!data) throw new Error("compatibility_data_unavailable");
   const API_ORIGIN = "https://api.terento.app";
-  const FALLBACK_IMAGE_URL = "/assets/generic-garmin-watch.png";
+  const FALLBACK_IMAGE_URL = "/assets/generic-garmin-watch.png?v=20260826-1";
   const isLocalPreview = ["localhost", "127.0.0.1", "::1"].includes(window.location.hostname);
   const previewStats = [
     {


### PR DESCRIPTION
The new fallback PNG is present on the VPS, but Cloudflare had a cached 404 for the previously absent path. Add a version query to emitted fallback image URLs in the public compatibility page and catalog API, and update the image regression assertion. Existing public/native/device API contracts and image semantics are unchanged. Full backend suite: 115 tests passing; compatibility web tests passing.