### PR TITLE
Fix beta.9 catalog decoding on supported macOS

### DIFF
--- a/Packaging/validate-live-map-catalog.sh
+++ b/Packaging/validate-live-map-catalog.sh
@@ -30,6 +30,21 @@ trap cleanup EXIT
     exit 1
 }
 
+catalog_sha256="$(/usr/bin/shasum -a 256 "$catalog_path" | /usr/bin/awk '{print $1}')"
+print "Catalog SHA-256: $catalog_sha256"
+/usr/bin/python3 - "$catalog_path" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    catalog = json.load(handle)
+
+providers = catalog.get("providers", [])
+for provider in providers:
+    print(f"Catalog provider {provider.get('id', '<missing>')}: {len(provider.get('maps', []))} maps")
+print(f"Catalog total: {sum(len(provider.get('maps', [])) for provider in providers)} maps")
+PY
+
 TERENTO_CATALOG_CONTRACT_PATH="$catalog_path" \
     "$repo_root/lab/native-connectivity-poc/Tests/run-stage1-provider-neutral-tests.sh"
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,8 @@ a claim that every exact watch has been independently verified.
   weaken source validation, device ownership, or destructive-operation rules.
 - Correct fixed-width Freizeitkarte IMG header parsing so a full region field
   cannot be joined with the following release field.
+- Accept catalog health timestamps with or without fractional seconds across
+  every supported macOS version instead of rejecting the complete live catalog.
 - Reject an incompatible live catalog as a whole and use the bundled
   last-known-good snapshot instead of exposing only some broken maps.
 - Validate the exact production catalog during release packaging, after API

--- a/lab/native-connectivity-poc/README.md
+++ b/lab/native-connectivity-poc/README.md
@@ -56,7 +56,9 @@ is omitted from installable artifacts. The loader tries
 bundled provider, the loader supplements it with the missing local metadata;
 if the live catalog contains a paused, retired, or down provider, that remote
 state remains authoritative and bundled packages cannot re-enable it. Neither
-path downloads a map binary.
+path downloads a map binary. Catalog timestamps accept ISO 8601 values with or
+without fractional seconds so decoding remains consistent across supported
+macOS releases.
 
 Map scanning is deliberately content-first. Known Garmin-owned images are
 excluded before their prefix is read. Remaining `.img` candidates are read

--- a/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapCatalogLoader.swift
+++ b/lab/native-connectivity-poc/Sources/TerentoPoC/MapCatalog/MapCatalogLoader.swift
@@ -225,7 +225,28 @@ struct MapCatalogDocumentDecoder: Sendable {
     func decode(_ data: Data) throws -> MapCatalog {
         do {
             let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+                let formatOptions: [ISO8601DateFormatter.Options] = [
+                    [.withInternetDateTime, .withFractionalSeconds],
+                    [.withInternetDateTime]
+                ]
+
+                for options in formatOptions {
+                    let formatter = ISO8601DateFormatter()
+                    formatter.formatOptions = options
+                    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+                    if let date = formatter.date(from: value) {
+                        return date
+                    }
+                }
+
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Expected an ISO 8601 timestamp with optional fractional seconds."
+                )
+            }
             let document = try decoder.decode(MapCatalogDocument.self, from: data)
             return try document.catalog()
         } catch let error as MapCatalogError {

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -398,6 +398,10 @@ struct Stage1ProviderNeutralTests {
             let parser = GarminIMGMetadataParser()
             let versionParser = OpenTopoMapVersionParser()
 
+            if packages.count != 177 {
+                print("OpenTopoMap catalog count mismatch: expected 177, got \(packages.count)")
+            }
+
             let allRowsPass = packages.count == 177 && packages.allSatisfy { package in
                 let providerRegion = package.providerRegionId
                 let version = package.version

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -32,6 +32,7 @@ struct Stage1ProviderNeutralTests {
         testLegacyPackageGetsRequiredMainArtifact()
         testOptionalContoursDoesNotHideMainArtifact()
         testProviderNativeMetadataDecodesWithoutFZKSemantics()
+        testCatalogAcceptsFractionalProviderTimestamps()
         testProviderRegistryHasNoImplicitDefaultAndSortsAlphabetically()
         testCatalogRegionsAreProviderScoped()
         testSourceKindsKeepProviderAndCustomInputsExplicit()
@@ -52,7 +53,7 @@ struct Stage1ProviderNeutralTests {
         testProviderLifecycleMetadataDecodesFailClosed()
         await testDownloadFailureUsesConfirmedProviderDownState()
 
-        print("PASS: 23 Stage 1 provider-neutral core tests")
+        print("PASS: 24 Stage 1 provider-neutral core tests")
     }
 
     private static func testLegacyPackageGetsRequiredMainArtifact() {
@@ -184,6 +185,41 @@ struct Stage1ProviderNeutralTests {
             )
         } catch {
             expect(false, "provider-native release, region, tags, and artifact metadata decode neutrally")
+        }
+    }
+
+    private static func testCatalogAcceptsFractionalProviderTimestamps() {
+        let json = """
+        {
+          "catalogVersion": 2,
+          "updatedAt": "2026-08-31T17:53:40Z",
+          "providers": [
+            {
+              "id": "opentopomap",
+              "name": "OpenTopoMap",
+              "status": "ACTIVE",
+              "health": "HEALTHY",
+              "lastCheckedAt": "2026-08-31T17:53:03.865470+00:00",
+              "lastSuccessfulCatalogSync": "2026-08-31T17:53:29.293507+00:00",
+              "maps": []
+            }
+          ]
+        }
+        """
+
+        do {
+            let catalog = try MapCatalogDocumentDecoder().decode(Data(json.utf8))
+            let provider = catalog.providers.first
+            expect(
+                provider?.lastCheckedAt != nil
+                    && provider?.lastSuccessfulCatalogSync != nil,
+                "catalog timestamps accept RFC 3339 fractional seconds on every supported macOS"
+            )
+        } catch {
+            expect(
+                false,
+                "catalog timestamps accept RFC 3339 fractional seconds on every supported macOS"
+            )
         }
     }
 
@@ -398,10 +434,6 @@ struct Stage1ProviderNeutralTests {
             let parser = GarminIMGMetadataParser()
             let versionParser = OpenTopoMapVersionParser()
 
-            if packages.count != 177 {
-                print("OpenTopoMap catalog count mismatch: expected 177, got \(packages.count)")
-            }
-
             let allRowsPass = packages.count == 177 && packages.allSatisfy { package in
                 let providerRegion = package.providerRegionId
                 let version = package.version
@@ -481,11 +513,6 @@ struct Stage1ProviderNeutralTests {
             let requiresBundledContourFixture = ProcessInfo.processInfo.environment[
                 "TERENTO_CATALOG_CONTRACT_PATH"
             ] == nil
-            print(
-                "OpenTopoMap matrix diagnostics: rows=\(packages.count), "
-                    + "rowChecks=\(allRowsPass), contours=\(contourRows.count), "
-                    + "externalCatalog=\(!requiresBundledContourFixture)"
-            )
             expect(
                 allRowsPass
                     && (!requiresBundledContourFixture || contourRows.count == 176),

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -489,7 +489,9 @@ struct Stage1ProviderNeutralTests {
             expect(
                 allRowsPass
                     && (!requiresBundledContourFixture || contourRows.count == 176),
-                "all 177 OpenTopoMap rows accept full, compact, and split generated dates with strict identity/version checks"
+                "all 177 OpenTopoMap rows accept full, compact, and split generated dates with strict identity/version checks "
+                    + "[rows=\(packages.count), rowChecks=\(allRowsPass), "
+                    + "contours=\(contourRows.count), externalCatalog=\(!requiresBundledContourFixture)]"
             )
         } catch {
             expect(

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -496,7 +496,8 @@ struct Stage1ProviderNeutralTests {
         } catch {
             expect(
                 false,
-                "all 177 OpenTopoMap rows accept full, compact, and split generated dates with strict identity/version checks"
+                "all 177 OpenTopoMap rows accept full, compact, and split generated dates with strict identity/version checks "
+                    + "[error=\(error)]"
             )
         }
     }

--- a/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
+++ b/lab/native-connectivity-poc/Tests/TerentoPoCTests/Stage1ProviderNeutralTests.swift
@@ -481,6 +481,11 @@ struct Stage1ProviderNeutralTests {
             let requiresBundledContourFixture = ProcessInfo.processInfo.environment[
                 "TERENTO_CATALOG_CONTRACT_PATH"
             ] == nil
+            print(
+                "OpenTopoMap matrix diagnostics: rows=\(packages.count), "
+                    + "rowChecks=\(allRowsPass), contours=\(contourRows.count), "
+                    + "externalCatalog=\(!requiresBundledContourFixture)"
+            )
             expect(
                 allRowsPass
                     && (!requiresBundledContourFixture || contourRows.count == 176),


### PR DESCRIPTION
## Summary
- decodes ISO 8601 catalog timestamps with or without fractional seconds
- fixes the live catalog failure reproduced on the GitHub macOS-15 runner
- reports catalog hash and provider counts in scheduled/release gate logs
- adds a regression test using the production microsecond timestamp format

## Evidence
- production catalog SHA-256: 47ebb2114dadc7b6956097062f8fa8c4b312d76c5cb0362703597e0e95a28b40
- production matrix: 63 Freizeitkarte + 177 OpenTopoMap
- the pre-fix macOS-15 gate failed consistently while decoding this exact catalog
- the fixed macOS-15 gate passed: https://github.com/VooZ2/terento/actions/runs/33631335002

This remains a beta.9 release blocker; public artifacts will be rebuilt after merge.