### PR TITLE
Fix unresolved device identity routing

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -129,7 +129,12 @@ Returns an authenticated, no-store/noindex diagnostic drill-down for one exact
 compatibility identity. Dashboard links add the internal `canonical_device_id`
 query parameter when available, so harmless formatting differences in legacy
 identity labels remain in one model history; identity text remains the fallback
-for records without a canonical link. The list uses the compact columns Date, Region, Result,
+for records without a canonical link. Links for records without a canonical
+device also add the internal `identity_scope=unresolved` parameter. That scope
+prevents a pending record from being redirected to a canonical device that
+happens to use the same textual identity and limits the drill-down to
+uncanonicalized operations. Assigning a canonical Garmin device redirects to
+that exact device history after the audited identity update. The list uses the compact columns Date, Region, Result,
 Stage, Code, Issue, and State, and defaults to Open. A Review action opens the
 detail dialog with the separate evidence/lifecycle summary, Resolve/Reopen,
 auditable identity selector, GitHub issue link/create actions, and collapsed

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -284,6 +284,12 @@ def _diagnostics_url(value: dict[str, Any], *, state: str | None = None) -> str:
     canonical_id = str(value.get("canonical_device_model_id") or "").strip()
     if canonical_id:
         parameters["canonical_device_id"] = canonical_id
+    else:
+        # A textual identity can be shared by both a canonical aggregate and a
+        # still-unresolved aggregate. Preserve the unresolved scope so the
+        # diagnostics route cannot redirect the pending row to the canonical
+        # device before an operator reviews it.
+        parameters["identity_scope"] = "unresolved"
     if state:
         parameters["state"] = state
     return "/admin/diagnostics?" + urlencode(parameters)
@@ -723,11 +729,7 @@ def _overview_operation_href(operation: dict[str, Any]) -> str:
     device_id = str(operation.get("canonical_device_model_id") or "").strip()
     if device_id:
         return _device_detail_url(device_id, origin="installations", state=state, anchor="installations")
-    identity = str(operation.get("compatibility_identity") or operation.get("model") or "Unknown").strip()
-    parameters = {"identity": identity}
-    if state:
-        parameters["state"] = state
-    return "/admin/diagnostics?" + urlencode(parameters)
+    return _diagnostics_url(operation, state=state)
 
 
 def _overview_activity_row(operation: dict[str, Any]) -> str:
@@ -795,7 +797,6 @@ def _overview_failure_reasons(reasons: list[dict[str, Any]]) -> str:
 def _overview_model_activity_item(item: dict[str, Any]) -> str:
     model = str(item.get("model") or item.get("compatibility_identity") or "Unknown device").strip()
     variant = _normalise_variant(item.get("variant"))
-    identity = str(item.get("compatibility_identity") or model).strip()
     context = " · ".join(part for part in (model, variant if variant != "—" and variant not in model else "") if part)
     operation_count = int(item.get("operation_count") or 0)
     successful = int(item.get("successful_count") or 0)
@@ -806,7 +807,7 @@ def _overview_model_activity_item(item: dict[str, Any]) -> str:
     device_id = str(item.get("canonical_device_model_id") or "").strip()
     href = (
         _device_detail_url(device_id, origin="installations", state="open", anchor="installations")
-        if device_id else "/admin/diagnostics?" + urlencode({"identity": identity})
+        if device_id else _diagnostics_url(item)
     )
     result = f"{successful} successful · {failed} failed" if successful or failed else f"{operation_count} operation{'s' if operation_count != 1 else ''}"
     return (
@@ -832,11 +833,10 @@ def _overview_review_item(item: dict[str, Any]) -> str:
     review_status = str(item.get("review_status") or "PENDING").upper()
     public_enabled = bool(item.get("public_statistics_enabled"))
     label = "Unpublished" if review_status == "APPROVED" and not public_enabled else "Review required"
-    identity = str(item.get("compatibility_identity") or model).strip()
     device_id = str(item.get("canonical_device_model_id") or "").strip()
     href = (
         _device_detail_url(device_id, origin="installations")
-        if device_id else "/admin/diagnostics?" + urlencode({"identity": identity})
+        if device_id else _diagnostics_url(item)
     )
     return (
         f"<li class='overview-review-item'><a href='{html.escape(href, quote=True)}'>"
@@ -861,11 +861,10 @@ def _overview_review_attention_item(item: dict[str, Any]) -> str:
     review_status = str(item.get("review_status") or "PENDING").upper()
     public_enabled = bool(item.get("public_statistics_enabled"))
     label = "Unpublished" if review_status == "APPROVED" and not public_enabled else "Review required"
-    identity = str(item.get("compatibility_identity") or model).strip()
     device_id = str(item.get("canonical_device_model_id") or "").strip()
     href = (
         _device_detail_url(device_id, origin="installations")
-        if device_id else "/admin/diagnostics?" + urlencode({"identity": identity})
+        if device_id else _diagnostics_url(item)
     )
     return (
         "<li class='overview-attention-item overview-attention-review'>"
@@ -2923,11 +2922,17 @@ def diagnostics_page(
     resolved_operations: list[dict[str, Any]] | None = None,
     identity_devices: list[dict[str, Any]] | None = None,
     canonical_device_model_id: str | None = None,
+    unresolved_only: bool = False,
 ) -> bytes:
     identity = identity.strip()
     canonical_device_model_id = str(canonical_device_model_id or "").strip() or None
 
     def matches(value: dict[str, Any]) -> bool:
+        if unresolved_only:
+            return (
+                not str(value.get("canonical_device_model_id") or "").strip()
+                and str(value.get("compatibility_identity") or value.get("model") or "").strip() == identity
+            )
         if canonical_device_model_id:
             return str(value.get("canonical_device_model_id") or "").strip() == canonical_device_model_id
         return str(value.get("compatibility_identity") or value.get("model") or "").strip() == identity

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -12,7 +12,7 @@ from http import HTTPStatus
 from http.cookies import SimpleCookie
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
-from urllib.parse import parse_qs, unquote, urlsplit
+from urllib.parse import parse_qs, quote, unquote, urlsplit
 from uuid import uuid4
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -1121,13 +1121,14 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 query = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
                 identity = query.get("identity", [""])[0].strip()
                 canonical_device_id = query.get("canonical_device_id", [""])[0].strip()
+                unresolved_only = query.get("identity_scope", [""])[0].strip() == "unresolved"
                 if not identity:
                     self._redirect("/admin/installations", send_body=send_body)
                     return
                 try:
                     statistics = service.compatibility_statistics()
                     identity_devices = service.admin_devices().get("devices", [])
-                    if not canonical_device_id:
+                    if not canonical_device_id and not unresolved_only:
                         matching_statistic = next((
                             row for row in statistics
                             if str(row.get("compatibility_identity") or row.get("model") or "").strip() == identity
@@ -1154,6 +1155,7 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                         resolved_operations=service.compatibility_resolved_operation_details(),
                         identity_devices=identity_devices,
                         canonical_device_model_id=canonical_device_id,
+                        unresolved_only=unresolved_only,
                     )
                 except Exception:
                     LOGGER.exception("compatibility diagnostics failed")
@@ -1544,10 +1546,12 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 return
             if request_path == "/admin/diagnostics/identity":
                 try:
+                    identity_action = form.get("identity_action", "").strip().upper()
+                    canonical_device_model_id = form.get("canonical_device_model_id", "").strip() or None
                     changed = service.resolve_compatibility_identity(
                         form.get("operation_key", "").strip(),
-                        action=form.get("identity_action", "").strip().upper(),
-                        canonical_device_model_id=form.get("canonical_device_model_id", "").strip() or None,
+                        action=identity_action,
+                        canonical_device_model_id=canonical_device_model_id,
                         admin_user_id=int(session["id"]),
                         reason=form.get("identity_reason", "").strip() or None,
                         note=form.get("identity_note", "").strip() or None,
@@ -1558,7 +1562,14 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                 except ValueError:
                     self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_identity_resolution"}, send_body=True, cache_control="no-store")
                     return
-                self._redirect(self._safe_admin_return(form.get("return_to"), "/admin"), send_body=True)
+                if identity_action == "ASSIGN" and canonical_device_model_id:
+                    target = (
+                        f"/admin/devices/{quote(canonical_device_model_id, safe='')}"
+                        "?from=installations#installations"
+                    )
+                else:
+                    target = self._safe_admin_return(form.get("return_to"), "/admin")
+                self._redirect(target, send_body=True)
                 return
             self._send_json(HTTPStatus.NOT_FOUND, {"error": "not_found"}, send_body=True, cache_control="no-store")
 

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -311,7 +311,7 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("Last 7 days", body)
         self.assertIn("Install failed", body)
         self.assertIn("Device transport", body)
-        self.assertIn("/admin/diagnostics?identity=f%C4%93nix+8+%C2%B7+47+mm&amp;state=failed", body)
+        self.assertIn("/admin/diagnostics?identity=f%C4%93nix+8+%C2%B7+47+mm&amp;identity_scope=unresolved&amp;state=failed", body)
         self.assertIn("/admin/providers/opentopomap", body)
         self.assertIn("OpenTopoMap health Degraded", body)
         self.assertIn("<span>Map install operations</span><strong>4</strong>", body)
@@ -1001,6 +1001,74 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("Identity pending", evidence_row)
         self.assertNotIn("error-count", evidence_row)
         self.assertIn("historical-number'>0</td>", evidence_row)
+
+    def test_pending_and_canonical_rows_with_the_same_text_keep_distinct_destinations(self):
+        identity = "fēnix 8 Pro · 47 mm, AMOLED"
+        canonical_id = "garmin-fenix-8-pro-47-amoled"
+        rows = [{
+            "model": "fēnix 8 Pro",
+            "variant": "47 mm, AMOLED",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": canonical_id,
+            "attempted_install_count": 1,
+            "successful_install_count": 1,
+            "recognized_map_capable_evidence": True,
+        }, {
+            "model": "fēnix 8 Pro",
+            "variant": "47 mm",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": None,
+            "attempted_install_count": 1,
+            "successful_install_count": 1,
+            "recognized_map_capable_evidence": False,
+        }]
+        operations = [{
+            "operation_key": "canonical-operation",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": canonical_id,
+            "phase_outcome": "SUCCEEDED",
+            "automatic_finishing_result": "VERIFIED",
+            "identity_resolution_state": "RESOLVED",
+        }, {
+            "operation_key": "pending-operation",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": None,
+            "phase_outcome": "SUCCEEDED",
+            "automatic_finishing_result": "VERIFIED",
+            "identity_resolution_state": "UNRESOLVED",
+        }]
+
+        body = dashboard_page(
+            rows, {"username": "operator"}, "csrf", operations=operations,
+        ).decode()
+
+        self.assertIn(
+            "data-diagnostics-url='/admin/devices/garmin-fenix-8-pro-47-amoled?from=installations#installations'",
+            body,
+        )
+        self.assertIn(
+            "data-diagnostics-url='/admin/diagnostics?identity=f%C4%93nix+8+Pro+%C2%B7+47+mm%2C+AMOLED&amp;identity_scope=unresolved'",
+            body,
+        )
+
+        diagnostics = diagnostics_page(
+            rows,
+            {"username": "operator"},
+            "csrf",
+            identity=identity,
+            operations=operations,
+            identity_devices=[{
+                "id": canonical_id,
+                "model": "fēnix 8 Pro",
+                "variant": "47 mm, AMOLED",
+                "familyName": "fēnix",
+            }],
+            unresolved_only=True,
+        ).decode()
+        self.assertIn("Diagnostic ID: <code>pending-operation</code>", diagnostics)
+        self.assertNotIn("Diagnostic ID: <code>canonical-operation</code>", diagnostics)
+        self.assertIn("Resolve identity", diagnostics)
+        self.assertIn("Assign canonical Garmin device", diagnostics)
 
     def test_canonical_diagnostics_include_all_raw_identity_spellings(self):
         canonical_id = "garmin-fenix-8-47-amoled"

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -48,6 +48,15 @@ class FakeEvidenceDatabase:
         self.device_support_status = "SUPPORTED"
         self.authorization_audit = []
         self.public_review_actions = []
+        self.identity_reviews = []
+        self.compatibility_rows = [{
+            "model": "fēnix 8", "firmware_versions": "20.19", "attempted_install_count": 1,
+            "successful_install_count": 1, "failed_install_count": 0, "success_rate": 100,
+            "last_success": "2026-08-24", "last_failure": None, "error_categories": {},
+            "calculated_status": "TESTED", "physical_device_evidence_count": 1,
+            "review_notes": "Owner evidence",
+        }]
+        self.compatibility_operations = []
 
     def admin_review_summary(self):
         return {
@@ -111,16 +120,27 @@ class FakeEvidenceDatabase:
         return 0
 
     def compatibility_statistics(self):
-        return [{
-            "model": "fēnix 8", "firmware_versions": "20.19", "attempted_install_count": 1,
-            "successful_install_count": 1, "failed_install_count": 0, "success_rate": 100,
-            "last_success": "2026-08-24", "last_failure": None, "error_categories": {},
-            "calculated_status": "TESTED", "physical_device_evidence_count": 1,
-            "review_notes": "Owner evidence",
-        }]
+        return self.compatibility_rows
 
     def compatibility_operation_details(self):
+        return self.compatibility_operations
+
+    def compatibility_resolved_operation_details(self):
         return []
+
+    def resolve_compatibility_identity(
+        self, operation_key, *, action, canonical_device_model_id,
+        admin_user_id=None, reason=None, note=None,
+    ):
+        self.identity_reviews.append({
+            "operation_key": operation_key,
+            "action": action,
+            "canonical_device_model_id": canonical_device_model_id,
+            "admin_user_id": admin_user_id,
+            "reason": reason,
+            "note": note,
+        })
+        return 1
 
     def public_compatibility_statistics(self, limit):
         return [{
@@ -297,6 +317,29 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         connection.request(method, path, body=body, headers=headers or {})
         response = connection.getresponse(); data = response.read(); connection.close()
         return response, data
+
+    def authenticated_admin_headers(self):
+        setup_body = urlencode({
+            "username": "operator", "password": "long-test-password",
+            "password_confirmation": "long-test-password",
+            "bootstrap_secret": "one-time-bootstrap-secret",
+        })
+        self.request(
+            "POST", "/admin/setup", setup_body,
+            {"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        login_body = urlencode({"username": "operator", "password": "long-test-password"})
+        login, _ = self.request(
+            "POST", "/admin/login", login_body,
+            {"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        cookies = login.headers.get_all("Set-Cookie")
+        session_cookie = next(value.split(";", 1)[0] for value in cookies if value.startswith("terento_admin_session="))
+        csrf_cookie = next(value.split(";", 1)[0] for value in cookies if value.startswith("terento_admin_csrf="))
+        return {
+            "Cookie": f"{session_cookie}; {csrf_cookie}",
+            "csrf_token": csrf_cookie.split("=", 1)[1],
+        }
 
     def test_event_is_idempotent(self):
         body = json.dumps(event()).encode()
@@ -697,6 +740,84 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         })
         self.assertEqual(updated.status, 200)
         self.assertEqual(self.database.users[0]["username"], "owner")
+
+    def test_pending_identity_route_does_not_redirect_to_same_text_canonical_device(self):
+        headers = self.authenticated_admin_headers()
+        identity = "fēnix 8 · 47 mm, AMOLED"
+        canonical_id = "garmin-fenix-8-47-amoled"
+        self.database.compatibility_rows = [{
+            "model": "fēnix 8",
+            "variant": "47 mm, AMOLED",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": canonical_id,
+            "attempted_install_count": 1,
+            "successful_install_count": 1,
+            "recognized_map_capable_evidence": True,
+        }, {
+            "model": "fēnix 8",
+            "variant": "47 mm",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": None,
+            "attempted_install_count": 1,
+            "successful_install_count": 1,
+            "recognized_map_capable_evidence": False,
+        }]
+        self.database.compatibility_operations = [{
+            "operation_key": "canonical-operation",
+            "event_id": "canonical-event",
+            "occurred_at": "2026-09-03T00:20:00+00:00",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": canonical_id,
+            "phase_outcome": "SUCCEEDED",
+            "automatic_finishing_result": "VERIFIED",
+            "identity_resolution_state": "RESOLVED",
+            "write_started": True,
+        }, {
+            "operation_key": "pending-operation",
+            "event_id": "pending-event",
+            "occurred_at": "2026-09-03T01:00:00+00:00",
+            "compatibility_identity": identity,
+            "canonical_device_model_id": None,
+            "phase_outcome": "SUCCEEDED",
+            "automatic_finishing_result": "VERIFIED",
+            "identity_resolution_state": "UNRESOLVED",
+            "write_started": True,
+        }]
+
+        path = "/admin/diagnostics?" + urlencode({
+            "identity": identity,
+            "identity_scope": "unresolved",
+        })
+        response, body = self.request("GET", path, headers={"Cookie": headers["Cookie"]})
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"Resolve identity", body)
+        self.assertIn(b"pending-operation", body)
+        self.assertNotIn(b"canonical-operation", body)
+
+        assignment = urlencode({
+            "csrf_token": headers["csrf_token"],
+            "operation_key": "pending-operation",
+            "identity_action": "ASSIGN",
+            "canonical_device_model_id": canonical_id,
+            "identity_reason": "Exact model confirmed",
+            "return_to": path,
+        })
+        assigned, _ = self.request(
+            "POST", "/admin/diagnostics/identity", assignment,
+            {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Cookie": headers["Cookie"],
+            },
+        )
+        self.assertEqual(assigned.status, 303)
+        self.assertEqual(
+            assigned.headers["Location"],
+            "/admin/devices/garmin-fenix-8-47-amoled?from=installations#installations",
+        )
+        self.assertEqual(
+            self.database.identity_reviews[-1]["canonical_device_model_id"],
+            canonical_id,
+        )
 
     def test_admin_rejects_wrong_bootstrap_secret_and_csrf(self):
         setup_body = urlencode({


### PR DESCRIPTION
## Summary
- keep unresolved installation rows scoped to unresolved diagnostics
- expose identity assignment even when a canonical row has the same display identity
- redirect successful assignments to the canonical device installation history

## Verification
- Tests/run-backend-api-unit-tests.sh (199 tests)
- Tests/run-backend-tests.sh
- Tests/run-release-documentation-tests.sh
- git diff --check