### PR TITLE
chore(brand): add repository-wide brand governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,3 +27,19 @@ Describe the device model, test scope, and result, or write Not performed with t
 ## Limitations and follow-up
 
 <!-- What is intentionally not included or still pending? -->
+
+## Brand and user-facing changes
+
+<!-- Complete this section only when the PR changes user-facing UI, public copy,
+styling, icons, screenshots, or visual assets. Otherwise select N/A. -->
+
+- [ ] Canonical logo reused without geometry changes.
+- [ ] Approved semantic tokens used instead of new raw brand colors.
+- [ ] `Interactive Primary` remains the single primary action family.
+- [ ] `Warm Stone` is not used as a primary CTA.
+- [ ] Font roles remain correct.
+- [ ] Status uses explicit text, an icon, and supporting color.
+- [ ] Normal UI describes outcomes rather than implementation mechanics.
+- [ ] Public claims match the current release.
+- [ ] Accessibility and keyboard focus behavior were checked.
+- [ ] Not applicable: this PR has no user-facing changes.

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /docs/
 /internal/
 /lab/test-site/
-/AGENTS.md
+/AGENTS.override.md
 
 # Local Codex task prompts are working instructions, not public project docs.
 /legal/web/CODEX-PROMPT*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Terento repository instructions
+
+These are the repository-wide instructions for Codex and contributors. Keep
+changes narrow, evidence-based, and consistent with the canonical documents
+under `internal/` and the current release state.
+
+## Mandatory reading for user-facing work
+
+Before changing user-facing UI, public copy, CSS, admin UI, icons,
+illustrations, screenshots, marketing documentation, or visual assets, read:
+
+- `brand/BRAND_GUIDELINES.md`
+- `brand/DESIGN_TOKENS.json`
+- the nearest scoped `AGENTS.md`
+
+Also inspect the current implementation before editing. Preserve current
+layout and runtime behavior unless the task explicitly requests a change.
+
+## Source precedence
+
+Use this order when sources disagree:
+
+1. `brand/logo/logo.svg` — canonical, immutable logo geometry.
+2. `brand/DESIGN_TOKENS.json` — canonical numeric token values.
+3. `brand/BRAND_GUIDELINES.md` — canonical usage, accessibility, voice, and
+   product-truth rules.
+4. Generated or platform-specific implementation files — implementations of
+   the canonical sources; they must not redefine the brand.
+5. Screenshots, mockups, boards, PDFs, and presentations — editorial
+   references only, never implementation sources.
+
+## Locked brand and product rules
+
+- Never modify the canonical logo geometry or reinterpret its paths.
+- Do not introduce new brand colors, fonts, or visual directions inside a
+  feature task. Use approved semantic tokens instead of inventing raw colors.
+- `Interactive Primary` is the only primary action family. `Warm Stone` is
+  never a primary CTA.
+- Instrument Sans is for brand, marketing, hero, and expressive headings;
+  Inter is for UI, body text, labels, buttons, and information; JetBrains
+  Mono is for diagnostics and technical identifiers only.
+- Normal product UI describes outcomes, not MTP, IMG, USB object handles, or
+  filesystem mechanics.
+- Every status has explicit text and an icon; color is supporting information,
+  never the only status signal.
+- Public claims must match functionality available in the current release.
+  Beta limitations must remain truthful.
+- Do not reduce accessibility or keyboard focus behavior.
+- Do not alter unrelated working behavior during visual or documentation
+  work.
+
+## Change discipline
+
+- Prefer small, focused diffs and avoid opportunistic cleanup.
+- Update tests when user-facing behavior changes.
+- Preserve repository safety, privacy, licensing, device-ownership, and
+  provider boundaries documented by the applicable canonical documents.
+- Report intentional exceptions and unresolved limitations explicitly.
+- Keep local machine or operator-specific instructions in the ignored
+  `AGENTS.override.md`; never copy private infrastructure, credentials,
+  secrets, or personal working instructions into tracked files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,9 @@ Thank you for taking an interest in Terento. Contributions, bug reports, documen
 ## Project status
 
 Terento is an active beta and pre-MVP project for macOS. It is not a stable
-production release. The current public beta is `v1.0.0-beta.6` and includes a
-notarized Apple Silicon DMG and ZIP; there is no PKG or App Store package.
+production release. The current release identity, supported artifacts, and
+availability are maintained in `RELEASE_NOTES.md`, GitHub Releases, and the
+current release metadata; do not copy a version number into this document.
 
 The production app is the root Xcode macOS target and consumes the SwiftPM
 source module in `lab/native-connectivity-poc/`. The SwiftPM target also
@@ -20,6 +21,22 @@ general map-installation test.
 - Search existing issues and pull requests before opening a new one.
 - For security vulnerabilities, follow SECURITY.md instead of opening a public issue.
 - Do not upload Garmin device dumps, map binaries, private logs, credentials, API keys, or personal data.
+
+## Brand and user-facing changes
+
+Before changing user-facing UI, public copy, CSS, admin UI, icons,
+illustrations, screenshots, marketing documentation, or visual assets, read:
+
+- `AGENTS.md`
+- `brand/BRAND_GUIDELINES.md`
+- `brand/DESIGN_TOKENS.json`
+- the nearest scoped `AGENTS.md`
+
+A normal feature PR must not silently introduce a new brand color, font, logo
+variant, visual direction, or competing component language. Visual and copy
+changes must preserve product truth, accessibility, clear status
+communication, and the existing device-safety boundaries. A dedicated,
+separately reviewed brand-system decision is required for exceptions.
 
 ## Development environment
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -19,6 +19,7 @@ repository, subject to the normal review of the current worktree:
 | `legal/` | Public legal web source and publication inputs |
 | `backend/catalog-api/` | Metadata-only catalog service |
 | `brand/` | Approved brand assets and guidelines; exploratory previews remain local |
+| `AGENTS.md` | Repository-wide Codex and contributor instructions |
 | `LICENSE`, `NOTICE`, `THIRD_PARTY_NOTICES.md` | Source and dependency notices |
 
 ## Local-only or operational areas
@@ -32,7 +33,7 @@ boundary:
 | `docs/` | Local task and deployment notes |
 | `deploy/` | Environment-specific deployment/operator material |
 | `lab/test-site/` | Local test-site experiments |
-| `AGENTS.md` | Local Codex/repository operating instructions |
+| `AGENTS.override.md` | Local machine or operator-specific Codex overrides; ignored and must never be committed |
 | `.cursor/` | Local editor/agent state and debug logs |
 
 ## Generated and ignored output
@@ -65,13 +66,12 @@ The local packaging pipeline and `dist/` output are separate from the public
 website and from source publication. The pipeline can produce notarized arm64
 ZIP and DMG artifacts, but organizing this tree does not publish them.
 
-The current public release is `v1.0.0-beta.6`. The Xcode marketing version is
-`1.0.0`, build `5`; the release tag and artifact names carry the `-beta.6`
-label. The corresponding GitHub prerelease contains the notarized arm64 ZIP
-and DMG. Keep this release identity aligned across Xcode settings, release
-notes, the Git tag, the update manifest, and artifact names.
+Release identity, artifact availability, and release-specific provenance are
+maintained in `RELEASE_NOTES.md`, GitHub Releases, and current release
+metadata. Keep that identity aligned across Xcode settings, release notes,
+the Git tag, the update manifest, and artifact names; do not duplicate a
+version number in this repository map.
 
-The current working tree also contains user changes across application code,
-tests, website/legal content, and packaging files. Those changes must be
-reviewed and committed as separate logical changes; this cleanup does not
-stage, commit, or publish them.
+Changes to application code, tests, website/legal content, and packaging must
+be reviewed and committed as separate logical changes; this repository-map
+update does not change those boundaries or publish them.

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ pull requests are welcome.
 Start with:
 
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — development setup and safe device testing
+- [`brand/BRAND_GUIDELINES.md`](brand/BRAND_GUIDELINES.md) — approved visual and user-facing rules
 - [`SECURITY.md`](SECURITY.md) — reporting security issues
 - [`Packaging/README.md`](Packaging/README.md) — build, signing, and release details
 

--- a/backend/catalog-api/AGENTS.md
+++ b/backend/catalog-api/AGENTS.md
@@ -1,0 +1,21 @@
+# Catalog API and admin instructions
+
+These are future-change rules for `backend/catalog-api/**`. Do not change
+backend runtime files as a side effect of brand work.
+
+- API, database, authentication, evidence collection, and admin behavior must
+  not change as a side effect of brand work.
+- Keep admin UI consistent with the Terento palette and typography. Reuse
+  existing semantic colors and components instead of creating an independent
+  admin brand.
+- Diagnostics may use technical terminology. Normal admin navigation and
+  action labels should remain clear and outcome-oriented.
+- Destructive, warning, success, and information states must remain explicit;
+  never rely on color alone.
+- Do not add external font or asset origins without reviewing CSP,
+  deployment, privacy, and third-party notices.
+- Isolate visual refactors from API or data-model refactors.
+- Preserve current responsive behavior and action semantics.
+
+The admin interface may remain denser and more operational than the public
+website; it is not a public marketing surface.

--- a/brand/AGENTS.md
+++ b/brand/AGENTS.md
@@ -1,0 +1,18 @@
+# Brand directory instructions
+
+These instructions supplement the repository-wide `AGENTS.md` for `brand/**`.
+
+- `brand/logo/logo.svg` is the only source of logo geometry. Derived logo
+  assets must preserve its path geometry, proportions, opening, and curves.
+- `brand/DESIGN_TOKENS.json` is the numeric source of truth. Change token
+  values only through an explicit, separately approved brand-system decision.
+- Markdown explains usage and intent; it must not silently redefine numeric
+  values.
+- Screenshots, boards, PDFs, presentations, and mockups are references, not
+  sources of truth.
+- Changes to spacing and radius defaults must be versioned and based on real
+  product QA.
+- New fonts, colors, logo variants, and identity effects require a dedicated
+  brand-system decision.
+- Keep documentation edits aligned with the current approved visual
+  direction; do not turn governance work into a visual redesign.

--- a/brand/BRAND_GUIDELINES.md
+++ b/brand/BRAND_GUIDELINES.md
@@ -3,9 +3,28 @@
 Status: **Approved visual direction / implementation baseline**
 Date: **2026-08-20**
 
+Governance/editorial revision: **2026-08-30**. This revision clarifies source
+precedence and release-neutral product-truth rules. The approved visual
+identity values remain unchanged.
+
 These guidelines capture the visual system validated in the four final Terento boards. They are intended to be used by Codex, designers, maintainers, and future contributors.
 
 The visual identity is now implementation work, not an exploration round.
+
+## Source of truth
+
+Use the following precedence order:
+
+1. `brand/logo/logo.svg` — canonical and immutable logo geometry.
+2. `brand/DESIGN_TOKENS.json` — canonical numeric token values.
+3. This document — canonical usage, accessibility, voice, and product-truth
+   rules.
+4. Generated or platform-specific implementation files — implementations of
+   the canonical sources.
+5. Screenshots, mockups, boards, PDFs, and presentations — editorial
+   references only, never implementation sources.
+
+The Brandbook PDF and presentation files are not implementation dependencies.
 
 ---
 
@@ -450,7 +469,7 @@ Technical detail belongs in diagnostics.
 
 ---
 
-## 12. Website and pre-release claims
+## 12. Website and product-truth claims
 
 The final validation boards demonstrate the future product state. They are not proof that those features already exist.
 
@@ -463,11 +482,15 @@ Examples such as:
 
 are approved design-copy examples for a future state, not automatic permission to publish those claims now.
 
-For the current pre-release site, prefer truthful language such as:
+Public-facing claims must match functionality available in the current
+release. Beta pages must state relevant platform, compatibility, and feature
+limits. Future-state mockups and validation copy are not proof of shipped
+functionality.
 
-> Terento is in development.
-
-and link to the project/repository only when appropriate.
+Do not imply unsupported automatic updating, broad device support, or
+availability. Do not understate functionality that is already publicly
+released. Link to the project or repository when appropriate, and keep every
+release-specific claim aligned with the current release metadata.
 
 ---
 

--- a/brand/README.md
+++ b/brand/README.md
@@ -51,8 +51,26 @@ Typography:
 
 Exploratory preview boards are intentionally kept outside the public
 repository. This directory contains only the approved identity baseline and
-derived logo exports; use truthful product copy such as “Terento is in
-development.”
+derived logo exports. Public-facing claims must match functionality available
+in the current release; beta pages must state relevant platform,
+compatibility, and feature limits, and future-state mockups are not proof of
+shipped functionality.
+
+## Source hierarchy
+
+Use these sources in order:
+
+1. `logo/logo.svg` for immutable logo geometry
+2. `DESIGN_TOKENS.json` for numeric token values
+3. `BRAND_GUIDELINES.md` for usage and intent
+4. generated or platform-specific implementation files
+5. screenshots, mockups, boards, PDFs, and presentations as human-facing
+   references only
+
+The canonical SVG and machine-readable token file outrank visual examples.
+PDFs, presentation files, and screenshots must not be used to extract or
+redefine implementation values, and the Brandbook is not an implementation
+dependency.
 
 ## Implementation defaults
 

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -1,0 +1,24 @@
+# Website instructions
+
+These are future-change rules for `site/**`. Do not change current site files
+as a side effect of unrelated work.
+
+- Preserve the approved visual direction and current layout unless a task
+  explicitly requests a redesign.
+- Reuse existing semantic variables and components. Do not invent page-level
+  brand colors.
+- Use Instrument Sans for brand and marketing headings. Use Inter for
+  navigation, controls, body copy, labels, and information.
+- Keep one clear primary-action hierarchy. `Warm Stone` cannot become a
+  second primary CTA.
+- Preserve the existing light/dark hierarchy. Do not use light Sky, Lichen,
+  or Warm Stone as normal-size text on Alpine Off-White.
+- Maintain visible keyboard focus and reduced-motion behavior.
+- Localization must preserve meaning and hierarchy, not merely literal word
+  length.
+- Public copy must match the current release state. Future-state mockup text
+  is not evidence that a feature has shipped.
+- Change app screenshots only as part of a reviewed application release or an
+  explicitly scoped screenshot task.
+- Do not make broad CSS or generated-page refactors during unrelated content
+  changes.


### PR DESCRIPTION
Adds tracked repository and scoped governance instructions, preserves local AGENTS.override.md, aligns documentation with release-neutral product truth, and leaves runtime files unchanged. Validation: git diff --check, ignore-policy checks, protected-path checks, and exact eleven-file diff scope passed. No build, device, deploy, or release action performed.