### PR TITLE
fix(api): collect only valid OTM main archives

### DIFF
--- a/backend/catalog-api/docs/operations.md
+++ b/backend/catalog-api/docs/operations.md
@@ -84,6 +84,12 @@ records the correction in `admin_audit_log`, so testing starts from the
 required paused state and a later activation remains an intentional admin
 action.
 
+The beta.8 OpenTopoMap collector accepts exactly 177 official `main` ZIP
+archives. `contours` links remain visible to the parser for source auditing,
+but are not collected or allowed to fail the main catalog; their installation
+gate is deferred. Main archive inspection uses bounded range requests with a
+small retry and a maximum of four concurrent provider requests.
+
 ## Asset review and publication
 
 Asset work is explicit and non-destructive. A candidate is prepared into

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -1337,6 +1337,34 @@ class Database:
                         (definition.id, artifact.source_url),
                     )
 
+            if definition.id == "opentopomap":
+                # Beta.8 publishes main maps only. A complete replacement
+                # snapshot must hide any contours or packages left by an
+                # earlier collector run without touching map binaries.
+                package_ids = [package.id for package in snapshot.packages]
+                artifact_ids = [
+                    artifact.id
+                    for package in snapshot.packages
+                    for artifact in package.artifacts
+                ]
+                connection.execute(
+                    """
+                    DELETE FROM map_artifact
+                    WHERE package_id IN (
+                        SELECT id FROM map_package WHERE provider_id = %s
+                    ) AND NOT (id = ANY(%s))
+                    """,
+                    (definition.id, artifact_ids),
+                )
+                connection.execute(
+                    """
+                    UPDATE map_package
+                    SET availability = 'RETIRED', updated_at = now()
+                    WHERE provider_id = %s AND NOT (id = ANY(%s))
+                    """,
+                    (definition.id, package_ids),
+                )
+
     def provider_rows(self) -> list[dict[str, Any]]:
         query = """
             SELECT

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -239,7 +239,10 @@ class CatalogService:
                 action="provider.catalog_collection_failed",
                 provider_id=provider_id,
                 request_id=request_id,
-                details={"error": type(exc).__name__},
+                details={
+                    "error": type(exc).__name__,
+                    "detail": str(exc)[:500],
+                },
             )
             raise
         self.database.record_admin_audit(

--- a/backend/catalog-api/src/terento_catalog/provider_catalog.py
+++ b/backend/catalog-api/src/terento_catalog/provider_catalog.py
@@ -6,10 +6,12 @@ URLs only; they never proxy or persist provider map binaries.
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from html.parser import HTMLParser
 import re
+import time
 from typing import Any, Protocol
 from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import Request, urlopen
@@ -118,6 +120,11 @@ KNOWN_PROVIDER_DEFINITIONS: dict[str, ProviderDefinition] = {
     item.id: item for item in (FREIZEITKARTE, OPENTOPO_MAP)
 }
 
+# Beta.8 exposes only OpenTopoMap's ready-to-install Garmin main archives.
+# Optional contours remain outside the collection gate until their own
+# validation contract is accepted.
+OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT = 177
+
 
 class FreizeitkarteProviderAdapter:
     definition = FREIZEITKARTE
@@ -214,15 +221,30 @@ class OpenTopoMapProviderAdapter:
         *,
         fetcher: OpenTopoMapFetcher | None = None,
         catalog_url: str | None = None,
+        expected_main_package_count: int = OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT,
+        max_workers: int = 4,
+        measurement_attempts: int = 2,
     ) -> None:
         self.fetcher = fetcher or OpenTopoMapFetcher()
         self.catalog_url = catalog_url or self.definition.catalog_url
+        self.expected_main_package_count = expected_main_package_count
+        self.max_workers = max(1, min(max_workers, 4))
+        self.measurement_attempts = max(1, min(measurement_attempts, 3))
 
     def collect(self) -> ProviderSnapshot:
         html = self.fetcher.fetch_text(self.catalog_url)
-        links = parse_opentopomap_catalog(html, self.catalog_url)
+        links = [
+            link
+            for link in parse_opentopomap_catalog(html, self.catalog_url)
+            if link.kind == "main"
+        ]
+        if len(links) != self.expected_main_package_count:
+            raise ProviderCollectionError(
+                "OpenTopoMap main catalog count changed: "
+                f"expected {self.expected_main_package_count}, found {len(links)}"
+            )
         packages_by_region: dict[str, dict[str, Any]] = {}
-        measurements: dict[str, Any] = {}
+        measurements = self._measure_links(links)
         for link in links:
             package = packages_by_region.setdefault(
                 link.region,
@@ -236,10 +258,7 @@ class OpenTopoMapProviderAdapter:
                 raise ProviderCollectionError(
                     f"OpenTopoMap has duplicate {link.kind} artifact for {link.region}"
                 )
-            measurement = measurements.get(link.source_url)
-            if measurement is None:
-                measurement = self.fetcher.measure_zip(link.source_url)
-                measurements[link.source_url] = measurement
+            measurement = measurements[link.source_url]
             if measurement.download_size_bytes <= 0:
                 raise ProviderCollectionError(
                     f"OpenTopoMap artifact {link.source_url} has invalid size"
@@ -268,11 +287,7 @@ class OpenTopoMapProviderAdapter:
         fallback_release = _release_label(html)
         packages = []
         for region, value in sorted(packages_by_region.items()):
-            artifacts = tuple(
-                value["artifacts"][kind]
-                for kind in ("main", "contours")
-                if kind in value["artifacts"]
-            )
+            artifacts = (value["artifacts"]["main"],)
             source_updated_at = next(
                 (
                     artifact.source_updated_at
@@ -313,6 +328,37 @@ class OpenTopoMapProviderAdapter:
             packages=tuple(packages),
             collected_at=datetime.now(timezone.utc),
         )
+
+    def _measure_links(self, links: list[OpenTopoMapLink]) -> dict[str, Any]:
+        unique_urls = tuple(dict.fromkeys(link.source_url for link in links))
+        measurements: dict[str, Any] = {}
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
+            pending = {
+                executor.submit(self._measure_with_retry, url): url
+                for url in unique_urls
+            }
+            for future in as_completed(pending):
+                url = pending[future]
+                try:
+                    measurements[url] = future.result()
+                except Exception as exc:
+                    raise ProviderCollectionError(
+                        f"OpenTopoMap artifact inspection failed for {url}: "
+                        f"{type(exc).__name__}: {exc}"
+                    ) from exc
+        return measurements
+
+    def _measure_with_retry(self, url: str) -> Any:
+        failure: Exception | None = None
+        for attempt in range(self.measurement_attempts):
+            try:
+                return self.fetcher.measure_zip(url)
+            except Exception as exc:  # provider/network failure is retried narrowly
+                failure = exc
+                if attempt + 1 < self.measurement_attempts:
+                    time.sleep(0.25 * (attempt + 1))
+        assert failure is not None
+        raise failure
 
 
 @dataclass(frozen=True)

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -467,7 +467,9 @@ class Beta8APITests(unittest.TestCase):
             def measure_zip(self, url):
                 return Measurement()
 
-        snapshot = OpenTopoMapProviderAdapter(fetcher=Fetcher()).collect()
+        snapshot = OpenTopoMapProviderAdapter(
+            fetcher=Fetcher(), expected_main_package_count=1, max_workers=1
+        ).collect()
         package = snapshot.packages[0]
         self.assertEqual(package.id, "opentopomap-azores")
         self.assertEqual(package.provider_region_id, "azores")
@@ -476,8 +478,51 @@ class Beta8APITests(unittest.TestCase):
         self.assertEqual(package.source_updated_at.isoformat(), "2026-05-24T20:24:18+00:00")
         self.assertEqual(
             [artifact.id for artifact in package.artifacts],
-            ["opentopomap-azores-main", "opentopomap-azores-contours"],
+            ["opentopomap-azores-main"],
         )
+        self.assertEqual(package.capabilities, ("main",))
+
+        class RecordingFetcher(Fetcher):
+            def __init__(self):
+                self.measured_urls = []
+
+            def measure_zip(self, url):
+                self.measured_urls.append(url)
+                return Measurement()
+
+        recording_fetcher = RecordingFetcher()
+        OpenTopoMapProviderAdapter(
+            fetcher=recording_fetcher, expected_main_package_count=1, max_workers=1
+        ).collect()
+        self.assertEqual(recording_fetcher.measured_urls, [
+            "https://garmin.opentopomap.org/europe/azores/otm-azores.zip"
+        ])
+
+        with self.assertRaisesRegex(RuntimeError, "expected 2, found 1"):
+            OpenTopoMapProviderAdapter(
+                fetcher=Fetcher(), expected_main_package_count=2
+            ).collect()
+
+    def test_otm_snapshot_cleanup_hides_deferred_contours(self):
+        source = (
+            Path(__file__).parents[1]
+            / "src"
+            / "terento_catalog"
+            / "db.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("if definition.id == \"opentopomap\":", source)
+        self.assertIn("DELETE FROM map_artifact", source)
+        self.assertIn("availability = 'RETIRED'", source)
+        self.assertIn("Beta.8 publishes main maps only", source)
+
+    def test_collection_failure_audit_keeps_provider_error_detail(self):
+        source = (
+            Path(__file__).parents[1]
+            / "src"
+            / "terento_catalog"
+            / "http_api.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn('"detail": str(exc)[:500]', source)
 
     def test_provider_health_checks_mime_zip_and_img(self):
         class Measurement:


### PR DESCRIPTION
Fix the production OTM catalog collection failure caused by the optional Saint Helena contours archive reporting an empty IMG payload. The beta.8 adapter now filters to exactly 177 official main archives, validates them with bounded concurrent range requests and narrow retries, and leaves contours deferred. Successful OTM snapshots retire stale deferred metadata without touching map binaries. Collection audit entries now retain the provider error detail. Local validation: 17 beta.8 tests, 9 ZIP tests, 123 backend tests excluding the existing Node.js-dependent admin suite, and a real read-only OTM collect returned 177 packages / 177 main artifacts / 0 contours.