### PR TITLE
fix(api): keep OTM paused for beta.8 testing

### DIFF
--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -78,6 +78,12 @@ beta.8. It restores OpenTopoMap to `PAUSED` only when the provider is active,
 has no available packages, and has no audited activation. The repair is
 recorded in `admin_audit_log`; an explicitly audited activation is preserved.
 
+Migration `028_force_otm_beta8_paused.sql` is the explicit beta.8 release
+state correction. It pauses an existing `ACTIVE` OpenTopoMap record once and
+records the correction in `admin_audit_log`, so testing starts from the
+required paused state and a later activation remains an intentional admin
+action.
+
 ## Asset review and publication
 
 Asset work is explicit and non-destructive. A candidate is prepared into

--- a/backend/catalog-api/src/terento_catalog/migrations/028_force_otm_beta8_paused.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/028_force_otm_beta8_paused.sql
@@ -1,0 +1,27 @@
+-- Keep OpenTopoMap paused for the beta.8 testing release.
+-- This is a one-time operator-authorized state correction after an older
+-- deployment left the known adapter ACTIVE. It changes provider lifecycle
+-- state only; packages and provider metadata remain intact.
+
+WITH repaired AS (
+    UPDATE map_provider AS p
+    SET status = 'PAUSED', updated_at = now()
+    WHERE p.id = 'opentopomap'
+      AND p.status = 'ACTIVE'
+    RETURNING p.id
+)
+INSERT INTO admin_audit_log (
+    admin_user_id, action, provider_id, old_status, new_status,
+    reason, target, request_id, details
+)
+SELECT
+    NULL,
+    'provider.status_repaired',
+    repaired.id,
+    'ACTIVE',
+    'PAUSED',
+    'Kept OpenTopoMap PAUSED for beta.8 testing until explicit activation.',
+    'PAUSED',
+    'migration-028',
+    '{"beta8Testing":true,"explicitActivationRequired":true}'::jsonb
+FROM repaired;

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -178,6 +178,21 @@ class Beta8APITests(unittest.TestCase):
         self.assertIn("migration-027", migration)
         self.assertNotIn("DELETE FROM map_provider", migration)
 
+    def test_beta8_otm_pause_repair_is_explicit_and_audited(self):
+        migration = (
+            Path(__file__).parents[1]
+            / "src"
+            / "terento_catalog"
+            / "migrations"
+            / "028_force_otm_beta8_paused.sql"
+        ).read_text(encoding="utf-8")
+        self.assertIn("p.id = 'opentopomap'", migration)
+        self.assertIn("p.status = 'ACTIVE'", migration)
+        self.assertIn("SET status = 'PAUSED'", migration)
+        self.assertIn("provider.status_repaired", migration)
+        self.assertIn("migration-028", migration)
+        self.assertIn("explicitActivationRequired", migration)
+
     def test_provider_neutral_catalog_keeps_legacy_fields_and_artifacts(self):
         document = build_catalog([
             {


### PR DESCRIPTION
Production smoke after PR #66 found OpenTopoMap still ACTIVE because the conservative repair encountered existing provider metadata. Add a one-time explicit beta.8 state correction that pauses an ACTIVE OpenTopoMap record and records the change in admin_audit_log. This preserves all packages and FZK data and requires a later explicit activation action.