### PR TITLE
Beta 8 — prepare public release

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ works.
 - USB connection
 - Internet connection for downloading maps
 
-Freizeitkarte is the only map source supported in beta.8.
+Beta.8 supports Freizeitkarte and OpenTopoMap main-map packages. Optional
+OpenTopoMap contour packages are deferred to a later beta.
 
 ## Download
 
@@ -179,13 +180,15 @@ See the full
 ## Maps
 
 Terento beta.8 works with
-[Freizeitkarte](https://www.freizeitkarte-osm.de/), which provides Garmin maps
-based on OpenStreetMap data.
+[Freizeitkarte](https://www.freizeitkarte-osm.de/) and
+[OpenTopoMap](https://garmin.opentopomap.org/), which provide Garmin maps based
+on OpenStreetMap data.
 
 Maps are downloaded from the selected provider's original infrastructure.
 Terento does not host, mirror, or repackage them.
 
 - [Freizeitkarte](https://www.freizeitkarte-osm.de/)
+- [OpenTopoMap](https://garmin.opentopomap.org/)
 - [OpenStreetMap copyright](https://www.openstreetmap.org/copyright)
 
 Terento is an independent open-source project and is not affiliated with,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,81 +1,75 @@
-# Terento v1.0.0-beta.7
+# Terento v1.0.0-beta.8
 
-Release date: 2026-08-26
+Release date: 2026-09-01
 
-Beta.7 keeps the complete validated Freizeitkarte catalog visible while
-separating catalog membership from Terento's map-acquisition policy. Downloads
-for Crimea and canonical Russian Federation regions are withheld before any
-temporary workspace or network request is created. Other regions, including
-Ukraine, Belarus and unknown non-Russian identities, remain available under
-the normal validation rules.
+Beta.8 expands Terento into a provider-neutral Garmin map manager. It adds
+OpenTopoMap main maps alongside Freizeitkarte, imports compatible local Garmin
+`.img` maps from the Mac, and lets users remove one recognized third-party map
+at a time after explicit confirmation.
 
-This remains a pre-MVP beta for hardware validation. Freizeitkarte remains the
-only map provider, and model eligibility is not a claim that every exact watch
-has been independently verified.
+This remains a pre-MVP beta for hardware validation. Model eligibility is not
+a claim that every exact watch has been independently verified.
 
 ## Highlights
 
-- Crimea remains listed under its canonical provider identity and is presented
-  as part of Ukraine and temporarily occupied by russia.
-- Canonical Russian Federation packages remain searchable and visible, but
-  Terento does not offer their downloads while russia's war of aggression
-  against Ukraine continues.
-- Withheld rows show a neutral `Unavailable` state, policy explanation and no
-  checkbox-like control, size, update action or storage impact.
-- Ukraine and all other non-withheld packages retain the normal selectable map
-  control and acquisition flow.
-- Install and Safe Update use one acquisition-policy gate. A withheld package
-  fails before creating temporary files or making an HTTP request.
-- Existing Terento-owned maps are not reclassified. Backup and Remove remain
-  available, while Update is hidden for a currently withheld region.
+- Choose Freizeitkarte or OpenTopoMap from one provider-neutral catalog.
+- Install one or several maps from the same provider in one operation.
+- Import a compatible raw Garmin `.img` map from the Mac through the same
+  validation, storage, transfer and verification lifecycle.
+- Manage Terento-installed maps and remove one recognized external map at a
+  time with an explicit safety confirmation.
+- View provider health-aware errors when a map source is temporarily down.
+- Optionally share anonymous map download and installation outcomes through a
+  separate, off-by-default statistics control.
 
 ## Application updates
 
-- Terento performs one non-blocking HTTPS metadata check per launch after the
-  first window becomes usable. Startup failures remain silent.
-- About retains the manual update check and persistent result state.
-- A user-confirmed Download action opens only a strictly validated official
-  Terento distribution URL. The app does not download, mount or replace itself.
+- Provider, package and local-import maps now use one common lifecycle:
+  prepare, validate, storage check, transfer, verify, manifest and rescan.
+- OpenTopoMap package identity and release headers are normalized without
+  weakening provider, region or release validation.
+- Sequential multi-map transfers include a bounded device-settle boundary for
+  Garmin firmware that needs time to commit its MTP object database.
+- Install, success, failure, confirmation and Manage maps screens received a
+  consistent beta.8 visual and accessibility pass.
+- About reports `1.0.0-beta.8` and distributed build `8`.
 
 ## Safety and privacy
 
-- Garmin-owned, unknown and manually managed files remain read-only.
+- Garmin-owned and unknown files remain read-only.
+- External-map removal targets one exact recognized `.img` object and requires
+  filename, path, size and hash checks plus a post-delete rescan.
 - New installs never overwrite an existing target. Safe Update still follows
   write-new → verify → remove-old and never deletes the working map first.
 - Device manifests and physical-watch ownership keys remain local. There is no
   account, login, cloud device profile or server-side Garmin identifier storage.
-- Catalog filtering and acquisition policy do not add telemetry or map proxying;
-  available maps still download directly from Freizeitkarte infrastructure.
+- Map statistics are independent from compatibility evidence, optional, queued
+  locally and non-blocking. They exclude watch identifiers, serial numbers,
+  Unit IDs, file paths, manifests, binaries and diagnostic logs.
+- Maps download directly from the selected provider. Terento does not host,
+  mirror, proxy or repackage provider binaries.
 
 ## Validation status
 
-- Automated policy tests cover canonical Crimea and Russian identities,
-  Freizeitkarte `RUS*` alias mapping, non-Russian controls, stale selections,
-  accessibility labels, Manage actions and fail-before-workspace/network order.
-- The full native shell regression matrix and signed arm64 Release dry-run pass
-  on the beta.7 candidate tree, including bundled-library and runtime-path
-  verification.
-- Owner hardware evidence on the connected fēnix 8 confirms the 63-package
-  catalog view, withheld Russia/Crimea presentation and normal Ukraine row.
-- No install, update or remove operation was performed as part of that visual
-  hardware check. Safe Update's real-device newer-map gate remains pending.
+- The full native shell regression matrix and Swift CI pass on the final beta.8
+  source, including provider-neutral acquisition, destructive-operation safety,
+  privacy boundaries, bundled libraries and runtime paths.
+- Owner hardware evidence on a Garmin fēnix 8 (47 mm AMOLED) confirms two-map
+  Freizeitkarte and two-map OpenTopoMap operations, watch visibility, Manage
+  maps discovery, persistence after reconnect and isolated one-map removal.
+- Custom `.img` installation and subsequent managed removal were also confirmed
+  on the same test watch.
 
 ## Known limitations
 
 - Map-capable means eligible for a guarded beta attempt, not independently
   verified compatibility.
-- Safe Update has not yet passed its real-device newer-map gate.
-- Freizeitkarte is the only supported map provider. Terento does not host,
-  mirror or proxy map binaries.
+- A single installation batch can contain maps from only one provider.
+- OpenTopoMap contour-package selection is deferred to a later beta.
 - macOS 13 or later on Apple Silicon is required. Intel Macs, App Store, PKG,
   Windows and Linux distributions are not included.
 
 ## Release artifacts
 
-The release pipeline completed successfully and Apple notarization was
-accepted with no issues.
-
-```text
-Terento-1.0.0-beta.7-macOS-arm64.dmg  6a74b7613a81c68b9e0e3995dd0e00c6a7778957fc039b40a113731573e95faa
-Terento-1.0.0-beta.7-macOS-arm64.zip  f9940254242935843e7fdd340d5962961e4cdaf8f6752dcf2cef9d3fef248203
-```
+The release pipeline must complete Apple notarization, stapling, Gatekeeper
+assessment and launch verification before artifact hashes are recorded here.

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -13,6 +13,11 @@ protocol DeviceFileReader: Sendable {
 
 @main
 struct Stage1ProviderNeutralTests {
+    private static let packageRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
     static func main() async {
         testLegacyPackageGetsRequiredMainArtifact()
         testOptionalContoursDoesNotHideMainArtifact()
@@ -354,7 +359,7 @@ struct Stage1ProviderNeutralTests {
 
     private static func testEveryBundledOpenTopoMapRowAcceptsBothDateHeaderForms() {
         do {
-            let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            let root = packageRoot
             let data = try Data(contentsOf: root.appendingPathComponent(
                 "Sources/TerentoPoC/Resources/Maps/catalog.json"
             ))
@@ -395,7 +400,7 @@ struct Stage1ProviderNeutralTests {
                     parser.parse($0, filename: filename)
                 }
 
-                return fullVersion == version
+                let rowPasses = fullVersion == version
                     && compactVersion == version
                     && fullMetadata?.provider == "OpenTopoMap"
                     && compactMetadata?.provider == "OpenTopoMap"
@@ -413,6 +418,10 @@ struct Stage1ProviderNeutralTests {
                     && package.optionalArtifacts.allSatisfy {
                         $0.kind == .contours && $0.required == false && $0.version != nil
                     }
+                if !rowPasses {
+                    print("OpenTopoMap catalog validation failed for \(package.id) [\(providerRegion)] release \(version)")
+                }
+                return rowPasses
             }
 
             let contourRows = packages.flatMap(\.optionalArtifacts).filter { $0.kind == .contours }
@@ -430,7 +439,7 @@ struct Stage1ProviderNeutralTests {
 
     private static func testBundledCatalogIncludesOpenTopoMap() {
         do {
-            let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            let root = packageRoot
             let data = try Data(contentsOf: root.appendingPathComponent(
                 "Sources/TerentoPoC/Resources/Maps/catalog.json"
             ))
@@ -454,7 +463,7 @@ struct Stage1ProviderNeutralTests {
 
     private static func testBundledProvidersHaveReviewedInstallPaths() {
         do {
-            let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            let root = packageRoot
             let data = try Data(contentsOf: root.appendingPathComponent(
                 "Sources/TerentoPoC/Resources/Maps/catalog.json"
             ))
@@ -488,7 +497,7 @@ struct Stage1ProviderNeutralTests {
 
     private static func testRemoteCatalogReceivesBundledProviderSupplement() {
         do {
-            let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            let root = packageRoot
             let data = try Data(contentsOf: root.appendingPathComponent(
                 "Sources/TerentoPoC/Resources/Maps/catalog.json"
             ))
@@ -513,7 +522,7 @@ struct Stage1ProviderNeutralTests {
 
     private static func testRemotePausedProviderDoesNotReceiveBundledPackages() {
         do {
-            let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            let root = packageRoot
             let data = try Data(contentsOf: root.appendingPathComponent(
                 "Sources/TerentoPoC/Resources/Maps/catalog.json"
             ))


### PR DESCRIPTION
## Summary

- replace stale beta.7 release notes with the beta.8 provider-neutral feature and validation summary;
- correct README provider support to Freizeitkarte plus OpenTopoMap main maps;
- make the 177-row OpenTopoMap catalog audit independent of the caller's working directory;
- print the exact failing package if that catalog audit regresses again.

## Validation

- Stage 1 provider-neutral catalog suite: 19/19 PASS from repository root
- all 177 OpenTopoMap rows validated
- git diff --check: PASS

No application runtime behavior changes are included.