### PR TITLE
Preserve admin deployment checks with Cloudflare Access

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -9,6 +9,8 @@ on:
       - "backend/catalog-api/Dockerfile"
       - "backend/catalog-api/pyproject.toml"
       - ".github/workflows/deploy-catalog-api.yml"
+      - "scripts/infra/check-admin-boundary.py"
+      - "Tests/admin-access-boundary-tests.py"
   workflow_dispatch:
 
 permissions:
@@ -34,6 +36,7 @@ jobs:
       CATALOG_SSH_KEY: ${{ secrets.TERENTO_SITE_SSH_KEY }}
       CATALOG_SSH_KNOWN_HOSTS: ${{ secrets.TERENTO_SITE_SSH_KNOWN_HOSTS }}
       OPERATIONS_INGEST_SECRET: ${{ secrets.TERENTO_OPERATIONS_INGEST_SECRET }}
+      TERENTO_ADMIN_ACCESS_REQUIRED: ${{ vars.TERENTO_ADMIN_ACCESS_REQUIRED }}
     steps:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
@@ -249,7 +252,7 @@ jobs:
           fi
 
           if ! docker exec "$api_container" python -c \
-            'import urllib.request; assert b"<title>Admin sign in \xc2\xb7 Terento</title>" in urllib.request.urlopen("http://127.0.0.1:8000/admin/login", timeout=5).read()'; then
+            'import urllib.request; assert b"<title>Admin sign in \xc2\xb7 Terento</title>" in urllib.request.urlopen("http://127.0.0.1:8000/admin/login", timeout=5).read(); import http.client; c=http.client.HTTPConnection("127.0.0.1",8000,timeout=5); c.request("GET","/admin/campaign-links"); r=c.getresponse(); assert r.status==303 and r.getheader("Location")=="/admin/login"'; then
             rollback
             exit 1
           fi
@@ -263,6 +266,9 @@ jobs:
           rm -rf -- "$stage" "$override"
           REMOTE
 
+      - name: Validate admin edge boundary checker
+        run: python3 Tests/admin-access-boundary-tests.py
+
       - name: Verify public catalog API
         shell: bash
         run: |
@@ -270,28 +276,20 @@ jobs:
           health="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/health)"
           maps="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/maps/catalog.json)"
           devices="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/devices/catalog.json)"
-          login="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/admin/login)"
+          python3 scripts/infra/check-admin-boundary.py
           deletion_body_file="$RUNNER_TEMP/terento-compatibility-delete-contract.json"
           deletion_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 \
             -H 'Content-Type: application/json' --data '{}' -X DELETE \
             -o "$deletion_body_file" -w '%{http_code}' \
             https://api.terento.app/compatibility/events)"
           deletion_body="$(cat "$deletion_body_file")"
-          headers="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -D - -o /dev/null https://api.terento.app/admin/campaign-links || true)"
-          status="$(printf '%s\n' "$headers" | awk 'toupper($1) ~ /^HTTP\// {code=$2} END {print code}')"
-          location="$(printf '%s\n' "$headers" | awk 'tolower($1)=="location:" {print $2; exit}' | tr -d '\r')"
           if [ "$health" != '{"status":"ok"}' ] \
             || ! grep -Fq '"catalogVersion"' <<<"$maps" \
             || ! jq -e '.schemaVersion == 2 and (.providers | type == "array") and any(.providers[]; .id == "freizeitkarte")' <<<"$maps" >/dev/null \
             || ! grep -Fq '"catalogVersion"' <<<"$devices" \
-            || ! grep -Fq '<title>Admin sign in · Terento</title>' <<<"$login" \
-            || [ "$status" != "303" ] \
-            || [ "$location" != "/admin/login" ] \
-            || ! grep -Fqi "script-src 'none'" <<<"$headers" \
             || [ "$deletion_status" != "405" ] \
             || ! jq -e '.error == "deletion_not_supported"' <<<"$deletion_body" >/dev/null; then
             printf '%s\n' "Public catalog verification failed" >&2
-            printf '%s\n' "$headers" >&2
             printf 'compatibility DELETE status=%s body=%s\n' "$deletion_status" "$deletion_body" >&2
             exit 1
           fi

--- a/Tests/admin-access-boundary-tests.py
+++ b/Tests/admin-access-boundary-tests.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+import unittest
+spec=importlib.util.spec_from_file_location('boundary',Path(__file__).resolve().parents[1]/'scripts/infra/check-admin-boundary.py')
+m=importlib.util.module_from_spec(spec);spec.loader.exec_module(m)
+class Boundary(unittest.TestCase):
+ def test_exact_access_redirect(self):
+  m.verify_response('/admin/login',302,{'Location':'https://'+m.TEAM+'/cdn-cgi/access/login/api.terento.app?redirect_url=x'},b'',True)
+ def test_reject_untrusted_redirects(self):
+  for u in ['http://'+m.TEAM+'/cdn-cgi/access/login/api.terento.app','https://'+m.TEAM+'.evil.test/cdn-cgi/access/login/api.terento.app','https://'+m.TEAM+'/other','/admin/login']:
+   with self.assertRaises(AssertionError):m.verify_response('/admin/login',302,{'Location':u},b'',True)
+ def test_enforced_mode_rejects_unprotected_login(self):
+  with self.assertRaises(AssertionError):m.verify_response('/admin/login',200,{},b'<title>Admin sign in \xc2\xb7 Terento</title>',True)
+ def test_transition_mode_preserves_app_gate(self):
+  m.verify_response('/admin/campaign-links',303,{'Location':'/admin/login','Content-Security-Policy':"script-src 'none'"},b'',False)
+  with self.assertRaises(AssertionError):m.verify_response('/admin/campaign-links',200,{},b'',False)
+if __name__=='__main__':unittest.main()

--- a/Tests/run-ci-workflow-contract-tests.sh
+++ b/Tests/run-ci-workflow-contract-tests.sh
@@ -3,3 +3,4 @@ set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
 PYTHONDONTWRITEBYTECODE=1 python3 "$repo_root/Tests/ci-workflow-contract-tests.py"
+PYTHONDONTWRITEBYTECODE=1 python3 "$repo_root/Tests/admin-access-boundary-tests.py"

--- a/scripts/infra/check-admin-boundary.py
+++ b/scripts/infra/check-admin-boundary.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Check the public admin gate without granting deployment CI admin access."""
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+TEAM = 'polished-pond-5159.cloudflareaccess.com'
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+def valid_access(status, location):
+    u = urllib.parse.urlsplit(location)
+    return (status == 302 and u.scheme == 'https' and u.netloc == TEAM
+            and u.path == '/cdn-cgi/access/login/api.terento.app')
+
+def verify_response(path, status, headers, body, required):
+    if valid_access(status, headers.get('Location', '')):
+        return
+    if required:
+        raise AssertionError('Expected configured Cloudflare Access boundary')
+    if path == '/admin/login':
+        assert status == 200 and b'<title>Admin sign in \xc2\xb7 Terento</title>' in body
+    else:
+        assert status == 303 and headers.get('Location') == '/admin/login'
+        assert "script-src 'none'" in headers.get('Content-Security-Policy', '')
+
+if __name__ == '__main__':
+    required = os.environ.get('TERENTO_ADMIN_ACCESS_REQUIRED', 'false') == 'true'
+    opener = urllib.request.build_opener(NoRedirect)
+    for path in ('/admin/login', '/admin/campaign-links'):
+        try:
+            response = opener.open(urllib.request.Request('https://api.terento.app' + path, headers={'User-Agent': 'Terento-Deployment-Check/1.0'}), timeout=10)
+        except urllib.error.HTTPError as e:
+            response = e
+        with response:
+            verify_response(path, response.code, response.headers, response.read(2*1024*1024), required)
+    print('Public admin boundary PASS (Access required=%s)' % required)

--- a/site-deploy/README.md
+++ b/site-deploy/README.md
@@ -63,3 +63,13 @@ lock. Public shell/CSS versions and generated pages are maintained by the
 normalizer. The retired Guide progress script is removed; reading-position
 restoration is retained. Download normalization accepts the current layout and
 fails explicitly for obsolete layouts.
+
+### Admin edge authentication
+
+API deployment verifies the native login and private-page redirect inside its
+container. Public checks use `scripts/infra/check-admin-boundary.py`, without an
+administrator credential or Access bypass token. The rollout checker accepts the
+existing application gate or the exact configured Cloudflare Access login redirect.
+After activation, repository variable `TERENTO_ADMIN_ACCESS_REQUIRED=true`
+requires the edge gate; unrelated redirects and errors fail. Test with
+`python3 Tests/admin-access-boundary-tests.py`.


### PR DESCRIPTION
Cloudflare Access will protect the admin paths, so public deployment checks must validate its login redirect while native login and private-page checks remain inside the API container. The checker pins the expected Access team/route and supports a repository-variable-controlled transition to mandatory edge authentication, without giving CI an admin or bypass credential.

Validated: four boundary tests, workflow contract checks, and live pre-Access admin verification. No application code or data schema changes.
