### PR TITLE
Fix FZK provider-native release version serialization

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -328,6 +328,13 @@ installation even when the catalog provides this metadata.
 `sourceURL` is always an original provider URL. The API never fetches that
 archive for the client and never streams its bytes.
 
+`version` is the comparable year/month value used by clients for update
+ordering. When a provider publishes a native release label such as FZK's
+`2/2026`, the API derives this comparable value from the provider source date
+(`2026-05` for a `2026-05-03` source date) and preserves the original label in
+`release` and `releaseMetadata.versionLabel`. The historical `2000-01`
+serializer sentinel is never emitted.
+
 The collector uses the release page as the provider-wide version signal. For
 each official regional page it selects the English Garmin package when
 available, otherwise the first published language variant. It validates the

--- a/backend/catalog-api/src/terento_catalog/catalog.py
+++ b/backend/catalog-api/src/terento_catalog/catalog.py
@@ -161,7 +161,17 @@ def _build_provider_neutral_catalog(
         package = packages.get(key)
         if package is None:
             release = str(row.get("release") or "unknown")
-            year, month = _release_version(release)
+            normalized_version = _release_version(
+                release,
+                source_updated_at=row.get("package_source_updated_at"),
+            )
+            if normalized_version is None:
+                # A provider-native release label is not necessarily a
+                # calendar version. Do not expose the old technical sentinel
+                # (2000-01) when neither the label nor the provider date can
+                # establish a comparable version.
+                continue
+            year, month = normalized_version
             source_size = row.get("artifact_size_bytes")
             download_size = row.get("artifact_download_size_bytes") or source_size
             install_size = row.get("artifact_install_size_bytes")
@@ -238,11 +248,47 @@ def _build_provider_neutral_catalog(
     }
 
 
-def _release_version(value: str) -> tuple[int, int]:
+def _release_version(
+    value: str,
+    *,
+    source_updated_at: Any = None,
+) -> tuple[int, int] | None:
+    """Return a comparable year/month without inventing a provider version.
+
+    Some providers publish a release sequence such as Freizeitkarte's
+    ``2/2026``. That is a provider-native label, not February 2026. When the
+    provider also supplies a source date, that date is the authoritative
+    comparable version (for example ``2026-05-03`` becomes ``2026-05``).
+    """
+
+    if source_updated_at is not None:
+        year = getattr(source_updated_at, "year", None)
+        month = getattr(source_updated_at, "month", None)
+        if (
+            isinstance(year, int)
+            and isinstance(month, int)
+            and _valid_version(year, month)
+        ):
+            return year, month
+
     match = re.search(r"\b(20\d{2})[-/.](0?[1-9]|1[0-2])\b", value)
     if match:
-        return int(match.group(1)), int(match.group(2))
-    return 2000, 1
+        version = int(match.group(1)), int(match.group(2))
+        return version if _valid_version(*version) else None
+
+    # `2/2026` is intentionally not reversed to `2026-02`: the first number
+    # is a provider release sequence and only the source date can establish
+    # the calendar month used for comparisons.
+    if re.search(r"\b(?:0?[1-9]|1[0-2])/20\d{2}\b", value):
+        return None
+
+    return None
+
+
+def _valid_version(year: int, month: int) -> bool:
+    # 2000-01 was the historical serializer fallback and is never a valid
+    # public provider version.
+    return year >= 2000 and 1 <= month <= 12 and (year, month) != (2000, 1)
 
 
 def _native_validation_state(value: str) -> str:

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -251,6 +251,75 @@ class Beta8APITests(unittest.TestCase):
         self.assertIsNone(unknown_artifact["sizeBytes"])
         self.assertEqual(len(unknown_install["providers"][0]["maps"]), 1)
 
+    def test_provider_native_release_uses_source_date_for_comparable_version(self):
+        document = build_catalog([
+            {
+                "provider_id": "freizeitkarte",
+                "provider_name": "Freizeitkarte",
+                "provider_adapter_id": "freizeitkarte",
+                "provider_status": "ACTIVE",
+                "provider_health": "HEALTHY",
+                "provider_website": "https://www.freizeitkarte-osm.de/",
+                "provider_attribution": "OSM",
+                "provider_license_information": "ODbL",
+                "package_id": "freizeitkarte-lithuania",
+                "provider_region_id": "LTU+",
+                "canonical_region_id": "LT",
+                "package_name": "Lithuania",
+                "package_region": "LT",
+                "release": "2/2026",
+                "release_id": "2/2026",
+                "version_label": "2/2026",
+                "package_source_updated_at": datetime(2026, 5, 3, tzinfo=UTC),
+                "country_codes": ["LT"],
+                "region_kind": "country",
+                "capabilities": ["main"],
+                "artifact_id": "freizeitkarte-lithuania-main",
+                "artifact_kind": "main",
+                "artifact_source_url": "https://download.freizeitkarte-osm.de/LTU.zip",
+                "artifact_size_bytes": 219000000,
+                "artifact_install_size_bytes": 276000000,
+                "artifact_required": True,
+                "artifact_validation_status": "VALIDATED",
+                "artifact_content_type": "application/zip",
+            },
+        ], datetime(2026, 8, 31, tzinfo=UTC))
+
+        package = document["providers"][0]["maps"][0]
+        self.assertEqual(package["release"], "2/2026")
+        self.assertEqual(package["version"], {"year": 2026, "month": 5})
+        self.assertEqual(package["releaseDate"], "2026-05-03T00:00:00+00:00")
+        self.assertEqual(
+            package["releaseMetadata"]["versionLabel"],
+            "2/2026",
+        )
+        self.assertNotEqual(package["version"], {"year": 2000, "month": 1})
+
+    def test_provider_neutral_catalog_does_not_emit_historical_version_sentinel(self):
+        document = build_catalog([
+            {
+                "provider_id": "freizeitkarte",
+                "provider_name": "Freizeitkarte",
+                "provider_adapter_id": "freizeitkarte",
+                "provider_status": "ACTIVE",
+                "provider_health": "UNKNOWN",
+                "package_id": "freizeitkarte-unknown",
+                "provider_region_id": "UNKNOWN",
+                "canonical_region_id": "XX",
+                "package_name": "Unknown",
+                "package_region": "XX",
+                "release": "unknown",
+                "artifact_id": "freizeitkarte-unknown-main",
+                "artifact_kind": "main",
+                "artifact_source_url": "https://download.freizeitkarte-osm.de/unknown.zip",
+                "artifact_size_bytes": 100,
+                "artifact_install_size_bytes": None,
+                "artifact_required": True,
+            },
+        ], datetime(2026, 8, 31, tzinfo=UTC))
+
+        self.assertEqual(document["providers"][0]["maps"], [])
+
     def test_map_event_validation_is_private_and_normalizes_identifiers(self):
         event = validate_map_event(json.dumps({
             "schemaVersion": 1,

--- a/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapModels.swift
+++ b/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapModels.swift
@@ -620,6 +620,23 @@ struct MapPackage: Codable, Equatable, Identifiable, Sendable {
         artifacts.first(where: { $0.kind == .main })
     }
 
+    /// Provider-native labels are intended for user-facing display. The
+    /// normalized version remains available for comparisons and update logic.
+    var displayVersionLabel: String? {
+        if let label = releaseMetadata?.versionLabel?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ), !label.isEmpty {
+            return label
+        }
+
+        // 2000-01 was the historical API serializer fallback. It is not a
+        // real map version and must never reach the user-facing UI.
+        guard version.year != 2000 || version.month != 1 else {
+            return nil
+        }
+        return version.description
+    }
+
     var optionalArtifacts: [MapArtifact] {
         artifacts.filter { !$0.required }
     }

--- a/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapSelectionPlanner.swift
+++ b/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapSelectionPlanner.swift
@@ -40,10 +40,14 @@ struct MapSelectionItem: Identifiable, Equatable, Sendable {
         let providerName = comparison.providerName.trimmingCharacters(
             in: .whitespacesAndNewlines
         )
-        guard !providerName.isEmpty else {
-            return package.version.description
+        var parts: [String] = []
+        if !providerName.isEmpty {
+            parts.append(providerName)
         }
-        return "\(providerName) · \(package.version.description)"
+        if let versionLabel = package.displayVersionLabel {
+            parts.append(versionLabel)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     var action: MapSelectionAction { lifecycleAction }
@@ -69,7 +73,7 @@ struct MapSelectionItem: Identifiable, Equatable, Sendable {
         case .notInstalled:
             return installSizeBytes == nil ? "Size calculated before installation" : ""
         case .updateAvailable:
-            return "Update available · \(installedVersionLabel ?? "Version unavailable") → \(package.version)"
+            return "Update available · \(installedVersionLabel ?? "Version unavailable") → \(package.displayVersionLabel ?? "Version unavailable")"
         case .upToDate:
             return "Installed · Up to date"
         case .newerInstalled:

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/MapVersionComparisonTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/MapVersionComparisonTests.swift
@@ -15,6 +15,7 @@ struct MapVersionComparisonTests {
         testEarlierCatalogVersionMeansInstalledVersionIsNewer()
         testInvalidVersionProducesUnknown()
         testEmbeddedDateFragmentIsUnknown()
+        testProviderNativeVersionLabelIsUsedForDisplay()
         testOtherInstalledRegionStillMeansInstallAvailable()
         testKnownDifferentRegionCannotMatchByIdentifier()
 
@@ -79,6 +80,48 @@ struct MapVersionComparisonTests {
         expect(
             version == nil,
             "an embedded date fragment is not treated as a map release"
+        )
+    }
+
+    private static func testProviderNativeVersionLabelIsUsedForDisplay() {
+        let package = MapPackage(
+            id: "freizeitkarte-lithuania",
+            providerId: "freizeitkarte",
+            regionId: "LT",
+            name: "Lithuania",
+            version: MapVersion(year: 2000, month: 1)!,
+            sizeBytes: 219_000_000,
+            sourceURL: nil,
+            releaseDate: "2026-05-03",
+            identifier: "LTU+",
+            releaseMetadata: MapReleaseMetadata(
+                releaseId: "2/2026",
+                versionLabel: "2/2026",
+                generatedAt: nil,
+                sourceUpdatedAt: "2026-05-03"
+            )
+        )
+
+        expect(
+            package.displayVersionLabel == "2/2026",
+            "provider-native release label is preferred for display"
+        )
+
+        let fallbackPackage = MapPackage(
+            id: "freizeitkarte-unknown",
+            providerId: "freizeitkarte",
+            regionId: "XX",
+            name: "Unknown",
+            version: MapVersion(year: 2000, month: 1)!,
+            sizeBytes: 100,
+            sourceURL: nil,
+            releaseDate: nil,
+            identifier: nil
+        )
+
+        expect(
+            fallbackPackage.displayVersionLabel == nil,
+            "historical 2000-01 fallback is hidden from display"
         )
     }
 


### PR DESCRIPTION
## Summary

- normalize FZK provider-native `2/2026` using the provider source date (`2026-05-03` -> comparable `2026-05`)
- preserve `release` / `releaseMetadata.versionLabel` for user-facing provider-native display
- never emit or show the historical `2000-01` serializer fallback

## Validation

- backend beta.8 API tests: 12/12 PASS
- focused Swift map-version tests: PASS
- `git diff --check`: PASS

This PR targets `release/beta.8`. It does not deploy or change production.