### PR TITLE
Add admin needs review indicator

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -150,6 +150,15 @@ disables public statistics. Every change is audited. This action does not
 change evidence events, calculated status, installation counts, installation
 authorization, or any existing public/native/device API field.
 
+The shared authenticated admin navigation shows `Needs review` only when an
+actionable queue is non-empty. Its count is split into distinct active failed
+installation operations, unresolved-identity operations, and exact eligible
+models awaiting first public publication. The popover links failures and
+identity work to Installation evidence and publication work to Devices.
+Resolved diagnostics, `NOT_IDENTIFIABLE` identities, rejected publication
+reviews, and already-published models are excluded. The summary is private,
+no-store, and does not add fields to any public or native API response.
+
 `POST /admin/diagnostics/resolve` and `/admin/diagnostics/reopen` change only
 the retained diagnostic lifecycle, while `POST /admin/diagnostics/identity`
 assigns or leaves an exact canonical Garmin record and writes an identity audit

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -524,9 +524,24 @@ def _admin_header(user: dict[str, Any], csrf_token: str, *, active: str = "evide
     evidence_class = " class='active'" if active == "evidence" else ""
     campaign_class = " class='active'" if active == "campaigns" else ""
     devices_class = " class='active'" if active == "devices" else ""
+    review = user.get("admin_review_summary") or {}
+    installation_issues = int(review.get("installationIssues") or 0)
+    identity_pending = int(review.get("identityPending") or 0)
+    ready_to_publish = int(review.get("readyToPublish") or 0)
+    review_total = int(review.get("total") or (
+        installation_issues + identity_pending + ready_to_publish
+    ))
+    review_menu = f"""<details class="needs-review-menu">
+        <summary aria-label="Needs review: {review_total}">Needs review <span class="needs-review-count">{review_total}</span></summary>
+        <div class="needs-review-popover" role="group" aria-label="Review queue">
+          <a href="/admin"><span>Installation issues</span><strong>{installation_issues}</strong></a>
+          <a href="/admin"><span>Identity pending</span><strong>{identity_pending}</strong></a>
+          <a href="/admin/devices"><span>Ready to publish</span><strong>{ready_to_publish}</strong></a>
+        </div>
+      </details>""" if review_total else ""
     return f"""<header class="admin-topbar"><div class="admin-topbar-inner">
       <div class="admin-header-zone admin-header-left">{_admin_brand()}</div>
-      <nav class="admin-section-nav" aria-label="Admin sections"><a{evidence_class} href="/admin">Installations</a><a{devices_class} href="/admin/devices">Devices</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a></nav>
+      <nav class="admin-section-nav" aria-label="Admin sections"><a{evidence_class} href="/admin">Installations</a><a{devices_class} href="/admin/devices">Devices</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a>{review_menu}</nav>
       <nav class="admin-nav" aria-label="Admin navigation"><label class="timezone-control"><span class="sr-only">Time zone</span><select id="admin-timezone" aria-label="Time zone" title="Time zone"><option value="browser">Automatic (browser)</option><option value="UTC">UTC</option><option value="Europe/Vilnius">Europe/Vilnius</option><option value="Europe/London">Europe/London</option><option value="Europe/Berlin">Europe/Berlin</option><option value="America/New_York">America/New_York</option><option value="America/Los_Angeles">America/Los_Angeles</option><option value="Asia/Tokyo">Asia/Tokyo</option></select></label><a class="admin-website-link" href="https://terento.app/" target="_blank" rel="noopener noreferrer" aria-label="Open Terento website in a new tab">Website <span aria-hidden="true">↗</span></a><span class="admin-user" aria-label="Signed in as {username}">{username}</span>
       <form method="post" action="/admin/logout"><input type="hidden" name="csrf_token" value="{html.escape(csrf_token)}"><button class="link-button" type="submit">Sign out</button></form></nav>
     </div></header>"""
@@ -2152,6 +2167,14 @@ button{cursor:pointer}
 .admin-section-nav a,.admin-nav a,.link-button{display:inline-flex;align-items:center;min-height:32px;padding:6px 8px;border:1px solid transparent;border-radius:var(--admin-control-radius);background:none;text-decoration:none;color:var(--secondary);font-weight:650;transition:background-color .15s ease,border-color .15s ease,color .15s ease}
 .admin-section-nav a:hover,.admin-nav a:hover,.link-button:hover,.admin-section-nav a:active,.admin-nav a:active,.link-button:active{background:color-mix(in srgb,var(--sky) 12%,transparent);color:var(--interactive)}
 .admin-section-nav a.active{background:color-mix(in srgb,var(--sky) 13%,var(--off-white));border-color:color-mix(in srgb,var(--sky) 28%,var(--border));color:var(--interactive);box-shadow:none}
+.needs-review-menu{position:relative}
+.needs-review-menu summary{display:inline-flex;align-items:center;gap:6px;min-height:32px;padding:6px 8px;border:1px solid color-mix(in srgb,var(--stone) 45%,var(--border));border-radius:var(--admin-control-radius);background:color-mix(in srgb,var(--stone) 10%,var(--off-white));color:var(--graphite);cursor:pointer;list-style:none;font-weight:700}
+.needs-review-menu summary::-webkit-details-marker{display:none}
+.needs-review-menu summary:focus-visible{outline:3px solid var(--admin-focus-ring);outline-offset:2px}
+.needs-review-count{display:inline-flex;align-items:center;justify-content:center;min-width:20px;height:20px;padding:0 6px;border-radius:999px;background:var(--stone);color:white;font-size:10px;font-weight:800}
+.needs-review-popover{position:absolute;z-index:20;top:calc(100% + 7px);right:0;width:230px;padding:7px;border:1px solid var(--border);border-radius:10px;background:var(--surface);box-shadow:0 14px 34px rgba(34,42,43,.16)}
+.needs-review-popover a{display:flex!important;justify-content:space-between;gap:12px;width:100%;padding:8px 9px!important;color:var(--graphite)!important}
+.needs-review-popover strong{font-variant-numeric:tabular-nums}
 .admin-nav{display:flex;align-items:center;justify-self:end;min-width:0;gap:8px;color:var(--secondary);font-size:13px;white-space:nowrap}
 .admin-nav form{display:flex;align-items:center;margin:0}
 .admin-user{padding:6px 0;color:var(--graphite);font-weight:650;white-space:nowrap}
@@ -2344,6 +2367,7 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 @media(max-width:800px){.admin-topbar-inner,.dashboard{width:min(calc(100% - 32px),var(--max-width))}.admin-topbar-inner{display:flex;flex-wrap:wrap;gap:12px}.admin-header-left{flex:0 0 auto}.admin-section-nav{order:3;flex-basis:100%;margin-left:0}.admin-nav{flex:1 1 auto;justify-content:flex-end}.heading-row{align-items:flex-start;flex-direction:column;gap:12px}.diagnostic-model-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}.filter-bar{align-items:stretch}.filter-bar label,.filter-bar select,.filter-bar input{flex:1 1 170px}.filter-bar .results-count{width:100%;margin:2px 4px 0}.public-status{align-items:flex-start;flex-direction:column}.public-status-value{width:100%;justify-content:space-between;flex-wrap:wrap}.status-guide-grid{grid-template-columns:1fr}.campaign-fields{grid-template-columns:1fr}.campaign-field-wide{grid-column:auto}.attribution-preview{grid-template-columns:1fr}.sync-summary{white-space:normal!important}.device-detail-grid{grid-template-columns:1fr}.device-support-review form{grid-template-columns:1fr}.diagnostic-operation-heading{flex-direction:column}.diagnostic-actions{justify-content:flex-start}.diagnostic-detail-summary{grid-template-columns:1fr}.diagnostic-actions-grid{grid-template-columns:1fr}.github-review{grid-column:auto}}
 @media(max-width:980px){.admin-topbar-inner{display:flex;flex-wrap:wrap;gap:12px}.admin-header-left{flex:0 0 auto}.admin-section-nav{order:3;flex-basis:100%;margin-left:0}.admin-nav{flex:1 1 auto;justify-content:flex-end}}
 @media(max-width:560px){.admin-topbar-inner{align-items:flex-start;flex-direction:column;padding:14px 0}.admin-header-left,.admin-section-nav,.admin-nav{width:100%}.admin-section-nav{order:0;overflow:auto;justify-content:flex-start}.admin-section-nav a{white-space:nowrap}.admin-nav{justify-content:space-between;gap:10px;flex-wrap:wrap}.timezone-control{width:100%;justify-content:space-between}.timezone-control select{width:auto;flex:1}.dashboard{padding-top:28px}.diagnostic-model-metrics{gap:8px}.diagnostic-model-metrics article{padding:12px}.auth-card{width:calc(100% - 32px);padding:24px}.section-heading{align-items:flex-start;flex-direction:column;gap:4px}.campaign-card{padding:16px}.campaign-preset-row{align-items:stretch;flex-direction:column;gap:8px}.campaign-preset-row .campaign-label,.campaign-preset-row select{flex:none}.campaign-preset-row select{width:100%;height:var(--admin-control-height);margin-left:0}.generated-url-row{grid-template-columns:1fr}.copy-button{width:100%}.copy-status{min-height:18px}.device-dialog-inner,.diagnostic-detail-inner{padding:18px}.device-detail-grid dl div,.device-detail-secondary dl div{grid-template-columns:1fr;gap:2px}.device-detail-grid dd,.device-detail-secondary dd{text-align:left}.diagnostic-technical-details dl{grid-template-columns:1fr}.diagnostic-summary-action{float:none;display:block;margin-top:6px}.github-link-form{grid-template-columns:1fr}.github-link-form button{width:100%}}
+@media(max-width:560px){.admin-section-nav{overflow:visible;flex-wrap:wrap}.needs-review-popover{left:0;right:auto}}
 @media(max-width:800px){.admin-summary-strip{align-items:flex-start;flex-direction:column;gap:6px}.admin-summary-context,.device-summary-sync{text-align:left;white-space:normal}.device-detail-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 @media(max-width:560px){.device-detail-grid{grid-template-columns:1fr}.device-catalog-details dl div{grid-template-columns:1fr;gap:2px}.device-catalog-details dd{text-align:left}.device-detail-grid dd{text-align:left}.device-filter-bar .results-count{margin-left:0}.device-dialog-inner{padding:18px}}
 @media(max-width:1100px){.device-table-wrap{overflow-x:auto;overflow-y:visible}.device-table-wrap table{min-width:1050px}.device-table-wrap thead th{top:0}}

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -323,6 +323,47 @@ class Database:
         with self.connection() as connection:
             return list(connection.execute(query, (limit,)).fetchall())
 
+    def admin_review_summary(self) -> dict[str, int]:
+        """Return actionable operator-review counts without exposing events."""
+        query = """
+            WITH operation_reviews AS (
+                SELECT
+                    COALESCE(operation_id::text, 'legacy:' || event_id::text) AS operation_key,
+                    bool_or(phase_outcome = 'FAILED') AS has_failure,
+                    bool_or(
+                        canonical_device_model_id IS NULL
+                        AND COALESCE(identity_resolution_state, 'UNRESOLVED')
+                            NOT IN ('RESOLVED', 'NOT_IDENTIFIABLE')
+                    ) AS identity_pending
+                FROM compatibility_evidence_event
+                WHERE diagnostic_status = 'ACTIVE'
+                GROUP BY COALESCE(operation_id::text, 'legacy:' || event_id::text)
+            ), publication_reviews AS (
+                SELECT count(*) AS ready_to_publish
+                FROM compatibility_model_statistics
+                WHERE canonical_device_model_id IS NOT NULL
+                  AND calculated_status IN ('TESTING', 'TESTED', 'SUPPORTED', 'VERIFIED')
+                  AND (
+                      review_status = 'PENDING'
+                      OR (review_status = 'APPROVED' AND public_statistics_enabled = false)
+                  )
+            )
+            SELECT
+                count(*) FILTER (WHERE has_failure) AS installation_issues,
+                count(*) FILTER (WHERE identity_pending) AS identity_pending,
+                (SELECT ready_to_publish FROM publication_reviews) AS ready_to_publish
+            FROM operation_reviews
+        """
+        with self.connection() as connection:
+            row = connection.execute(query).fetchone()
+        summary = {
+            "installationIssues": int((row or {}).get("installation_issues") or 0),
+            "identityPending": int((row or {}).get("identity_pending") or 0),
+            "readyToPublish": int((row or {}).get("ready_to_publish") or 0),
+        }
+        summary["total"] = sum(summary.values())
+        return summary
+
     def admin_user_count(self) -> int:
         with self.connection() as connection:
             row = connection.execute("SELECT count(*) AS count FROM admin_user").fetchone()

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -193,6 +193,9 @@ class CatalogService:
             note=note,
         )
 
+    def admin_review_summary(self) -> dict[str, int]:
+        return self.database.admin_review_summary()
+
     def admin_is_configured(self) -> bool:
         return self.database.admin_user_count() > 0
 
@@ -425,6 +428,16 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 service.logout_admin(session_token)
                 self._redirect("/admin/login", send_body=send_body, clear_cookie=True)
                 return
+            try:
+                session = {**session, "admin_review_summary": service.admin_review_summary()}
+            except Exception:
+                LOGGER.exception("admin review summary failed")
+                session = {**session, "admin_review_summary": {
+                    "installationIssues": 0,
+                    "identityPending": 0,
+                    "readyToPublish": 0,
+                    "total": 0,
+                }}
             if request_path in {"/admin/diagnostics", "/admin/diagnostics/"}:
                 query = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
                 identity = query.get("identity", [""])[0].strip()

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -75,6 +75,23 @@ class RecordingDatabase(Database):
         yield Connection()
 
 
+class ReviewSummaryDatabase(Database):
+    def __init__(self):
+        super().__init__("unused")
+
+    @contextmanager
+    def connection(self):
+        class Connection:
+            def execute(self, query, parameters=None):
+                return RecordingResult(row={
+                    "installation_issues": 1,
+                    "identity_pending": 2,
+                    "ready_to_publish": 3,
+                })
+
+        yield Connection()
+
+
 class AdminSemanticsTests(unittest.TestCase):
     def test_variant_formatting_normalizes_sizes_without_dropping_functional_labels(self):
         self.assertEqual(
@@ -190,6 +207,45 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("REFERENCES device_model(id) ON DELETE RESTRICT", migration)
         self.assertNotIn("DROP TABLE", migration)
         self.assertNotIn("DROP VIEW", migration)
+
+    def test_needs_review_summary_counts_actionable_tasks(self):
+        summary = ReviewSummaryDatabase().admin_review_summary()
+        self.assertEqual(summary, {
+            "installationIssues": 1,
+            "identityPending": 2,
+            "readyToPublish": 3,
+            "total": 6,
+        })
+        source = inspect.getsource(Database.admin_review_summary)
+        self.assertIn("diagnostic_status = 'ACTIVE'", source)
+        self.assertIn("GROUP BY COALESCE(operation_id::text", source)
+        self.assertIn("canonical_device_model_id IS NOT NULL", source)
+        self.assertIn("review_status = 'PENDING'", source)
+        self.assertIn("review_status = 'APPROVED' AND public_statistics_enabled = false", source)
+
+    def test_shared_navigation_shows_actionable_review_breakdown(self):
+        body = devices_page([], None, {
+            "username": "operator",
+            "admin_review_summary": {
+                "installationIssues": 1,
+                "identityPending": 2,
+                "readyToPublish": 3,
+                "total": 6,
+            },
+        }, "csrf").decode()
+        self.assertIn('aria-label="Needs review: 6"', body)
+        self.assertIn('class="needs-review-count">6</span>', body)
+        self.assertIn("Installation issues</span><strong>1", body)
+        self.assertIn("Identity pending</span><strong>2", body)
+        self.assertIn("Ready to publish</span><strong>3", body)
+        self.assertIn("needs-review-popover", body)
+
+        zero_body = devices_page([], None, {
+            "username": "operator",
+            "admin_review_summary": {"total": 0},
+        }, "csrf").decode()
+        zero_header = zero_body[zero_body.index("<header"):zero_body.index("</header>")]
+        self.assertNotIn("needs-review-menu", zero_header)
 
     def test_resolve_and_reopen_persist_lifecycle_metadata_without_deleting_evidence(self):
         database = RecordingDatabase(

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -49,6 +49,14 @@ class FakeEvidenceDatabase:
         self.authorization_audit = []
         self.public_review_actions = []
 
+    def admin_review_summary(self):
+        return {
+            "installationIssues": 1,
+            "identityPending": 1,
+            "readyToPublish": 1,
+            "total": 3,
+        }
+
     def insert_compatibility_event(self, value):
         if value["id"] in self.events:
             return False
@@ -553,6 +561,9 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         devices, devices_body = self.request("GET", "/admin/devices", headers={"Cookie": cookie_header})
         self.assertEqual(devices.status, 200)
         self.assertIn(b">Devices<", devices_body)
+        self.assertIn(b"Needs review", devices_body)
+        self.assertIn(b'aria-label="Needs review: 3"', devices_body)
+        self.assertIn(b"Ready to publish", devices_body)
         self.assertIn(b'data-device-sort="maps"', devices_body)
         self.assertIn(
             "img-src https://terento.app https://api.terento.app https://res.garmin.com data:",


### PR DESCRIPTION
## Summary
- add a shared admin navigation counter for actionable review work
- split the counter into installation issues, identity pending, and ready-to-publish items
- hide the indicator when there is no review work
- keep public, native, and device API contracts unchanged

## Validation
- 131 backend tests passed
- Devices page JavaScript syntax check passed
- git diff check passed

This clean PR intentionally excludes the unrelated Compatibility page commit that entered the previous branch.