### PR TITLE
Beta 8 — harden sequential OpenTopoMap installs

### DIFF
--- a/Terento.xcodeproj/project.pbxproj
+++ b/Terento.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 			ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 			CODE_SIGN_ENTITLEMENTS = app/Terento/Terento.entitlements;
 			CODE_SIGN_STYLE = Manual;
-			CURRENT_PROJECT_VERSION = 7;
+			CURRENT_PROJECT_VERSION = 8;
 			DEVELOPMENT_TEAM = VXALAZU3B5;
 			GENERATE_INFOPLIST_FILE = NO;
 			HEADER_SEARCH_PATHS = ("$(DERIVED_FILE_DIR)/TerentoNativeDependencies/include", "$(DERIVED_FILE_DIR)/TerentoNativeDependencies/include/libusb-1.0", "$(inherited)");
@@ -318,7 +318,7 @@
 			ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 			CODE_SIGN_ENTITLEMENTS = app/Terento/Terento.entitlements;
 			CODE_SIGN_STYLE = Manual;
-			CURRENT_PROJECT_VERSION = 7;
+			CURRENT_PROJECT_VERSION = 8;
 			DEVELOPMENT_TEAM = VXALAZU3B5;
 			GENERATE_INFOPLIST_FILE = NO;
 			HEADER_SEARCH_PATHS = ("$(DERIVED_FILE_DIR)/TerentoNativeDependencies/include", "$(DERIVED_FILE_DIR)/TerentoNativeDependencies/include/libusb-1.0", "$(inherited)");

--- a/lab/native-connectivity-poc/README.md
+++ b/lab/native-connectivity-poc/README.md
@@ -95,10 +95,16 @@ Map rows use the country/region as the title, normalize legacy provider-
 decorated names such as `Lithuania · Otm Lithuania`, and show provider plus
 normalized release on the second line. Same-provider regional variants use a
 parenthesized qualifier only when needed.
-The owner has confirmed one-map and same-provider multi-map OTM installation,
+The owner has confirmed one-map and same-provider two-map OTM installation,
 watch use, reconnect persistence, Manage maps discovery, one-map Remove, and
-the one-provider selection lock on the tested watch. Broader device evidence
-remains a separate release claim.
+the one-provider selection lock on the tested fēnix 8. An earlier two-map OTM
+release-candidate run verified and recorded the first map but exposed an
+affected-firmware MTP stall when the next device session was opened
+immediately. The batch transition now uses a provider-neutral five-second
+device-settle boundary before reopening MTP. The exact two-map OTM scenario
+passed on real hardware in build 8; the equivalent two-map Freizeitkarte
+scenario also passed. Broader device evidence remains a separate release
+claim.
 
 The final beta.8 app presentation keeps only `Update` and `Remove` in normal
 Manage maps rows. `Update` appears only from the canonical provider-neutral
@@ -190,11 +196,14 @@ confirmation, generic provider/custom inventory grouping, optional artifact
 storage planning, model-admission safety, and the Freizeitkarte/OpenTopoMap
 source paths. The common multi-map lifecycle resolves MTP object IDs again by
 exact managed filename and validated size after a write, because some Garmin
-firmware re-enumerates handles between sessions. The owner has separately
-confirmed one OpenTopoMap installation
-and Manage maps visibility on real hardware; these native tests do not turn
-that result into a broader device-support claim or exercise the separate
-web/admin UI. The focused beta.8 checks also cover the independent statistics
+firmware re-enumerates handles between sessions. It also applies one bounded,
+provider-neutral settle window between successful batch items so firmware can
+commit/index the completed IMG before Terento opens the next MTP inventory.
+The owner has separately confirmed same-provider multi-map OpenTopoMap and
+Freizeitkarte installation, Manage maps and watch visibility, reconnect
+persistence, and isolated one-map removal on real fēnix 8 hardware. These
+native tests do not turn that result into a broader device-support claim or
+exercise the separate web/admin UI. The focused beta.8 checks also cover the independent statistics
 consent/queue contract, measured installation viewport, and production
 `Update`/`Remove` action matrix. The metadata API contract is covered by backend tests; these
 native tests do not exercise it. The external-map safety tests cover only the

--- a/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapEngine.swift
+++ b/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapEngine.swift
@@ -198,6 +198,12 @@ private struct MapInventoryScanOutput: Sendable {
 
 @MainActor
 final class MapEngine: ObservableObject {
+    /// Garmin may briefly keep its MTP object database busy after accepting
+    /// and indexing a map. Opening the next MTP session immediately can block
+    /// indefinitely on affected firmware, even though the completed map was
+    /// already verified and recorded locally. Keep this provider-neutral:
+    /// every successful item in a multi-map batch receives the same bounded
+    /// settle window before the next device inventory is opened.
     @Published private(set) var state: MapEngineState = .idle
     @Published private(set) var result: MapInventoryResult?
     @Published private(set) var selectedPreflight: InstallationPreflightResult?
@@ -1439,6 +1445,16 @@ final class MapEngine: ObservableObject {
                         )
                         results.append(result)
                         guard result.isSuccess else { break }
+
+                        if index + 1 < plan.installItems.count {
+                            // Move away from a misleading Finishing 100% state
+                            // while the watch commits/indexes the completed
+                            // object. No MTP call or device write is active
+                            // during this bounded wait.
+                            phaseRelay.send(.preparing)
+                            phaseProgressRelay.send(.preparing, 0)
+                            try await Task.sleep(for: .seconds(5))
+                        }
                     }
                     return results
                 }

--- a/lab/native-connectivity-poc/Tests/run-stage45-map-selection-tests.sh
+++ b/lab/native-connectivity-poc/Tests/run-stage45-map-selection-tests.sh
@@ -161,6 +161,16 @@ if ! grep -Fq 'mapEngine.beginInstallation(plan: plan, operationId: operationID)
     exit 1
 fi
 
+if ! grep -Fq 'Task.sleep(for: .seconds(5))' \
+        "$project_root/Sources/TerentoPoC/MapCatalog/MapEngine.swift" \
+    || ! grep -Fq 'phaseRelay.send(.preparing)' \
+        "$project_root/Sources/TerentoPoC/MapCatalog/MapEngine.swift" \
+    || ! grep -Fq 'index + 1 < plan.installItems.count' \
+        "$project_root/Sources/TerentoPoC/MapCatalog/MapEngine.swift"; then
+    print -u2 "FAIL: sequential multi-map installs do not settle before reopening MTP"
+    exit 1
+fi
+
 if ! grep -Fq 'private func activeInstallationContent' "$connect_screen" \
     || ! grep -Fq 'Text("Installing maps")' "$connect_screen" \
     || ! grep -Fq 'Keep your Garmin connected until installation is complete.' "$connect_screen"; then


### PR DESCRIPTION
## Summary

- add a bounded provider-neutral device-settle window between successful maps in one batch;
- move progress away from a misleading Finishing 100% state during that boundary;
- increment the release candidate to build 8;
- record owner-confirmed real-hardware evidence for two-map OTM and FZK batches, reconnect persistence, and isolated one-map removal.

## Automated validation

- Stage 4.5 map selection: 27/27 PASS
- Stage 4.2 installation safety: 30/30 PASS
- Release build: PASS
- ad-hoc signature verification: PASS
- git diff --check: PASS

## Hardware evidence

Owner-confirmed on Garmin fēnix 8 (47 mm AMOLED):

- two OpenTopoMap maps in one operation: PASS;
- two Freizeitkarte maps in one operation: PASS;
- maps visible in Manage maps and on the watch: PASS;
- disconnect/reconnect persistence: PASS;
- removing one selected map leaves the others unchanged: PASS.

This is the final post-merge beta.8 release hardening change.