### PR TITLE
Allow explicit weekly report verification

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -14,6 +14,12 @@ on:
   schedule:
     - cron: "30 6 * * 1"
   workflow_dispatch:
+    inputs:
+      send_health_report:
+        description: Send and retain a weekly-format health report for SMTP verification
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -293,7 +299,11 @@ jobs:
 
   publish-operational-report:
     name: Publish weekly or release health report
-    if: always() && (github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v'))
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+      startsWith(github.ref, 'refs/tags/v') ||
+      (github.event_name == 'workflow_dispatch' && inputs.send_health_report))
     needs:
       - changes
       - site-tests
@@ -313,6 +323,7 @@ jobs:
       SMTP_PORT: "2525"
       REPORT_FROM: report@terento.app
       REPORT_TO: report@terento.app
+      SEND_HEALTH_REPORT: ${{ inputs.send_health_report || 'false' }}
       SELECTION_RESULT: ${{ needs.changes.result }}
       SITE_RESULT: ${{ needs.site-tests.result }}
       BACKEND_RESULT: ${{ needs.backend-tests.result }}
@@ -331,7 +342,7 @@ jobs:
           set -euo pipefail
           kind="RELEASE_GATE"
           component="release"
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$SEND_HEALTH_REPORT" = "true" ]; then
             kind="WEEKLY_TEST"
             component="test-matrix"
           fi
@@ -365,7 +376,7 @@ jobs:
             > "$RUNNER_TEMP/terento-operational-report.json"
       - name: Send weekly report through SMTP2GO
         id: email
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.send_health_report)
         run: python3 scripts/send-weekly-health-report.py "$RUNNER_TEMP/terento-operational-report.json"
       - name: Retain consolidated health report
         if: always()
@@ -375,7 +386,7 @@ jobs:
         run: |
           set -euo pipefail
           test -n "$OPERATIONS_INGEST_SECRET"
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$SEND_HEALTH_REPORT" = "true" ]; then
             email_outcome="${EMAIL_OUTCOME:-unknown}"
             jq --arg email "$email_outcome" '.details.email = $email' \
               "$RUNNER_TEMP/terento-operational-report.json" \

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -27,6 +27,8 @@ def main() -> int:
     swift = (WORKFLOWS / "swift-ci.yml").read_text(encoding="utf-8")
     for contract in (
         'cron: "30 6 * * 1"',
+        "send_health_report:",
+        "github.event_name == 'workflow_dispatch' && inputs.send_health_report",
         "Select required test suites",
         "Site tests",
         "Backend API tests",


### PR DESCRIPTION
## Summary
- add a default-off manual input for sending a weekly-format health report
- keep ordinary manual CI runs email-free
- retain the same SMTP outcome in Admin observations
- add CI workflow contracts for the explicit dispatch path

## Verification
- workflow YAML parsing
- Terento test plan: ci (2 runners)

[ci] 2 runners
  RUN  Tests/run-ci-test-selection-tests.sh
PASS: changed paths select the minimum safe test suites and fail open to all
  PASS Tests/run-ci-test-selection-tests.sh
  RUN  Tests/run-ci-workflow-contract-tests.sh
PASS: 6 workflows use pinned actions and required quality gates
  PASS Tests/run-ci-workflow-contract-tests.sh
[ci] PASS in 0.1s

ALL PASS: 2/2 runners in 0.1s (2/2)
- changed-path selection resolves to all seven suites
- 

Private canonical planning/state documents were reviewed and updated locally; they remain intentionally ignored.