### PR TITLE
fix(api): restore unsafe active OTM state

### DIFF
--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -73,6 +73,11 @@ compatibility-status classifier parameter as `BIGINT`, matching PostgreSQL's
 `count(*)` aggregate type, so the derived view can be rebuilt during a forward
 deployment.
 
+Migration `027_restore_otm_paused_state.sql` is a one-time safety repair for
+beta.8. It restores OpenTopoMap to `PAUSED` only when the provider is active,
+has no available packages, and has no audited activation. The repair is
+recorded in `admin_audit_log`; an explicitly audited activation is preserved.
+
 ## Asset review and publication
 
 Asset work is explicit and non-destructive. A candidate is prepared into

--- a/backend/catalog-api/src/terento_catalog/migrations/027_restore_otm_paused_state.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/027_restore_otm_paused_state.sql
@@ -1,0 +1,40 @@
+-- Restore the beta.8 OpenTopoMap safety state if an older deployment left the
+-- metadata-only provider active without any available catalog packages.
+-- Preserve an explicitly audited activation; only repair an unaudited,
+-- unusable ACTIVE state and record the repair in the provider audit history.
+
+WITH repaired AS (
+    UPDATE map_provider AS p
+    SET status = 'PAUSED', updated_at = now()
+    WHERE p.id = 'opentopomap'
+      AND p.status = 'ACTIVE'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM map_package AS package
+          WHERE package.provider_id = p.id
+            AND package.availability = 'AVAILABLE'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM admin_audit_log AS audit
+          WHERE audit.provider_id = p.id
+            AND audit.action = 'provider.status_changed'
+            AND audit.new_status = 'ACTIVE'
+      )
+    RETURNING p.id
+)
+INSERT INTO admin_audit_log (
+    admin_user_id, action, provider_id, old_status, new_status,
+    reason, target, request_id, details
+)
+SELECT
+    NULL,
+    'provider.status_repaired',
+    repaired.id,
+    'ACTIVE',
+    'PAUSED',
+    'Restored OpenTopoMap to PAUSED because activation evidence was not present.',
+    'PAUSED',
+    'migration-027',
+    '{"activationRequired":true,"availablePackageCount":0}'::jsonb
+FROM repaired;

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -162,6 +162,22 @@ class Beta8APITests(unittest.TestCase):
         self.assertNotIn("DROP TABLE", migration)
         self.assertNotIn("BYTEA", migration)
 
+    def test_otm_state_repair_is_conservative_and_audited(self):
+        migration = (
+            Path(__file__).parents[1]
+            / "src"
+            / "terento_catalog"
+            / "migrations"
+            / "027_restore_otm_paused_state.sql"
+        ).read_text(encoding="utf-8")
+        self.assertIn("UPDATE map_provider", migration)
+        self.assertIn("p.status = 'ACTIVE'", migration)
+        self.assertIn("package.availability = 'AVAILABLE'", migration)
+        self.assertIn("audit.action = 'provider.status_changed'", migration)
+        self.assertIn("provider.status_repaired", migration)
+        self.assertIn("migration-027", migration)
+        self.assertNotIn("DELETE FROM map_provider", migration)
+
     def test_provider_neutral_catalog_keeps_legacy_fields_and_artifacts(self):
         document = build_catalog([
             {


### PR DESCRIPTION
Production smoke found OpenTopoMap ACTIVE with zero available catalog packages after the provider activation gate deployment. Add a forward-only migration that restores PAUSED only for an unaudited unusable ACTIVE state, records the repair in admin_audit_log, and preserves explicitly audited activation. Includes a regression test and operations documentation. No map data or user device state is changed.