### PR TITLE
fix(site): bust caches for page intro styles

### DIFF
--- a/Tests/public-page-layout-contract-tests.cjs
+++ b/Tests/public-page-layout-contract-tests.cjs
@@ -5,6 +5,8 @@ const path = require("node:path");
 const root = path.resolve(__dirname, "..");
 const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
 const styles = read("site/styles.css");
+const styleVersion = "20260830-page-intros";
+const localizedContentVersion = "20260830-download-links";
 
 const cssBlock = (selector) => {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -88,6 +90,7 @@ const visibleText = (html) => html
 
 for (const [locale, contract] of Object.entries(locales)) {
   const html = read(contract.file);
+  assert.match(html, new RegExp(`/styles\\.css\\?v=${styleVersion}`));
   assert.equal((html.match(/class="download-sections"/g) || []).length, 1, `${locale} must use one three-column information grid`);
   assert.doesNotMatch(html, /class="download-grid"/);
   assert.doesNotMatch(html, /New to third-party maps\?|Neu bei Drittanbieter-Karten\?|Vous débutez avec les cartes tierces|Dopiero zaczynasz z mapami innych firm|Začínáte s mapami třetích stran|È la prima volta che installi mappe di terze parti/);
@@ -100,6 +103,9 @@ for (const [locale, contract] of Object.entries(locales)) {
     assert.match(match[2], /class="download-info-link-tail"/);
     assert.match(match[2], /class="download-info-link-arrow" aria-hidden="true">→<\/span>/);
     assert.doesNotMatch(match[1], /utm_/i);
+  }
+  if (locale !== "en") {
+    assert.match(html, new RegExp(`/localized-content\\.js\\?v=${localizedContentVersion}`));
   }
 }
 

--- a/scripts/normalize-public-shell.py
+++ b/scripts/normalize-public-shell.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SHELL_VERSION = "20260829-faq-routing"
-STYLE_VERSION = "20260829-faq-consolidation"
+STYLE_VERSION = "20260830-page-intros"
 LANGUAGE_VERSION = "20260829-compat-language"
+LOCALIZED_CONTENT_VERSION = "20260830-download-links"
 LOCALES = {
     "en": {"flag": "🇬🇧", "name": "English", "home": "Terento home", "primary": "Primary navigation", "menu": "Menu", "close": "Close menu", "about": "About", "compatibility": "Compatibility", "guide": "Guide", "faq": "FAQ", "download": "Download", "language": "Choose language", "footer": "Footer navigation", "status": "Open-source project", "legal": "Legal", "privacy": "Privacy", "support": "Support Terento", "stats": "Visit statistics (Umami) do not use cookies."},
     "de": {"flag": "🇩🇪", "name": "Deutsch", "home": "Terento Startseite", "primary": "Hauptnavigation", "menu": "Menü", "close": "Menü schließen", "about": "Über uns", "compatibility": "Kompatibilität", "guide": "Anleitung", "faq": "FAQ", "download": "Download", "language": "Sprache wählen", "footer": "Footer-Navigation", "status": "Open-Source-Projekt", "legal": "Rechtliches", "privacy": "Datenschutz", "support": "Support Terento", "stats": "Besuchsstatistik (Umami) verwendet keine Cookies."},
@@ -132,6 +133,11 @@ def main() -> None:
             raise SystemExit(f"missing footer in {relative}")
         source = re.sub(r'(/site-shell\.js\?v=)[^"\s]+', rf'\g<1>{SHELL_VERSION}', source)
         source = re.sub(r'(/styles\.css\?v=)[^"\s]+', rf'\g<1>{STYLE_VERSION}', source)
+        source = re.sub(
+            r'(/localized-content\.js\?v=)[^"\s]+',
+            rf'\g<1>{LOCALIZED_CONTENT_VERSION}',
+            source,
+        )
         source = re.sub(r'(/language\.js\?v=)[^"\s]+', rf'\g<1>{LANGUAGE_VERSION}', source)
         path.write_text(source, encoding="utf-8")
     print("Synchronized static public headers and footers.")

--- a/site/compatibility/index.html
+++ b/site/compatibility/index.html
@@ -36,7 +36,7 @@
 
     <link rel="icon" href="/favicon.ico?v=20260825-2" sizes="any">
     <link rel="icon" href="/favicon.svg?v=20260825-2" type="image/svg+xml">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 
 </head>
   <body class="compatibility-page">

--- a/site/cs/compatibility/index.html
+++ b/site/cs/compatibility/index.html
@@ -31,7 +31,7 @@
     <title>Kompatibilita hodinek Garmin — Terento</title>
 
 
-    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 </head>
   <body class="compatibility-page"><a class="skip-link" href="#main-content">Přejít k obsahu</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/cs/download/index.html
+++ b/site/cs/download/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs">
   <head>
     <script defer src="/site-shell.js?v=20260829-faq-routing"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Stáhněte si bezplatnou, notářsky ověřenou betu Terento pro Macy s Apple Silicon k instalaci a správě map třetích stran na kompatibilních hodinkách Garmin.">
     <meta name="robots" content="index,follow">
@@ -33,7 +33,7 @@
 
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4"><link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -58,7 +58,7 @@
     }
   }
 </script>
-    <script defer src="/localized-content.js?v=20260827-1"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
 </head>
   <body><a class="skip-link" href="#main-content">Přejít k obsahu</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/cs/guides/install-garmin-maps-mac/index.html
+++ b/site/cs/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/cs/index.html
+++ b/site/cs/index.html
@@ -39,10 +39,10 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
-    <script defer src="/localized-content.js?v=20260829-faq-consolidation"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/de/compatibility/index.html
+++ b/site/de/compatibility/index.html
@@ -37,7 +37,7 @@
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any">
     <link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 </head>
   <body class="compatibility-page">
     <a class="skip-link" href="#main-content">Zum Inhalt springen</a>

--- a/site/de/download/index.html
+++ b/site/de/download/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de">
   <head>
     <script defer src="/site-shell.js?v=20260829-faq-routing"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Lade die kostenlose, notarielle Terento-Beta für Apple-Silicon-Macs herunter, um Drittanbieter-Karten auf kompatiblen Garmin-Smartwatches zu installieren und zu verwalten.">
     <meta name="robots" content="index,follow">
@@ -34,7 +34,7 @@
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4"><link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script>
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -60,7 +60,7 @@
         }
       }
     </script>
-    <script defer src="/localized-content.js?v=20260827-1"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
 </head>
   <body><a class="skip-link" href="#main-content">Zum Inhalt springen</a>
     <header class="site-header">

--- a/site/de/guides/install-garmin-maps-mac/index.html
+++ b/site/de/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -39,10 +39,10 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
-    <script defer src="/localized-content.js?v=20260829-faq-consolidation"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/download/index.html
+++ b/site/download/index.html
@@ -38,7 +38,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/fr/compatibility/index.html
+++ b/site/fr/compatibility/index.html
@@ -31,7 +31,7 @@
     <title>Compatibilité des montres Garmin — Terento</title>
 
 
-    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 </head>
   <body class="compatibility-page"><a class="skip-link" href="#main-content">Aller au contenu</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/fr/download/index.html
+++ b/site/fr/download/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr">
   <head>
     <script defer src="/site-shell.js?v=20260829-faq-routing"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Téléchargez la bêta Terento gratuite et notariée pour Mac Apple Silicon afin d’installer et de gérer des cartes tierces sur les montres Garmin compatibles.">
     <meta name="robots" content="index,follow">
@@ -34,7 +34,7 @@
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4"><link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -59,7 +59,7 @@
     }
   }
 </script>
-    <script defer src="/localized-content.js?v=20260827-1"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
 </head>
   <body><a class="skip-link" href="#main-content">Aller au contenu</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/fr/guides/install-garmin-maps-mac/index.html
+++ b/site/fr/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -39,10 +39,10 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
-    <script defer src="/localized-content.js?v=20260829-faq-consolidation"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/guides/install-garmin-maps-mac/index.html
+++ b/site/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/index.html
+++ b/site/index.html
@@ -39,7 +39,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/it/compatibility/index.html
+++ b/site/it/compatibility/index.html
@@ -31,7 +31,7 @@
     <title>Compatibilità degli smartwatch Garmin — Terento</title>
 
 
-    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 </head>
   <body class="compatibility-page"><a class="skip-link" href="#main-content">Vai al contenuto</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/it/download/index.html
+++ b/site/it/download/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it">
   <head>
     <script defer src="/site-shell.js?v=20260829-faq-routing"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Scarica la beta gratuita e notarizzata di Terento per Mac Apple Silicon per installare e gestire mappe di terze parti sugli smartwatch Garmin compatibili.">
     <meta name="robots" content="index,follow">
@@ -33,7 +33,7 @@
 
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4"><link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -58,7 +58,7 @@
     }
   }
 </script>
-    <script defer src="/localized-content.js?v=20260827-1"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
 </head>
   <body><a class="skip-link" href="#main-content">Vai al contenuto</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/it/guides/install-garmin-maps-mac/index.html
+++ b/site/it/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/it/index.html
+++ b/site/it/index.html
@@ -39,10 +39,10 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
-    <script defer src="/localized-content.js?v=20260829-faq-consolidation"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/legal/index.html
+++ b/site/legal/index.html
@@ -32,7 +32,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/legal-language.js?v=20260829-language-routing"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>

--- a/site/pl/compatibility/index.html
+++ b/site/pl/compatibility/index.html
@@ -31,7 +31,7 @@
     <title>Kompatybilność zegarków Garmin — Terento</title>
 
 
-    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
 </head>
   <body class="compatibility-page"><a class="skip-link" href="#main-content">Przejdź do treści</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/pl/download/index.html
+++ b/site/pl/download/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl">
   <head>
     <script defer src="/site-shell.js?v=20260829-faq-routing"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Pobierz bezpłatną, notaryzowaną betę Terento na Maci z Apple Silicon, aby instalować i zarządzać mapami innych firm na zgodnych zegarkach Garmin.">
     <meta name="robots" content="index,follow">
@@ -33,7 +33,7 @@
 
 
     <link rel="icon" href="/favicon.ico?v=20260820-4" sizes="any"><link rel="icon" href="/favicon.svg?v=20260820-4" type="image/svg+xml"><link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4"><link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros"><script defer src="/language.js?v=20260829-compat-language"></script><script defer src="/privacy-consent.js?v=20260826-2"></script><script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
@@ -58,7 +58,7 @@
     }
   }
 </script>
-    <script defer src="/localized-content.js?v=20260827-1"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
 </head>
   <body><a class="skip-link" href="#main-content">Przejdź do treści</a><header class="site-header">
       <div class="shell header-inner">

--- a/site/pl/guides/install-garmin-maps-mac/index.html
+++ b/site/pl/guides/install-garmin-maps-mac/index.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png?v=20260820-4">
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
     <script type="application/ld+json">

--- a/site/pl/index.html
+++ b/site/pl/index.html
@@ -39,10 +39,10 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>
-    <script defer src="/localized-content.js?v=20260829-faq-consolidation"></script>
+    <script defer src="/localized-content.js?v=20260830-download-links"></script>
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -32,7 +32,7 @@
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=20260820-4" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
 
-    <link rel="stylesheet" href="/styles.css?v=20260829-faq-consolidation">
+    <link rel="stylesheet" href="/styles.css?v=20260830-page-intros">
     <script defer src="/language.js?v=20260829-compat-language"></script>
     <script defer src="/privacy-language.js?v=20260829-language-routing"></script>
     <script defer src="/privacy-consent.js?v=20260826-2"></script>


### PR DESCRIPTION
## Summary
- bump the normalized public CSS asset version so Cloudflare and browsers fetch the deployed intro/link styles
- bump localized-content.js for the corrected Download route behavior
- guard both asset versions in the public layout contract test

## Validation
- complete Tests/run-*.sh suite
- generator parity and structured-data validation
- git diff --check

Follow-up to #56 after live preflight confirmed the old versioned stylesheet remained a Cloudflare cache HIT.