### PR TITLE
Beta 8 — OpenTopoMap production catalog gate

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -69,7 +69,8 @@ PYTHONPATH=backend/catalog-api/src python3 -m unittest discover -s backend/catal
   metadata.
 - CSRF-protected `POST /admin/providers/<id>/check`, `/state`, `/collect`, and
   `/retire` operate only on known server-side adapters; they cannot upload
-  parser or executable provider code.
+  parser or executable provider code. The long OpenTopoMap sweep is rejected
+  from the HTTP collection action and runs only as the scheduler/operator job.
 - `POST /map-events` accepts a separate rate-limited, idempotent,
   privacy-minimised map-operation event contract. `GET
   /admin/map-statistics.json` exposes its private aggregates and never returns
@@ -148,17 +149,28 @@ weekly on Monday at 03:00 UTC (`COLLECTOR_SCHEDULE_UTC=MON 03:00`). A manual
 collection can still be run immediately after a provider release or source
 change.
 
-Scheduled catalog collection remains a separate process. The authenticated
-admin `/collect` action may run one known adapter on demand and records a
-collection run; health checks perform only bounded source probes. Neither path
-downloads, stores, proxies, mirrors, or serves a provider map binary.
+Scheduled catalog collection remains a separate process. It runs independent
+Freizeitkarte, OpenTopoMap, and Garmin-device jobs, so one source failure does
+not suppress the others. The authenticated admin `/collect` action remains
+available for the short FZK adapter; OTM uses the dedicated command below
+because inspecting 177 archives must not hold an HTTP request. Health checks
+perform only bounded source probes. No path downloads, stores, proxies,
+mirrors, or serves a provider map binary.
+
+```sh
+terento-catalog-collect --provider opentopomap --dry-run
+terento-catalog-collect --provider opentopomap
+```
 
 The reviewed OpenTopoMap adapter derives stable package identity from the
 official `otm-<region>.zip` filename and reads each country row's generated-at
-timestamp. It accepts all current official Garmin region shapes, excludes
-Basecamp archives, and relates the shared Canada contours archive to both
-Canada main packages. OpenTopoMap remains `PAUSED` until the beta.8 deployment
-gate is accepted; deploying the adapter does not activate it automatically.
+timestamp. Beta.8 collects exactly 177 current Garmin main archives, excludes
+Basecamp and contours, and validates every ZIP/IMG size using bounded range
+requests. A changed row count fails the complete snapshot before DB writes.
+Activation also fails closed unless the latest health is `HEALTHY`, the latest
+run succeeded, and all 177 available main artifacts are validated. OpenTopoMap
+remains `PAUSED` until an operator accepts that gate; collection never
+activates it automatically.
 
 Provider health is an availability summary. A provider can be `HEALTHY` when
 its website and catalog are reachable even before package downloads have been

--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -43,8 +43,25 @@ The scheduled sweep is weekly on Monday at 03:00 UTC:
 COLLECTOR_SCHEDULE_UTC=MON 03:00
 ```
 
-The scheduler collects Freizeitkarte maps first and Garmin device metadata
-second. A failed or partial provider run does not clear the previous catalog.
+The scheduler independently collects Freizeitkarte, OpenTopoMap main maps,
+and Garmin device metadata. A failed job does not suppress the other jobs or
+clear the previous known-good catalog.
+
+For the initial OpenTopoMap population, audit first and then run the same
+metadata-only command without `--dry-run`:
+
+```sh
+terento-catalog-collect --provider opentopomap --dry-run
+terento-catalog-collect --provider opentopomap
+```
+
+The beta.8 OTM gate requires `177 packages / 177 artifacts`, all artifacts
+`VALIDATED`, and zero contours. The command inspects ZIP central-directory and
+IMG metadata with bounded `HEAD`/`Range` requests; it does not retain the map
+archives. Keep OTM `PAUSED` until `/admin/providers/opentopomap` shows the
+successful run, 177 active packages, zero broken packages, and `HEALTHY`.
+Only then may an operator change it to `ACTIVE`. A failed activation request
+does not modify provider state.
 The Garmin collector creates a `MISSING` asset baseline for new devices; it
 does not request product-image binaries and it never changes an asset to
 `AVAILABLE`.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -948,6 +948,13 @@ def provider_detail_page(
     if status != "RETIRED":
         next_status = "PAUSED" if status == "ACTIVE" else "ACTIVE"
         state_button = _provider_action_button(provider_id, "state", "Pause" if next_status == "PAUSED" else "Activate", status=next_status, secondary=True)
+    collect_control = (
+        "<span class='provider-action-note'>Collected by the scheduled operator job</span>"
+        if provider_id == "opentopomap"
+        else _provider_action_button(
+            provider_id, "collect", "Collect catalog", secondary=True
+        )
+    )
     rows_packages = "".join(_provider_package_row(package) for package in packages)
     rows_sources = "".join(_provider_source_row(source) for source in sources)
     rows_health = "".join(_provider_health_row(item) for item in health_history)
@@ -965,7 +972,7 @@ def provider_detail_page(
         <div class='heading-row'><div><p class='eyebrow'>Provider detail</p><h1>{html.escape(name)}</h1><p class='lede'><code>{html.escape(provider_id)}</code> · adapter <code>{html.escape(str(provider.get('adapterId') or '—'))}</code></p></div><div class='provider-heading-status'>{_provider_status_badge(status)} {_provider_status_badge(health, kind='health')}</div></div>
         <section class='provider-action-bar' data-provider-id='{html.escape(provider_id, quote=True)}' aria-label='Provider actions'>
           {_provider_action_button(provider_id, 'check', 'Check now')}
-          {_provider_action_button(provider_id, 'collect', 'Collect catalog', secondary=True)}
+          {collect_control}
           {state_button}
           {_provider_action_button(provider_id, 'retire', 'Retire', secondary=True, disabled=status == 'RETIRED')}
           <p class='admin-action-status' id='provider-action-status' aria-live='polite'></p>

--- a/backend/catalog-api/src/terento_catalog/collect.py
+++ b/backend/catalog-api/src/terento_catalog/collect.py
@@ -8,6 +8,8 @@ from .collectors import FreizeitkarteCollector
 from .config import Settings
 from .db import Database
 from .provider_catalog import (
+    KNOWN_PROVIDER_DEFINITIONS,
+    OpenTopoMapProviderAdapter,
     ProviderAdapter,
     ProviderCollectionError,
     snapshot_from_freizeitkarte_records,
@@ -101,7 +103,13 @@ def collect_provider_once(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Collect all official Freizeitkarte Garmin metadata"
+        description="Collect one reviewed map provider's Garmin metadata"
+    )
+    parser.add_argument(
+        "--provider",
+        choices=tuple(sorted(KNOWN_PROVIDER_DEFINITIONS)),
+        default="freizeitkarte",
+        help="reviewed provider adapter to collect (default: freizeitkarte)",
     )
     parser.add_argument(
         "--dry-run",
@@ -111,14 +119,23 @@ def main() -> None:
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     settings = Settings.from_env()
-    count = collect_once(
-        Database(
-            settings.database_url,
-            connect_timeout_seconds=settings.database_connect_timeout_seconds,
-        ),
-        dry_run=args.dry_run,
+    database = Database(
+        settings.database_url,
+        connect_timeout_seconds=settings.database_connect_timeout_seconds,
     )
-    print(json.dumps({"collector": "freizeitkarte", "records": count}))
+    if args.provider == "freizeitkarte":
+        count = collect_once(database, dry_run=args.dry_run)
+        result: dict[str, int | str] = {
+            "provider": "freizeitkarte",
+            "packages": count,
+        }
+    else:
+        result = collect_provider_once(
+            database,
+            OpenTopoMapProviderAdapter(),
+            dry_run=args.dry_run,
+        )
+    print(json.dumps(result))
 
 
 if __name__ == "__main__":

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -1336,6 +1336,33 @@ class Database:
                         """,
                         (definition.id, artifact.source_url),
                     )
+            if definition.id == "opentopomap":
+                # OTM snapshots are complete. Beta.8 is main-only, so a
+                # repeated collection must also remove metadata for deferred
+                # contours instead of leaving a mixed public catalog behind.
+                package_ids = [package.id for package in snapshot.packages]
+                artifact_ids = [
+                    artifact.id
+                    for package in snapshot.packages
+                    for artifact in package.artifacts
+                ]
+                connection.execute(
+                    """
+                    DELETE FROM map_artifact
+                    WHERE package_id IN (
+                        SELECT id FROM map_package WHERE provider_id = %s
+                    ) AND NOT (id = ANY(%s))
+                    """,
+                    (definition.id, artifact_ids),
+                )
+                connection.execute(
+                    """
+                    UPDATE map_package
+                    SET availability = 'RETIRED', updated_at = now()
+                    WHERE provider_id = %s AND NOT (id = ANY(%s))
+                    """,
+                    (definition.id, package_ids),
+                )
 
     def provider_rows(self) -> list[dict[str, Any]]:
         query = """
@@ -1461,6 +1488,67 @@ class Database:
                 """,
                 (provider_id, limit),
             ).fetchall())
+
+    def provider_activation_readiness(self, provider_id: str) -> dict[str, Any]:
+        """Return fail-closed catalog evidence used before provider activation."""
+
+        with self.connection() as connection:
+            row = connection.execute(
+                """
+                SELECT
+                    p.last_catalog_sync,
+                    h.status AS health,
+                    r.status AS run_status,
+                    COALESCE(r.package_count, 0) AS run_package_count,
+                    COALESCE(r.artifact_count, 0) AS run_artifact_count,
+                    COALESCE(c.package_count, 0) AS package_count,
+                    COALESCE(c.available_package_count, 0) AS available_package_count,
+                    COALESCE(c.main_artifact_count, 0) AS main_artifact_count,
+                    COALESCE(c.validated_main_count, 0) AS validated_main_count,
+                    COALESCE(c.other_artifact_count, 0) AS other_artifact_count
+                FROM map_provider p
+                LEFT JOIN LATERAL (
+                    SELECT status FROM provider_health_check
+                    WHERE provider_id = p.id
+                    ORDER BY checked_at DESC, id DESC LIMIT 1
+                ) h ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT status, package_count, artifact_count
+                    FROM catalog_collection_run
+                    WHERE provider_id = p.id
+                    ORDER BY started_at DESC, id DESC LIMIT 1
+                ) r ON TRUE
+                LEFT JOIN LATERAL (
+                    SELECT
+                        count(DISTINCT mp.id) FILTER (
+                            WHERE mp.availability <> 'RETIRED'
+                        ) AS package_count,
+                        count(DISTINCT mp.id) FILTER (
+                            WHERE mp.availability = 'AVAILABLE'
+                        ) AS available_package_count,
+                        count(ma.id) FILTER (
+                            WHERE ma.kind = 'main' AND mp.availability <> 'RETIRED'
+                        ) AS main_artifact_count,
+                        count(ma.id) FILTER (
+                            WHERE ma.kind = 'main'
+                              AND ma.validation_status = 'VALIDATED'
+                              AND ma.size_bytes > 0
+                              AND ma.install_size_bytes > 0
+                              AND ma.install_payload_path IS NOT NULL
+                              AND mp.availability <> 'RETIRED'
+                        ) AS validated_main_count,
+                        count(ma.id) FILTER (
+                            WHERE ma.kind <> 'main' AND mp.availability <> 'RETIRED'
+                        ) AS other_artifact_count
+                    FROM map_package mp
+                    LEFT JOIN map_artifact ma ON ma.package_id = mp.id
+                    WHERE mp.provider_id = p.id
+                ) c ON TRUE
+                WHERE p.id = %s
+                """,
+                (provider_id,),
+            ).fetchone()
+        return dict(row) if row is not None else {}
 
     def provider_health_history(self, provider_id: str, limit: int = 50) -> list[dict[str, Any]]:
         with self.connection() as connection:

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -63,7 +63,7 @@ from .map_events import (
 from .provider_catalog import (
     KNOWN_PROVIDER_DEFINITIONS,
     FreizeitkarteProviderAdapter,
-    OpenTopoMapProviderAdapter,
+    OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT,
 )
 from .provider_health import check_provider as run_provider_health_check
 
@@ -198,12 +198,13 @@ class CatalogService:
         if definition is None:
             raise LookupError("provider_not_found")
         self.database.ensure_provider_definition(definition)
-        if provider_id == "freizeitkarte":
-            adapter = FreizeitkarteProviderAdapter()
-        elif provider_id == "opentopomap":
-            adapter = OpenTopoMapProviderAdapter()
-        else:  # pragma: no cover - guarded by the known registry
+        if provider_id == "opentopomap":
+            # Inspecting 177 remote ZIP central directories is intentionally a
+            # dedicated operator job, not a long-running HTTP request.
+            raise ValueError("provider_collection_requires_operator_job")
+        if provider_id != "freizeitkarte":  # pragma: no cover - known registry guard
             raise LookupError("provider_adapter_not_found")
+        adapter = FreizeitkarteProviderAdapter()
         try:
             result = _format_json_value(collect_provider_once(self.database, adapter))
         except Exception as exc:
@@ -239,6 +240,23 @@ class CatalogService:
         if status not in {"ACTIVE", "PAUSED", "RETIRED"}:
             raise ValueError("invalid_provider_status")
         self.database.ensure_provider_definition(definition)
+        if provider_id == "opentopomap" and status == "ACTIVE":
+            evidence = self.database.provider_activation_readiness(provider_id)
+            expected = OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT
+            ready = (
+                evidence.get("health") == "HEALTHY"
+                and evidence.get("run_status") == "SUCCEEDED"
+                and evidence.get("run_package_count") == expected
+                and evidence.get("run_artifact_count") == expected
+                and evidence.get("package_count") == expected
+                and evidence.get("available_package_count") == expected
+                and evidence.get("main_artifact_count") == expected
+                and evidence.get("validated_main_count") == expected
+                and evidence.get("other_artifact_count") == 0
+                and evidence.get("last_catalog_sync") is not None
+            )
+            if not ready:
+                raise ValueError("provider_catalog_not_ready_for_activation")
         if not self.database.set_provider_status(
             provider_id,
             status,

--- a/backend/catalog-api/src/terento_catalog/provider_catalog.py
+++ b/backend/catalog-api/src/terento_catalog/provider_catalog.py
@@ -7,9 +7,11 @@ URLs only; they never proxy or persist provider map binaries.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, datetime, timezone
 from html.parser import HTMLParser
 import re
+import time
 from typing import Any, Protocol
 from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import Request, urlopen
@@ -118,6 +120,11 @@ KNOWN_PROVIDER_DEFINITIONS: dict[str, ProviderDefinition] = {
     item.id: item for item in (FREIZEITKARTE, OPENTOPO_MAP)
 }
 
+# Beta.8 intentionally publishes only OpenTopoMap's ready-to-install Garmin
+# main archives. Contours remain parsed for source auditing, but are not
+# collected or exposed until their separate product gate is accepted.
+OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT = 177
+
 
 class FreizeitkarteProviderAdapter:
     definition = FREIZEITKARTE
@@ -214,15 +221,30 @@ class OpenTopoMapProviderAdapter:
         *,
         fetcher: OpenTopoMapFetcher | None = None,
         catalog_url: str | None = None,
+        expected_main_package_count: int = OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT,
+        max_workers: int = 4,
+        measurement_attempts: int = 2,
     ) -> None:
         self.fetcher = fetcher or OpenTopoMapFetcher()
         self.catalog_url = catalog_url or self.definition.catalog_url
+        self.expected_main_package_count = expected_main_package_count
+        self.max_workers = max(1, min(max_workers, 4))
+        self.measurement_attempts = max(1, min(measurement_attempts, 3))
 
     def collect(self) -> ProviderSnapshot:
         html = self.fetcher.fetch_text(self.catalog_url)
-        links = parse_opentopomap_catalog(html, self.catalog_url)
+        links = [
+            link
+            for link in parse_opentopomap_catalog(html, self.catalog_url)
+            if link.kind == "main"
+        ]
+        if len(links) != self.expected_main_package_count:
+            raise ProviderCollectionError(
+                "OpenTopoMap main catalog count changed: "
+                f"expected {self.expected_main_package_count}, found {len(links)}"
+            )
         packages_by_region: dict[str, dict[str, Any]] = {}
-        measurements: dict[str, Any] = {}
+        measurements = self._measure_links(links)
         for link in links:
             package = packages_by_region.setdefault(
                 link.region,
@@ -236,10 +258,7 @@ class OpenTopoMapProviderAdapter:
                 raise ProviderCollectionError(
                     f"OpenTopoMap has duplicate {link.kind} artifact for {link.region}"
                 )
-            measurement = measurements.get(link.source_url)
-            if measurement is None:
-                measurement = self.fetcher.measure_zip(link.source_url)
-                measurements[link.source_url] = measurement
+            measurement = measurements[link.source_url]
             if measurement.download_size_bytes <= 0:
                 raise ProviderCollectionError(
                     f"OpenTopoMap artifact {link.source_url} has invalid size"
@@ -268,11 +287,7 @@ class OpenTopoMapProviderAdapter:
         fallback_release = _release_label(html)
         packages = []
         for region, value in sorted(packages_by_region.items()):
-            artifacts = tuple(
-                value["artifacts"][kind]
-                for kind in ("main", "contours")
-                if kind in value["artifacts"]
-            )
+            artifacts = (value["artifacts"]["main"],)
             source_updated_at = next(
                 (
                     artifact.source_updated_at
@@ -313,6 +328,37 @@ class OpenTopoMapProviderAdapter:
             packages=tuple(packages),
             collected_at=datetime.now(timezone.utc),
         )
+
+    def _measure_links(self, links: list[OpenTopoMapLink]) -> dict[str, Any]:
+        unique_urls = tuple(dict.fromkeys(link.source_url for link in links))
+        measurements: dict[str, Any] = {}
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            pending = {
+                executor.submit(self._measure_with_retry, url): url
+                for url in unique_urls
+            }
+            for future in as_completed(pending):
+                url = pending[future]
+                try:
+                    measurements[url] = future.result()
+                except Exception as exc:
+                    raise ProviderCollectionError(
+                        f"OpenTopoMap artifact inspection failed for {url}: "
+                        f"{type(exc).__name__}"
+                    ) from exc
+        return measurements
+
+    def _measure_with_retry(self, url: str) -> Any:
+        failure: Exception | None = None
+        for attempt in range(self.measurement_attempts):
+            try:
+                return self.fetcher.measure_zip(url)
+            except Exception as exc:  # provider/network failure is retried narrowly
+                failure = exc
+                if attempt + 1 < self.measurement_attempts:
+                    time.sleep(0.25 * (attempt + 1))
+        assert failure is not None
+        raise failure
 
 
 @dataclass(frozen=True)

--- a/backend/catalog-api/src/terento_catalog/scheduler.py
+++ b/backend/catalog-api/src/terento_catalog/scheduler.py
@@ -4,10 +4,11 @@ import logging
 import time
 from datetime import datetime, timedelta, timezone
 
-from .collect import collect_once
+from .collect import collect_once, collect_provider_once
 from .collect_devices import collect_devices_once
 from .config import Settings
 from .db import Database
+from .provider_catalog import OpenTopoMapProviderAdapter
 
 LOGGER = logging.getLogger(__name__)
 WEEKDAYS = {
@@ -37,18 +38,27 @@ def run_schedule(database: Database, schedule_utc: str) -> None:
         wait_seconds = max(1, (target - now).total_seconds())
         LOGGER.info("next metadata collection at %s", target.isoformat())
         time.sleep(wait_seconds)
+        run_collection_cycle(database)
+
+
+def run_collection_cycle(database: Database) -> None:
+    """Run independent weekly metadata jobs without cross-provider blocking."""
+
+    jobs = (
+        ("Freizeitkarte", lambda: collect_once(database)),
+        (
+            "OpenTopoMap",
+            lambda: collect_provider_once(database, OpenTopoMapProviderAdapter()),
+        ),
+        ("Garmin device", lambda: collect_devices_once(database)),
+    )
+    for label, job in jobs:
         try:
-            collect_once(database)
+            job()
         except Exception:
-            # A failed provider fetch must not stop the next scheduled attempt.
-            LOGGER.exception("scheduled Freizeitkarte collection failed")
-            continue
-        try:
-            collect_devices_once(database)
-        except Exception:
-            # Garmin discovery is independent from the map catalog. A failed
-            # device fetch must not invalidate the successful map collection.
-            LOGGER.exception("scheduled Garmin device collection failed")
+            # One upstream failure must not suppress the other independent
+            # provider/device metadata jobs or the next scheduled cycle.
+            LOGGER.exception("scheduled %s collection failed", label)
 
 
 def run_daily(database: Database, schedule_utc: str) -> None:

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from terento_catalog.catalog import build_catalog
 from terento_catalog.admin import token_hash
+from terento_catalog.admin import provider_detail_page
 from terento_catalog.http_api import CatalogService, make_handler
 from terento_catalog.map_events import (
     MapEventValidationError,
@@ -124,6 +125,9 @@ class FakeProviderDatabase:
             return False
         self.status = status
         return True
+
+    def provider_activation_readiness(self, provider_id):
+        return {}
 
     def csrf_valid(self, session, token):
         return token == "csrf"
@@ -251,6 +255,71 @@ class Beta8APITests(unittest.TestCase):
         self.assertIsNone(unknown_artifact["sizeBytes"])
         self.assertEqual(len(unknown_install["providers"][0]["maps"]), 1)
 
+    def test_opentopomap_activation_requires_complete_healthy_main_catalog(self):
+        expected = 177
+
+        class Database(FakeProviderDatabase):
+            def __init__(self):
+                super().__init__()
+                self.status = "PAUSED"
+                self.readiness = {
+                    "health": "HEALTHY",
+                    "run_status": "SUCCEEDED",
+                    "run_package_count": expected,
+                    "run_artifact_count": expected,
+                    "package_count": expected,
+                    "available_package_count": expected,
+                    "main_artifact_count": expected,
+                    "validated_main_count": expected,
+                    "other_artifact_count": 0,
+                    "last_catalog_sync": datetime(2026, 8, 31, tzinfo=UTC),
+                }
+
+            def provider_activation_readiness(self, provider_id):
+                return self.readiness
+
+            def set_provider_status(self, provider_id, status, **kwargs):
+                self.status = status
+                return provider_id == "opentopomap"
+
+        database = Database()
+        service = CatalogService(database)
+        result = service.set_provider_status(
+            "opentopomap", "ACTIVE", admin_user_id=7
+        )
+        self.assertEqual(result, {"id": "opentopomap", "status": "ACTIVE"})
+
+        database.status = "PAUSED"
+        database.readiness["validated_main_count"] = expected - 1
+        with self.assertRaisesRegex(
+            ValueError, "provider_catalog_not_ready_for_activation"
+        ):
+            service.set_provider_status("opentopomap", "ACTIVE", admin_user_id=7)
+        self.assertEqual(database.status, "PAUSED")
+
+    def test_opentopomap_admin_collection_requires_operator_job(self):
+        with self.assertRaisesRegex(
+            ValueError, "provider_collection_requires_operator_job"
+        ):
+            CatalogService(FakeProviderDatabase()).collect_provider("opentopomap")
+
+        page = provider_detail_page(
+            {
+                "provider": {
+                    "id": "opentopomap",
+                    "name": "OpenTopoMap",
+                    "status": "PAUSED",
+                    "health": "HEALTHY",
+                }
+            },
+            [],
+            [],
+            {"id": 7, "username": "admin"},
+            "csrf",
+        )
+        self.assertNotIn(b"Collect catalog", page)
+        self.assertIn(b"scheduled operator job", page)
+
     def test_map_event_validation_is_private_and_normalizes_identifiers(self):
         event = validate_map_event(json.dumps({
             "schemaVersion": 1,
@@ -363,7 +432,9 @@ class Beta8APITests(unittest.TestCase):
             def measure_zip(self, url):
                 return Measurement()
 
-        snapshot = OpenTopoMapProviderAdapter(fetcher=Fetcher()).collect()
+        snapshot = OpenTopoMapProviderAdapter(
+            fetcher=Fetcher(), expected_main_package_count=1
+        ).collect()
         package = snapshot.packages[0]
         self.assertEqual(package.id, "opentopomap-azores")
         self.assertEqual(package.provider_region_id, "azores")
@@ -372,8 +443,51 @@ class Beta8APITests(unittest.TestCase):
         self.assertEqual(package.source_updated_at.isoformat(), "2026-05-24T20:24:18+00:00")
         self.assertEqual(
             [artifact.id for artifact in package.artifacts],
-            ["opentopomap-azores-main", "opentopomap-azores-contours"],
+            ["opentopomap-azores-main"],
         )
+
+    def test_opentopomap_beta8_collection_is_main_only_and_count_guarded(self):
+        html = """
+        <table>
+          <tr class="country"><td>Andorra</td>
+            <td><a href="europe/andorra/otm-andorra.zip">Garmin</a></td>
+            <td><a href="europe/andorra/otm-andorra-contours.zip">Contours</a></td>
+            <td>2026-05-24 20:24:18</td></tr>
+          <tr class="country"><td>Azores</td>
+            <td><a href="europe/azores/otm-azores.zip">Garmin</a></td>
+            <td><a href="europe/azores/otm-azores-contours.zip">Contours</a></td>
+            <td>2026-05-24 20:24:18</td></tr>
+        </table>
+        """
+
+        class Measurement:
+            download_size_bytes = 100
+            install_size_bytes = 120
+            payload_path = "map.img"
+
+        class Fetcher:
+            def __init__(self):
+                self.measured = []
+
+            def fetch_text(self, url):
+                return html
+
+            def measure_zip(self, url):
+                self.measured.append(url)
+                return Measurement()
+
+        fetcher = Fetcher()
+        snapshot = OpenTopoMapProviderAdapter(
+            fetcher=fetcher, expected_main_package_count=2
+        ).collect()
+        self.assertEqual(len(snapshot.packages), 2)
+        self.assertEqual(len(fetcher.measured), 2)
+        self.assertTrue(all("contours" not in url for url in fetcher.measured))
+        self.assertTrue(all(package.capabilities == ("main",) for package in snapshot.packages))
+        with self.assertRaisesRegex(RuntimeError, "expected 3, found 2"):
+            OpenTopoMapProviderAdapter(
+                fetcher=Fetcher(), expected_main_package_count=3
+            ).collect()
 
     def test_provider_health_checks_mime_zip_and_img(self):
         class Measurement:

--- a/backend/catalog-api/tests/test_scheduler.py
+++ b/backend/catalog-api/tests/test_scheduler.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
 
-from terento_catalog.scheduler import _parse_schedule
+from terento_catalog.scheduler import _parse_schedule, run_collection_cycle
 
 
 class SchedulerTests(unittest.TestCase):
@@ -15,6 +16,18 @@ class SchedulerTests(unittest.TestCase):
     def test_invalid_weekday_is_rejected(self) -> None:
         with self.assertRaisesRegex(RuntimeError, "MON-SUN"):
             _parse_schedule("FUNDAY 03:00")
+
+    @patch("terento_catalog.scheduler.collect_devices_once")
+    @patch("terento_catalog.scheduler.collect_provider_once")
+    @patch("terento_catalog.scheduler.collect_once")
+    def test_provider_jobs_are_independent(
+        self, collect_fzk, collect_otm, collect_devices
+    ) -> None:
+        collect_fzk.side_effect = RuntimeError("FZK offline")
+        run_collection_cycle(object())
+        collect_fzk.assert_called_once()
+        collect_otm.assert_called_once()
+        collect_devices.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Objective

Prepare the OpenTopoMap catalog for production without activating it automatically.

## Changes

- Collect exactly 177 OpenTopoMap Garmin main packages for beta.8.
- Exclude Basecamp and deferred contours from the persisted beta.8 snapshot.
- Validate ZIP and IMG metadata with bounded Range requests, four workers, and narrow retries.
- Reject a changed catalog count before any snapshot write.
- Run OpenTopoMap as a scheduler/operator job instead of a long Admin HTTP request.
- Keep FZK, OTM, and Garmin-device scheduled jobs independent.
- Remove stale OTM contours metadata on a complete replacement snapshot.
- Block OTM activation unless health is HEALTHY and the latest catalog evidence is complete: 177 packages, 177 validated main artifacts, zero contours, and a successful collection run.
- Keep collection and activation as separate operator actions.

## Validation

- Backend suite: 157/157 PASS.
- Live read-only OTM audit: 177 packages, 177 artifacts, 177 validated, 0 contours.
- App regressions: Stage 1 (17), Stage 4.1 (24), Stage 4.5 (27) PASS.
- Python compile and git diff check PASS.

## Production gate

This PR does not populate production data and does not activate OpenTopoMap. After merge and deployment:

1. Run the OpenTopoMap collector.
2. Confirm latest run SUCCEEDED.
3. Confirm 177 active packages, 177 validated main artifacts, zero contours, and zero broken packages.
4. Confirm provider health remains HEALTHY.
5. Explicitly activate OpenTopoMap.
6. Run one live app catalog smoke test.

## Deferred

- OpenTopoMap contours remain deferred beyond beta.8.
- Mixed-provider installation batches remain deferred to beta.9 or beta.10.
