### PR TITLE
Add explicit public compatibility review

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -140,6 +140,16 @@ alias retained) updates only `device_model.support_status` and records an
 audit entry. It cannot change evidence events, operation-level install counts,
 compatibility status, or any native device write authorization.
 
+The detail dialog also exposes the independent `Public compatibility` review.
+An exact catalog record becomes eligible only after it has recognized,
+map-capable compatibility evidence. CSRF-protected
+`POST /admin/devices/public-compatibility` accepts an explicit `PUBLISH` or
+`UNPUBLISH` action. Publishing sets the exact-identity review to `APPROVED`
+and enables public statistics; withdrawing returns it to `PENDING` and
+disables public statistics. Every change is audited. This action does not
+change evidence events, calculated status, installation counts, installation
+authorization, or any existing public/native/device API field.
+
 `POST /admin/diagnostics/resolve` and `/admin/diagnostics/reopen` change only
 the retained diagnostic lifecycle, while `POST /admin/diagnostics/identity`
 assigns or leaves an exact canonical Garmin record and writes an identity audit

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1123,6 +1123,15 @@ def _admin_device_payload(
         authorization_label, _, authorization_code = _admin_installation_authorization(
             row.get("support_status")
         )
+        public_identity = str(row.get("public_compatibility_identity") or "").strip()
+        public_review_status = str(row.get("public_review_status") or "PENDING").upper()
+        public_enabled = bool(row.get("public_statistics_enabled", False))
+        public_eligible = bool(public_identity and evidence_status)
+        public_published = bool(
+            public_eligible
+            and public_review_status == "APPROVED"
+            and public_enabled
+        )
         if asset_url:
             image = {"url": asset_url, "origin": "controlled", "status": "AVAILABLE"}
         elif source_image_url:
@@ -1148,6 +1157,14 @@ def _admin_device_payload(
             "installationAuthorization": authorization_code,
             "installationAuthorizationLabel": authorization_label,
             "evidenceStatus": evidence_status.value if evidence_status else None,
+            "publicCompatibility": {
+                "eligible": public_eligible,
+                "published": public_published,
+                "reviewStatus": public_review_status,
+                "statisticsEnabled": public_enabled,
+                "compatibilityIdentity": public_identity or None,
+                "displayName": row.get("public_display_name"),
+            },
             "recordSource": str(row.get("record_source") or "CURRENT_RETAIL").upper(),
             "collectorManaged": bool(row.get("collector_managed", True)),
             "asset": {"status": "AVAILABLE", "url": asset_url} if asset_url else {"status": "MISSING"},
@@ -1481,6 +1498,11 @@ def _devices_script() -> str:
       const statusBadge = (value) => value ? `<span class="status-badge status-${String(value).toLowerCase()}">${escapeHtml(evidenceLabel(value))}</span>` : '<span class="status-badge status-unavailable">Unavailable</span>';
       const mapBadge = (label, value) => `<span class="admin-state admin-state-map-${value}">${escapeHtml(label)}</span>`;
       const authorizationBadge = (value) => `<span class="admin-state admin-state-authorization-${String(value || 'PENDING').toLowerCase()}">${escapeHtml(authorizationLabel(value))}</span>`;
+      const publicationBadge = (publication) => publication?.published
+        ? '<span class="admin-state admin-state-publication-published">Published</span>'
+        : publication?.eligible
+          ? '<span class="admin-state admin-state-publication-pending">Approval required</span>'
+          : '<span class="admin-state admin-state-publication-unavailable">Not eligible</span>';
       const deviceSearch = (device) => [device.id, device.model, device.canonicalModel, device.family, device.familyName, device.variant, device.caseSizeMm, device.partNumber, device.displayType].filter(Boolean).join(' ').toLocaleLowerCase();
       const textCompare = (a, b) => String(a || '').localeCompare(String(b || ''), undefined, {sensitivity: 'base', numeric: true});
       const statusOrder = {unavailable: 0, TESTING: 1, TESTED: 2, SUPPORTED: 3, VERIFIED: 4};
@@ -1533,6 +1555,7 @@ def _devices_script() -> str:
         lastFocused = document.activeElement;
         const stats = device.installationStats;
         const catalog = device.catalog;
+        const publication = device.publicCompatibility || {};
         const mapLabel = device.mapCapable === true ? 'Yes' : device.mapCapable === false ? 'No' : 'Unknown';
         const image = device.image || {};
         const imageSourceLabel = image.origin === 'controlled' ? 'Terento · approved asset' : image.origin === 'garmin-source' ? 'Garmin · exact model' : image.origin === 'fallback' ? 'Terento · neutral fallback' : 'Not available';
@@ -1558,6 +1581,7 @@ def _devices_script() -> str:
             </dl></section>
             <section><p class="detail-kicker">Compatibility evidence</p><dl>
               <div><dt>Compatibility status</dt><dd class="detail-status-value">${escapeHtml(evidenceLabel(device.evidenceStatus))}</dd></div>
+              <div><dt>Public listing</dt><dd>${publicationBadge(publication)}</dd></div>
               <div><dt>Attempts</dt><dd>${stats.attempts}</dd></div>
               <div><dt>Successful</dt><dd>${stats.successful}</dd></div>
               <div><dt>Failed</dt><dd>${stats.failed}</dd></div>
@@ -1580,6 +1604,22 @@ def _devices_script() -> str:
               <label>Note <span class="optional-label">Optional</span><textarea name="note" rows="2" placeholder="Why this authorization changed"></textarea></label>
               <div class="dialog-actions"><button type="button" class="secondary-button" data-authorization-cancel>Cancel</button><button type="submit" disabled>Save</button></div>
             </form>
+          </section>
+          <section class="device-public-review" aria-labelledby="device-public-review-title">
+            <p class="detail-kicker" id="device-public-review-title">Public compatibility</p>
+            <div class="authorization-current"><span>Current</span><span class="authorization-current-value">${publicationBadge(publication)}</span></div>
+            <p class="review-help">${publication.published
+              ? `Visible on terento.app/compatibility/ with the evidence status ${escapeHtml(evidenceLabel(device.evidenceStatus))}.`
+              : publication.eligible
+                ? `Evidence is ready. Operator approval is required before this exact model is listed publicly.`
+                : `Exact recognized map-capable evidence is required before publication.`}</p>
+            ${publication.eligible ? `<form method="post" action="/admin/devices/public-compatibility">
+              <input type="hidden" name="csrf_token" value="${escapeHtml(terentoAdminDevices.csrfToken)}">
+              <input type="hidden" name="device_id" value="${escapeHtml(device.id)}">
+              <input type="hidden" name="publication_action" value="${publication.published ? 'UNPUBLISH' : 'PUBLISH'}">
+              <label>Note <span class="optional-label">Optional</span><textarea name="note" rows="2" placeholder="Why this public review changed"></textarea></label>
+              <div class="dialog-actions"><button type="submit" class="${publication.published ? 'secondary-button' : ''}">${publication.published ? 'Remove from public compatibility' : 'Approve and publish'}</button></div>
+            </form>` : ''}
           </section>
           <details class="device-catalog-details"><summary>Catalog details</summary><dl>
             <div><dt>Active</dt><dd>${device.active ? 'Yes' : 'No'}</dd></div>
@@ -2234,9 +2274,9 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 .device-thumb-placeholder:after{content:"";position:absolute;left:15px;top:13px;width:6px;height:2px;border-radius:2px;background:var(--sky);box-shadow:0 8px 0 var(--sky)}
 .new-badge{display:inline-flex;align-items:center;min-height:20px;padding:2px 7px;border:1px solid color-mix(in srgb,var(--lichen) 65%,var(--border));border-radius:999px;background:#EEF2E9;color:#52624C;font-size:10px;font-weight:750;letter-spacing:.06em;text-transform:uppercase}
 .admin-state{display:inline-flex;align-items:center;min-height:26px;padding:5px 9px;border:1px solid transparent;border-radius:999px;font-size:11px;font-weight:750;line-height:1;white-space:nowrap}
-.admin-state-map-yes,.admin-state-authorization-approved{background:#E7EEE2;border-color:#B4C6A7;color:#4B6142}
+.admin-state-map-yes,.admin-state-authorization-approved,.admin-state-publication-published{background:#E7EEE2;border-color:#B4C6A7;color:#4B6142}
 .admin-state-map-no,.admin-state-authorization-blocked{background:#F0E9E5;border-color:#D6BDB2;color:#7A493D}
-.admin-state-map-unknown,.admin-state-authorization-pending{background:var(--surface-muted);border-color:var(--border);color:var(--secondary)}
+.admin-state-map-unknown,.admin-state-authorization-pending,.admin-state-publication-pending,.admin-state-publication-unavailable{background:var(--surface-muted);border-color:var(--border);color:var(--secondary)}
 .numeric{font-variant-numeric:tabular-nums}
 .device-pagination{display:flex;align-items:center;justify-content:center;gap:16px;margin:14px 0 0;color:var(--secondary);font-size:13px}
 .device-pagination button,.dialog-close{min-height:34px;padding:7px 11px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--interactive);font-weight:700}
@@ -2269,14 +2309,15 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 .technical-value{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px!important}
 .device-product-link{margin:14px 0 0;padding-top:12px;border-top:1px solid var(--border);font-size:13px;font-weight:700}
 .device-product-link a{color:var(--interactive);text-underline-offset:3px}
-.device-support-review{margin-top:18px;padding-top:14px;border-top:1px solid var(--border)}
-.device-support-review form{display:grid;grid-template-columns:minmax(150px,.75fr) minmax(0,1.25fr);align-items:end;gap:10px 12px;margin-top:10px}
+.device-support-review,.device-public-review{margin-top:18px;padding-top:14px;border-top:1px solid var(--border)}
+.device-support-review form,.device-public-review form{display:grid;grid-template-columns:minmax(150px,.75fr) minmax(0,1.25fr);align-items:end;gap:10px 12px;margin-top:10px}
 .authorization-current{display:flex;align-items:center;gap:10px;margin:0;padding:8px 10px;background:var(--surface-muted);border-radius:8px;color:var(--secondary);font-size:12px}
 .authorization-current-value{margin-right:auto}
-.device-support-review label{display:block;color:var(--secondary);font-size:12px;font-weight:650}
-.device-support-review select,.device-support-review input,.device-support-review textarea,.admin-action-dialog select,.admin-action-dialog input,.admin-action-dialog textarea{display:block;width:100%;margin-top:5px}
-.device-support-review textarea{min-height:64px}
-.device-support-review .dialog-actions{grid-column:1/-1;margin-top:0}
+.device-support-review label,.device-public-review label{display:block;color:var(--secondary);font-size:12px;font-weight:650}
+.device-support-review select,.device-support-review input,.device-support-review textarea,.device-public-review input,.device-public-review textarea,.admin-action-dialog select,.admin-action-dialog input,.admin-action-dialog textarea{display:block;width:100%;margin-top:5px}
+.device-support-review textarea,.device-public-review textarea{min-height:64px}
+.device-support-review .dialog-actions,.device-public-review .dialog-actions{grid-column:1/-1;margin-top:0}
+.review-help{margin:8px 0 0;color:var(--secondary);font-size:12px;line-height:1.45}
 .secondary-button{min-height:32px;padding:6px 10px;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--interactive);font-size:12px;font-weight:700}
 .secondary-button:hover{border-color:var(--interactive);background:var(--success-bg)}
 .admin-action-dialog{width:min(520px,calc(100% - 32px));padding:22px;border:0;border-radius:14px;background:var(--surface);color:var(--graphite);box-shadow:0 24px 80px rgba(34,42,43,.24)}

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -425,6 +425,123 @@ class Database:
                 )
         return True
 
+    def update_public_compatibility_review(
+        self,
+        device_id: str,
+        *,
+        action: str,
+        admin_user_id: int | None = None,
+        note: str | None = None,
+    ) -> bool:
+        """Publish or withdraw one exact device's evidence projection.
+
+        This operator review changes only the legacy public-review gate. It
+        never changes evidence events, calculated status, install counts, or
+        device installation authorization.
+        """
+        normalized_action = action.strip().upper()
+        if normalized_action not in {"PUBLISH", "UNPUBLISH"}:
+            raise ValueError("unsupported public compatibility review action")
+        note = (note or "").strip() or None
+        with self.connection() as connection:
+            device = connection.execute(
+                """
+                SELECT id, model, variant
+                FROM device_model
+                WHERE id = %s AND manufacturer = 'Garmin'
+                FOR UPDATE
+                """,
+                (device_id,),
+            ).fetchone()
+            if device is None:
+                return False
+            statistics = connection.execute(
+                """
+                SELECT compatibility_identity, calculated_status
+                FROM compatibility_model_statistics
+                WHERE canonical_device_model_id = %s
+                ORDER BY last_evidence DESC NULLS LAST
+                LIMIT 1
+                """,
+                (device_id,),
+            ).fetchone()
+            if statistics is None:
+                if normalized_action == "PUBLISH":
+                    raise ValueError("compatibility evidence is required before publication")
+                return True
+            compatibility_identity = str(statistics["compatibility_identity"])
+            if normalized_action == "PUBLISH" and str(statistics["calculated_status"] or "") not in {
+                "TESTING", "TESTED", "SUPPORTED", "VERIFIED",
+            }:
+                raise ValueError("recognized map-capable evidence is required before publication")
+            public_display_name = (
+                f"{device['model']} · {device['variant']}"
+                if device["variant"] else str(device["model"])
+            )
+            review = connection.execute(
+                """
+                SELECT model, review_status, public_statistics_enabled, public_display_name
+                FROM compatibility_model_review
+                WHERE COALESCE(NULLIF(identity_key, ''), model) = %s
+                FOR UPDATE
+                """,
+                (compatibility_identity,),
+            ).fetchone()
+            new_review_status = "APPROVED" if normalized_action == "PUBLISH" else "PENDING"
+            new_enabled = normalized_action == "PUBLISH"
+            previous_status = str(review["review_status"]) if review else None
+            previous_enabled = bool(review["public_statistics_enabled"]) if review else None
+            changed = (
+                review is None
+                or previous_status != new_review_status
+                or previous_enabled != new_enabled
+                or str(review["public_display_name"] or "") != public_display_name
+            )
+            if review is None:
+                connection.execute(
+                    """
+                    INSERT INTO compatibility_model_review (
+                        model, identity_key, review_status,
+                        public_statistics_enabled, public_display_name, updated_at
+                    ) VALUES (%s, %s, %s, %s, %s, now())
+                    """,
+                    (
+                        compatibility_identity, compatibility_identity,
+                        new_review_status, new_enabled, public_display_name,
+                    ),
+                )
+            elif changed:
+                connection.execute(
+                    """
+                    UPDATE compatibility_model_review
+                    SET review_status = %s,
+                        public_statistics_enabled = %s,
+                        public_display_name = %s,
+                        updated_at = now()
+                    WHERE model = %s
+                    """,
+                    (new_review_status, new_enabled, public_display_name, review["model"]),
+                )
+            if changed:
+                connection.execute(
+                    """
+                    INSERT INTO public_compatibility_review_audit (
+                        device_model_id, compatibility_identity,
+                        previous_review_status, new_review_status,
+                        previous_public_statistics_enabled,
+                        new_public_statistics_enabled,
+                        public_display_name, note, changed_by
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        device_id, compatibility_identity,
+                        previous_status, new_review_status,
+                        previous_enabled, new_enabled,
+                        public_display_name, note, admin_user_id,
+                    ),
+                )
+        return True
+
     def update_diagnostic_lifecycle(
         self,
         operation_key: str,
@@ -1121,6 +1238,10 @@ class Database:
                 evidence.first_success,
                 evidence.last_success,
                 evidence.last_evidence,
+                public_review.compatibility_identity AS public_compatibility_identity,
+                public_review.review_status AS public_review_status,
+                COALESCE(public_review.public_statistics_enabled, false) AS public_statistics_enabled,
+                public_review.public_display_name,
                 latest.id AS latest_successful_sync_id,
                 latest.started_at AS latest_successful_sync_started_at,
                 latest.finished_at AS latest_successful_sync_finished_at,
@@ -1173,6 +1294,15 @@ class Database:
                     GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
                 ) AS o
             ) AS evidence ON TRUE
+            LEFT JOIN LATERAL (
+                SELECT s.compatibility_identity, s.review_status,
+                       s.public_statistics_enabled, s.public_display_name,
+                       s.last_evidence
+                FROM compatibility_model_statistics AS s
+                WHERE s.canonical_device_model_id = dm.id
+                ORDER BY s.last_evidence DESC NULLS LAST
+                LIMIT 1
+            ) AS public_review ON TRUE
             LEFT JOIN LATERAL (
                 SELECT r.*
                 FROM device_collection_run AS r

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -178,6 +178,21 @@ class CatalogService:
             note=note,
         )
 
+    def update_public_compatibility_review(
+        self,
+        device_id: str,
+        *,
+        action: str,
+        admin_user_id: int | None,
+        note: str | None = None,
+    ) -> bool:
+        return self.database.update_public_compatibility_review(
+            device_id,
+            action=action,
+            admin_user_id=admin_user_id,
+            note=note,
+        )
+
     def admin_is_configured(self) -> bool:
         return self.database.admin_user_count() > 0
 
@@ -528,6 +543,26 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                         return
                 except ValueError:
                     self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_installation_authorization"}, send_body=True, cache_control="no-store")
+                    return
+                self._redirect("/admin/devices", send_body=True)
+                return
+            if request_path == "/admin/devices/public-compatibility":
+                try:
+                    device_id = form.get("device_id", "").strip()
+                    action = form.get("publication_action", "").strip().upper()
+                    if not device_id or action not in {"PUBLISH", "UNPUBLISH"}:
+                        raise ValueError("invalid public compatibility review")
+                    updated = service.update_public_compatibility_review(
+                        device_id,
+                        action=action,
+                        admin_user_id=int(session["id"]),
+                        note=form.get("note", "").strip() or None,
+                    )
+                    if not updated:
+                        self._send_json(HTTPStatus.NOT_FOUND, {"error": "device_not_found"}, send_body=True, cache_control="no-store")
+                        return
+                except ValueError:
+                    self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_public_compatibility_review"}, send_body=True, cache_control="no-store")
                     return
                 self._redirect("/admin/devices", send_body=True)
                 return

--- a/backend/catalog-api/src/terento_catalog/migrations/023_public_compatibility_review_audit.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/023_public_compatibility_review_audit.sql
@@ -1,0 +1,17 @@
+CREATE TABLE public_compatibility_review_audit (
+    id BIGSERIAL PRIMARY KEY,
+    device_model_id TEXT NOT NULL REFERENCES device_model(id) ON DELETE RESTRICT,
+    compatibility_identity TEXT NOT NULL,
+    previous_review_status TEXT,
+    new_review_status TEXT NOT NULL,
+    previous_public_statistics_enabled BOOLEAN,
+    new_public_statistics_enabled BOOLEAN NOT NULL,
+    public_display_name TEXT NOT NULL,
+    note TEXT,
+    changed_by BIGINT REFERENCES admin_user(id) ON DELETE SET NULL,
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (new_review_status IN ('PENDING', 'APPROVED', 'REJECTED'))
+);
+
+CREATE INDEX public_compatibility_review_audit_device_idx
+    ON public_compatibility_review_audit(device_model_id, changed_at DESC);

--- a/backend/catalog-api/tests/test_admin_devices.py
+++ b/backend/catalog-api/tests/test_admin_devices.py
@@ -41,6 +41,10 @@ def device_row(**changes):
         "first_seen_collection_run_id": 7,
         "last_seen_collection_run_id": 7,
         "usb_identities": [{"vendorId": 2334, "productId": 20920}],
+        "public_compatibility_identity": "fēnix 8 · 47 mm AMOLED",
+        "public_review_status": "PENDING",
+        "public_statistics_enabled": False,
+        "public_display_name": None,
     }
     row.update(changes)
     return row
@@ -182,6 +186,41 @@ class AdminDevicesTests(unittest.TestCase):
         self.assertEqual(device["evidenceStatus"], "TESTED")
         self.assertEqual(device["installationStats"]["successful"], 1)
 
+    def test_public_compatibility_review_is_separate_and_exact(self) -> None:
+        pending = _admin_device_payload([device_row()], None)["devices"][0]
+        self.assertTrue(pending["publicCompatibility"]["eligible"])
+        self.assertFalse(pending["publicCompatibility"]["published"])
+        self.assertEqual(pending["publicCompatibility"]["reviewStatus"], "PENDING")
+
+        published = _admin_device_payload(
+            [device_row(
+                public_review_status="APPROVED",
+                public_statistics_enabled=True,
+                public_display_name="fēnix 8 · 47 mm, AMOLED",
+            )],
+            None,
+        )["devices"][0]
+        self.assertTrue(published["publicCompatibility"]["published"])
+        self.assertEqual(
+            published["publicCompatibility"]["compatibilityIdentity"],
+            "fēnix 8 · 47 mm AMOLED",
+        )
+
+        no_evidence = _admin_device_payload(
+            [device_row(
+                attempted_install_count=0,
+                successful_install_count=0,
+                failed_install_count=0,
+                first_success=None,
+                last_success=None,
+                last_evidence=None,
+                public_compatibility_identity=None,
+            )],
+            None,
+        )["devices"][0]
+        self.assertFalse(no_evidence["publicCompatibility"]["eligible"])
+        self.assertFalse(no_evidence["publicCompatibility"]["published"])
+
     def test_garmin_source_image_is_used_when_controlled_asset_is_missing(self) -> None:
         source = "https://res.garmin.com/en/products/010-02905-10/v/cf-lg.jpg"
         payload = _admin_device_payload(
@@ -292,6 +331,9 @@ class AdminDevicesTests(unittest.TestCase):
             "data-device-sort=\"authorization\"", "data-device-sort=\"status\"",
             "data-device-sort=\"attempts\"", "data-device-sort=\"success\"", "data-device-sort=\"evidence\"",
             "aria-sort=\"ascending\"", "Catalog metadata only", "device-catalog-id", "detail-status-value",
+            "Public compatibility", "Public listing", "Approve and publish",
+            "/admin/devices/public-compatibility", "publication_action",
+            "Operator approval is required before this exact model is listed publicly",
         ):
             self.assertIn(value, body)
         table_header = body[body.index("<thead>"):body.index("</thead>")]

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -27,6 +27,7 @@ from terento_catalog.db import Database
 ROOT = Path(__file__).resolve().parents[1]
 MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "021_canonical_admin_semantics.sql"
 IDENTITY_STATE_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "022_canonical_identity_state_consistency.sql"
+PUBLIC_REVIEW_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "023_public_compatibility_review_audit.sql"
 
 
 class RecordingResult:
@@ -42,11 +43,14 @@ class RecordingResult:
 
 
 class RecordingDatabase(Database):
-    def __init__(self, *, diagnostic_rows=None, identity_rows=None, canonical_row=None):
+    def __init__(self, *, diagnostic_rows=None, identity_rows=None, canonical_row=None,
+                 statistics_row=None, public_review_row=None):
         super().__init__("unused")
         self.diagnostic_rows = diagnostic_rows or []
         self.identity_rows = identity_rows or []
         self.canonical_row = canonical_row
+        self.statistics_row = statistics_row
+        self.public_review_row = public_review_row
         self.calls = []
 
     @contextmanager
@@ -62,6 +66,10 @@ class RecordingDatabase(Database):
                     return RecordingResult(row=database.canonical_row)
                 if "SELECT event_id, compatibility_identity, canonical_device_model_id" in query:
                     return RecordingResult(rows=database.identity_rows)
+                if "SELECT compatibility_identity, calculated_status" in query:
+                    return RecordingResult(row=database.statistics_row)
+                if "FROM compatibility_model_review" in query:
+                    return RecordingResult(row=database.public_review_row)
                 return RecordingResult()
 
         yield Connection()
@@ -123,6 +131,65 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("installation authorization", source)
         self.assertNotIn("compatibility_evidence_event", source)
         self.assertIn("device_authorization_audit", source)
+
+    def test_public_compatibility_review_is_explicit_audited_and_does_not_change_evidence(self):
+        database = RecordingDatabase(
+            canonical_row={
+                "id": "garmin-fenix-8-pro-51-amoled",
+                "model": "fēnix 8 Pro",
+                "variant": "51 mm, AMOLED",
+            },
+            statistics_row={
+                "compatibility_identity": "fēnix 8 Pro · 51 mm",
+                "calculated_status": "TESTED",
+            },
+        )
+        self.assertTrue(database.update_public_compatibility_review(
+            "garmin-fenix-8-pro-51-amoled",
+            action="PUBLISH",
+            admin_user_id=7,
+            note="Exact model reviewed",
+        ))
+        review_insert = next(
+            (query, params) for query, params in database.calls
+            if "INSERT INTO compatibility_model_review" in query
+        )
+        self.assertEqual(review_insert[1][0], "fēnix 8 Pro · 51 mm")
+        self.assertEqual(review_insert[1][2:5], (
+            "APPROVED", True, "fēnix 8 Pro · 51 mm, AMOLED",
+        ))
+        audit = next(
+            (query, params) for query, params in database.calls
+            if "INSERT INTO public_compatibility_review_audit" in query
+        )
+        self.assertEqual(audit[1][0], "garmin-fenix-8-pro-51-amoled")
+        self.assertEqual(audit[1][7], "Exact model reviewed")
+        mutating_queries = [
+            query for query, _ in database.calls
+            if query.lstrip().startswith("UPDATE") or query.lstrip().startswith("INSERT")
+        ]
+        self.assertFalse(any("compatibility_evidence_event" in query for query in mutating_queries))
+        self.assertFalse(any("UPDATE device_model" in query for query in mutating_queries))
+
+    def test_public_compatibility_publish_requires_eligible_evidence(self):
+        database = RecordingDatabase(
+            canonical_row={"id": "garmin-watch", "model": "Watch", "variant": "47 mm"},
+            statistics_row=None,
+        )
+        with self.assertRaisesRegex(ValueError, "evidence is required"):
+            database.update_public_compatibility_review(
+                "garmin-watch", action="PUBLISH", admin_user_id=7,
+            )
+        self.assertFalse(any(
+            "INSERT INTO compatibility_model_review" in query for query, _ in database.calls
+        ))
+
+    def test_public_review_migration_is_additive_and_audited(self):
+        migration = PUBLIC_REVIEW_MIGRATION.read_text(encoding="utf-8")
+        self.assertIn("CREATE TABLE public_compatibility_review_audit", migration)
+        self.assertIn("REFERENCES device_model(id) ON DELETE RESTRICT", migration)
+        self.assertNotIn("DROP TABLE", migration)
+        self.assertNotIn("DROP VIEW", migration)
 
     def test_resolve_and_reopen_persist_lifecycle_metadata_without_deleting_evidence(self):
         database = RecordingDatabase(

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -47,6 +47,7 @@ class FakeEvidenceDatabase:
         self.sessions = {}
         self.device_support_status = "SUPPORTED"
         self.authorization_audit = []
+        self.public_review_actions = []
 
     def insert_compatibility_event(self, value):
         if value["id"] in self.events:
@@ -144,6 +145,10 @@ class FakeEvidenceDatabase:
             "first_seen_collection_run_id": 1,
             "last_seen_collection_run_id": 1,
             "usb_identities": [],
+            "public_compatibility_identity": "fēnix 8 · 47 mm AMOLED",
+            "public_review_status": "PENDING",
+            "public_statistics_enabled": False,
+            "public_display_name": None,
         }], {
             "id": 1,
             "status": "SUCCEEDED",
@@ -190,6 +195,17 @@ class FakeEvidenceDatabase:
             "device_id": device_id,
             "admin_user_id": admin_user_id,
             "reason": reason,
+            "note": note,
+        })
+        return True
+
+    def update_public_compatibility_review(self, device_id, action, admin_user_id=None, note=None):
+        if device_id != "garmin-fenix-8-47-amoled":
+            return False
+        self.public_review_actions.append({
+            "device_id": device_id,
+            "action": action,
+            "admin_user_id": admin_user_id,
             "note": note,
         })
         return True
@@ -561,6 +577,23 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         self.assertEqual(reviewed.status, 303)
         self.assertEqual(self.database.device_support_status, "SUPPORTED")
         self.assertEqual(self.database.authorization_audit[-1]["reason"], "Validated on hardware")
+
+        publication_body = urlencode({
+            "csrf_token": csrf_token,
+            "device_id": "garmin-fenix-8-47-amoled",
+            "publication_action": "PUBLISH",
+            "note": "Exact identity reviewed for public listing",
+        })
+        published, _ = self.request("POST", "/admin/devices/public-compatibility", publication_body, {
+            "Content-Type": "application/x-www-form-urlencoded", "Cookie": cookie_header,
+        })
+        self.assertEqual(published.status, 303)
+        self.assertEqual(self.database.public_review_actions[-1], {
+            "device_id": "garmin-fenix-8-47-amoled",
+            "action": "PUBLISH",
+            "admin_user_id": 1,
+            "note": "Exact identity reviewed for public listing",
+        })
 
         unauthenticated_campaign, _ = self.request("GET", "/admin/campaign-links")
         self.assertEqual(unauthenticated_campaign.status, 303)


### PR DESCRIPTION
## Summary
- add an independent Public compatibility review to the Devices detail dialog
- require exact recognized map-capable evidence before first publication
- audit publish and withdraw actions without changing evidence, install counts, installation authorization, or native write authorization
- keep existing public/native/device API contracts unchanged

## Verification
- 127 backend tests pass
- Devices JavaScript syntax check passes
- git diff --check passes
