### PR TITLE
Fix Traefik service ambiguity

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -189,8 +189,6 @@ jobs:
                 traefik.http.routers.terento-operations.entrypoints: websecure
                 traefik.http.routers.terento-operations.tls: 'true'
                 traefik.http.routers.terento-operations.tls.certresolver: letsencrypt
-                traefik.http.routers.terento-operations.service: terento-operations
-                traefik.http.services.terento-operations.loadbalancer.server.port: '8000'
             catalog-scheduler:
               image: $image
             catalog-migrate:

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -56,6 +56,8 @@ def main() -> int:
     assert "OPERATIONS_INGEST_SECRET=%s" in deploy_api
     assert "OPERATIONS_INGEST_SECRET: \\${OPERATIONS_INGEST_SECRET}" in deploy_api
     assert "chmod --reference=\"$env_file\"" in deploy_api
+    assert "traefik.http.routers.terento-operations.rule" in deploy_api
+    assert "traefik.http.routers.terento-operations.service" not in deploy_api
     deploy_site = (WORKFLOWS / "deploy-site.yml").read_text(encoding="utf-8")
     assert "Retain website deployment health" in deploy_site
     codeql = (WORKFLOWS / "codeql.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove the duplicate Traefik service declaration introduced for the operations endpoint
- keep the operations router on the existing catalog API service
- add a CI contract preventing this routing ambiguity from returning

## Verification
- workflow YAML parsing
- Terento test plan: ci (2 runners)

[ci] 2 runners
  RUN  Tests/run-ci-test-selection-tests.sh
PASS: changed paths select the minimum safe test suites and fail open to all
  PASS Tests/run-ci-test-selection-tests.sh
  RUN  Tests/run-ci-workflow-contract-tests.sh
PASS: 6 workflows use pinned actions and required quality gates
  PASS Tests/run-ci-workflow-contract-tests.sh
[ci] PASS in 0.1s

ALL PASS: 2/2 runners in 0.1s (2/2)
- 

This hotfix restores the public catalog API routes while retaining the authenticated operations ingestion route.