### PR TITLE
Fix catalog deploy verification broken pipe

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -218,16 +218,16 @@ jobs:
           status="$(printf '%s\n' "$headers" | awk 'toupper($1) ~ /^HTTP\// {code=$2} END {print code}')"
           location="$(printf '%s\n' "$headers" | awk 'tolower($1)=="location:" {print $2; exit}' | tr -d '\r')"
           if [ "$health" != '{"status":"ok"}' ] \
-            || ! printf '%s\n' "$maps" | grep -q '"catalogVersion"' \
-            || ! printf '%s\n' "$devices" | grep -q '"catalogVersion"' \
-            || ! printf '%s\n' "$login" | grep -q '<title>Admin sign in · Terento</title>' \
+            || ! grep -Fq '"catalogVersion"' <<<"$maps" \
+            || ! grep -Fq '"catalogVersion"' <<<"$devices" \
+            || ! grep -Fq '<title>Admin sign in · Terento</title>' <<<"$login" \
             || [ "$status" != "303" ] \
             || [ "$location" != "/admin/login" ] \
-            || ! printf '%s\n' "$headers" | grep -qi "script-src 'none'"; then
+            || ! grep -Fqi "script-src 'none'" <<<"$headers"; then
             printf '%s\n' "Public catalog verification failed" >&2
             printf '%s\n' "$headers" >&2
             exit 1
           fi
 
           compatibility_script="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://terento.app/compatibility/compatibility.js)"
-          printf '%s\n' "$compatibility_script" | grep -q 'https://api.terento.app'
+          grep -Fq 'https://api.terento.app' <<<"$compatibility_script"


### PR DESCRIPTION
## Summary
- avoid early-closing grep pipelines in the catalog API production verification
- preserve the same health, catalog, admin redirect, CSP, and Compatibility checks
- prevent large JSON responses from failing under pipefail after a successful rollout

## Validation
- ran the revised verification against all live production endpoints successfully
- git diff check passed

This changes deployment verification only; API contracts and application behavior are unchanged.