### PR TITLE
Prepare scoped personal VPS production deployments

### DIFF
--- a/.github/workflows/check-vps-access.yml
+++ b/.github/workflows/check-vps-access.yml
@@ -1,0 +1,52 @@
+name: Check restricted VPS access
+on:
+  push:
+    branches: [beta]
+    paths: [.github/workflows/check-vps-access.yml]
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: rukas-access-check
+  cancel-in-progress: false
+jobs:
+  check:
+    if: github.repository == 'VooZ2/terento' && github.ref == 'refs/heads/beta'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: rukas-${{ matrix.role }}
+    strategy:
+      fail-fast: false
+      matrix:
+        role: [site, api]
+    steps:
+      - name: Verify forced command rejection
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          ROLE: ${{ matrix.role }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+          keydir="$(mktemp -d "$RUNNER_TEMP/rukas-ssh.XXXXXX")"
+          trap 'rm -rf "$keydir"' EXIT
+          printf '%s\n' "$VPS_SSH_KEY" > "$keydir/key"
+          unset VPS_SSH_KEY
+          printf '%s\n' '179.198.204.47 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4/GzEE6xDFxBp4kE17EKNR3q70vpmkOJSp7/otiAq0' > "$keydir/known_hosts"
+          ssh_args=(-i "$keydir/key" -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes -o "UserKnownHostsFile=$keydir/known_hosts" -o ConnectTimeout=15)
+          target="terento-ci-$ROLE@179.198.204.47"
+          expect() {
+            expected="$1"; shift
+            result=0
+            ssh "${ssh_args[@]}" "$target" "$@" > "$keydir/output" 2>&1 || result=$?
+            cat "$keydir/output"
+            if [[ "$result" != "$expected" ]]; then
+              printf 'Expected exit %s, received %s\n' "$expected" "$result"
+              exit 1
+            fi
+          }
+          expect 64 id
+          grep -q 'Only the fixed image deployment command is permitted' "$keydir/output"
+          expect 64 'deploy api sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+          grep -q 'Only the fixed image deployment command is permitted' "$keydir/output"
+          printf 'Role %s: authenticated; arbitrary and cross-project commands rejected. No deployment requested.\n' "$ROLE" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -11,6 +11,8 @@ on:
       - ".github/workflows/deploy-catalog-api.yml"
       - "scripts/infra/check-admin-boundary.py"
       - "Tests/admin-access-boundary-tests.py"
+      - ".github/workflows/publish-vps-images.yml"
+      - "scripts/infra/deploy-vps-image.sh"
   workflow_dispatch:
 
 permissions:
@@ -25,246 +27,35 @@ jobs:
     name: Backend regression suite
     uses: ./.github/workflows/reusable-catalog-api-quality.yml
 
-  deploy:
+  publish:
     needs: tests
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/beta'
+    if: github.repository == 'VooZ2/terento' && github.ref == 'refs/heads/beta'
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-vps-images.yml
+    with:
+      role: api
+
+  deploy:
+    needs: publish
+    if: github.repository == 'VooZ2/terento' && github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: rukas-api
     env:
-      CATALOG_SSH_HOST: ${{ secrets.TERENTO_SITE_SSH_HOST }}
-      CATALOG_SSH_PORT: ${{ secrets.TERENTO_SITE_SSH_PORT }}
-      CATALOG_SSH_USER: ${{ secrets.TERENTO_SITE_SSH_USER }}
-      CATALOG_SSH_KEY: ${{ secrets.TERENTO_SITE_SSH_KEY }}
-      CATALOG_SSH_KNOWN_HOSTS: ${{ secrets.TERENTO_SITE_SSH_KNOWN_HOSTS }}
       OPERATIONS_INGEST_SECRET: ${{ secrets.TERENTO_OPERATIONS_INGEST_SECRET }}
-      TERENTO_ADMIN_ACCESS_REQUIRED: ${{ vars.TERENTO_ADMIN_ACCESS_REQUIRED }}
+      TERENTO_ADMIN_ACCESS_REQUIRED: 'true'
     steps:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-
-      - name: Validate deployment configuration
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -n "$CATALOG_SSH_HOST"
-          test -n "$CATALOG_SSH_USER"
-          test -n "$CATALOG_SSH_KEY"
-          test -n "$CATALOG_SSH_KNOWN_HOSTS"
-          test -n "$OPERATIONS_INGEST_SECRET"
-
-      - name: Configure pinned SSH access
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -d -m 700 "$HOME/.ssh"
-          printf '%s\n' "$CATALOG_SSH_KEY" > "$HOME/.ssh/terento_catalog"
-          printf '%s\n' "$CATALOG_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          chmod 600 "$HOME/.ssh/terento_catalog" "$HOME/.ssh/known_hosts"
-
-      - name: Synchronize operations ingest secret
-        shell: bash
-        run: |
-          set -euo pipefail
-          port="${CATALOG_SSH_PORT:-22}"
-          local_secret="$RUNNER_TEMP/terento-operations-ingest-secret"
-          remote_secret="/tmp/terento-operations-ingest-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          cleanup() {
-            rm -f -- "$local_secret"
-            ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes \
-              "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" "rm -f -- '$remote_secret'" || true
-          }
-          trap cleanup EXIT
-          umask 077
-          printf '%s\n' "$OPERATIONS_INGEST_SECRET" > "$local_secret"
-          scp -i "$HOME/.ssh/terento_catalog" -P "$port" -o BatchMode=yes \
-            "$local_secret" "$CATALOG_SSH_USER@$CATALOG_SSH_HOST:$remote_secret"
-          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes \
-            "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" "bash -s -- '$remote_secret'" <<'REMOTE'
-          set -euo pipefail
-          secret_file="$1"
-          env_file="/docker/terento-catalog/deploy/hostinger/catalog/.env"
-          replacement="${env_file}.operations.$$"
-          cleanup() {
-            rm -f -- "$secret_file" "$replacement"
-          }
-          trap cleanup EXIT
-          test -f "$env_file"
-          test -s "$secret_file"
-          secret="$(tr -d '\r\n' < "$secret_file")"
-          test "${#secret}" -ge 32
-          test "${#secret}" -le 512
-          umask 077
-          awk '!/^OPERATIONS_INGEST_SECRET=/' "$env_file" > "$replacement"
-          printf 'OPERATIONS_INGEST_SECRET=%s\n' "$secret" >> "$replacement"
-          chmod --reference="$env_file" "$replacement"
-          chown --reference="$env_file" "$replacement"
-          mv -f -- "$replacement" "$env_file"
-          rm -f -- "$secret_file"
-          trap - EXIT
-          REMOTE
-
-      - name: Package catalog API source
-        shell: bash
-        run: |
-          set -euo pipefail
-          tar -czf "$RUNNER_TEMP/terento-catalog-api.tgz" backend/catalog-api
-
-      - name: Upload source to the VPS
-        shell: bash
-        run: |
-          set -euo pipefail
-          port="${CATALOG_SSH_PORT:-22}"
-          release_id="${GITHUB_SHA:0:12}"
-          remote_stage="/tmp/terento-catalog-api-${release_id}"
-          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
-            "rm -rf -- '$remote_stage' && mkdir -m 700 -p '$remote_stage'"
-          scp -i "$HOME/.ssh/terento_catalog" -P "$port" -o BatchMode=yes \
-            "$RUNNER_TEMP/terento-catalog-api.tgz" "$CATALOG_SSH_USER@$CATALOG_SSH_HOST:$remote_stage/source.tgz"
-          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
-            "tar -xzf '$remote_stage/source.tgz' -C '$remote_stage' && rm -f '$remote_stage/source.tgz'"
-
-      - name: Build and roll out the API container
-        shell: bash
-        run: |
-          set -euo pipefail
-          port="${CATALOG_SSH_PORT:-22}"
-          release_id="${GITHUB_SHA:0:12}"
-          ssh -i "$HOME/.ssh/terento_catalog" -p "$port" -o BatchMode=yes "$CATALOG_SSH_USER@$CATALOG_SSH_HOST" \
-            "bash -s -- '$release_id'" <<'REMOTE'
-          set -euo pipefail
-          release_id="$1"
-          stage="/tmp/terento-catalog-api-${release_id}"
-          project="/docker/terento-catalog/deploy/hostinger/catalog"
-          compose="$project/docker-compose.yml"
-          env_file="$project/.env"
-          image="terento-catalog-api:publish-${release_id}"
-          override="/tmp/terento-catalog-api-override-${release_id}.yml"
-          # The production checkout lives in a directory named `catalog`, so
-          # Docker Compose's existing production project is `catalog`.
-          # Keep this explicit: inferring from an arbitrary service container
-          # previously selected a stale duplicate project.
-          compose_project="catalog"
-          old_image=""
-          old_container=""
-
-          test -f "$compose"
-          test -f "$env_file"
-          old_container="$(docker ps -aq \
-            --filter label=com.docker.compose.project=${compose_project} \
-            --filter label=com.docker.compose.service=catalog-api | head -n 1)"
-          if [ -n "$old_container" ]; then
-            old_image="$(docker inspect --format '{{.Config.Image}}' "$old_container")"
-          fi
-          if [ -z "$old_image" ]; then
-            old_image="$(docker compose --project-directory "$project" --env-file "$env_file" -f "$compose" images -q catalog-api | head -n 1)"
-          fi
-          test -n "$old_image"
-
-          docker build --pull=false \
-            --label "io.terento.release=$release_id" \
-            -f "$stage/backend/catalog-api/Dockerfile" \
-            -t "$image" \
-            "$stage/backend/catalog-api"
-
-          cat > "$override" <<EOF
-          services:
-            catalog-api:
-              image: $image
-              environment:
-                OPERATIONS_INGEST_SECRET: \${OPERATIONS_INGEST_SECRET}
-              labels:
-                traefik.http.routers.terento-admin.rule: 'Host(\`api.terento.app\`) && PathPrefix(\`/admin\`)'
-                traefik.http.routers.terento-operations.rule: 'Host(\`api.terento.app\`) && PathPrefix(\`/internal/operations/\`)'
-                traefik.http.routers.terento-operations.entrypoints: websecure
-                traefik.http.routers.terento-operations.tls: 'true'
-                traefik.http.routers.terento-operations.tls.certresolver: letsencrypt
-            catalog-scheduler:
-              image: $image
-              environment:
-                COLLECTOR_SCHEDULE_UTC: '03:00'
-            catalog-migrate:
-              image: $image
-          EOF
-
-          compose_args=(--project-name "$compose_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
-          docker compose "${compose_args[@]}" config --quiet
-          # The remote script itself arrives over stdin. Keep the migration
-          # container detached from that stream or it consumes the remaining
-          # rollout commands after printing its migration result.
-          docker compose "${compose_args[@]}" --profile manual run --rm --no-deps -T catalog-migrate </dev/null
-
-          rollback() {
-            cat > "$override" <<EOF
-          services:
-            catalog-api:
-              image: $old_image
-            catalog-scheduler:
-              image: $old_image
-          EOF
-            docker compose "${compose_args[@]}" up -d --force-recreate --no-build catalog-api catalog-scheduler || true
-            rm -rf -- "$stage" "$override"
-          }
-
-          if ! docker compose "${compose_args[@]}" up -d --force-recreate --no-build catalog-api catalog-scheduler; then
-            rollback
-            exit 1
-          fi
-
-          echo "Catalog API containers after rollout:"
-          for container in $(docker ps -aq --filter label=com.docker.compose.service=catalog-api); do
-            docker inspect --format '{{.Name}} project={{ index .Config.Labels "com.docker.compose.project" }} image={{.Config.Image}} admin={{ index .Config.Labels "traefik.http.routers.terento-admin.rule" }}' "$container"
-          done
-
-          # Remove only services from the known duplicate project created by
-          # the earlier rollout attempts. Database/asset volumes are retained.
-          duplicate_project="terento-catalog"
-          duplicate_args=(--project-name "$duplicate_project" --project-directory "$project" --env-file "$env_file" -f "$compose" -f "$override")
-          docker compose "${duplicate_args[@]}" rm -sf catalog-api catalog-scheduler catalog-db || true
-
-          mapfile -t api_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-api)
-          mapfile -t scheduler_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-scheduler)
-          mapfile -t db_containers < <(docker ps --no-trunc -q --filter label=com.docker.compose.service=catalog-db)
-          api_container="$(docker compose "${compose_args[@]}" ps -q catalog-api)"
-          scheduler_container="$(docker compose "${compose_args[@]}" ps -q catalog-scheduler)"
-          db_container="$(docker compose "${compose_args[@]}" ps -q catalog-db)"
-
-          if [ "${#api_containers[@]}" -ne 1 ] || [ "${#scheduler_containers[@]}" -ne 1 ] || [ "${#db_containers[@]}" -ne 1 ] \
-            || [ "${api_containers[0]:-}" != "$api_container" ] \
-            || [ "${scheduler_containers[0]:-}" != "$scheduler_container" ] \
-            || [ "${db_containers[0]:-}" != "$db_container" ]; then
-            docker ps -a --format 'container={{.Names}} image={{.Image}} status={{.Status}}' \
-              --filter label=com.docker.compose.service
-            rollback
-            exit 1
-          fi
-
-          api_release="$(docker inspect --format '{{ index .Config.Labels "io.terento.release" }}' "$api_container")"
-          scheduler_release="$(docker inspect --format '{{ index .Config.Labels "io.terento.release" }}' "$scheduler_container")"
-          db_health="$(docker inspect --format '{{.State.Health.Status}}' "$db_container")"
-          if [ "$api_release" != "$release_id" ] || [ "$scheduler_release" != "$release_id" ] || [ "$db_health" != "healthy" ]; then
-            rollback
-            exit 1
-          fi
-
-          if ! docker exec "$api_container" python -c \
-            'import urllib.request; assert urllib.request.urlopen("http://127.0.0.1:8000/health", timeout=5).read() == b"{\"status\":\"ok\"}"'; then
-            rollback
-            exit 1
-          fi
-
-          if ! docker exec "$api_container" python -c \
-            'import urllib.request; assert b"<title>Admin sign in \xc2\xb7 Terento</title>" in urllib.request.urlopen("http://127.0.0.1:8000/admin/login", timeout=5).read(); import http.client; c=http.client.HTTPConnection("127.0.0.1",8000,timeout=5); c.request("GET","/admin/campaign-links"); r=c.getresponse(); assert r.status==303 and r.getheader("Location")=="/admin/login"'; then
-            rollback
-            exit 1
-          fi
-
-          echo "Catalog services: one API, one scheduler, one healthy database; release $release_id"
-          echo "Active Traefik containers:"
-          for container in $(docker ps -q --filter label=traefik.enable=true); do
-            docker inspect --format '{{.Name}} project={{ index .Config.Labels "com.docker.compose.project" }} image={{.Config.Image}} catalog={{ index .Config.Labels "traefik.http.routers.terento-catalog.rule" }} admin={{ index .Config.Labels "traefik.http.routers.terento-admin.rule" }}' "$container"
-          done
-
-          rm -rf -- "$stage" "$override"
-          REMOTE
+        with:
+          persist-credentials: false
+      - name: Deploy immutable API image through its scoped account
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_IMAGE_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: bash scripts/infra/deploy-vps-image.sh api
 
       - name: Validate admin edge boundary checker
         run: python3 Tests/admin-access-boundary-tests.py

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -8,6 +8,8 @@ on:
       - "site/**"
       - "site-deploy/**"
       - ".github/workflows/deploy-site.yml"
+      - ".github/workflows/publish-vps-images.yml"
+      - "scripts/infra/deploy-vps-image.sh"
     tags:
       - "v*"
   workflow_dispatch:
@@ -20,154 +22,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  publish:
+    if: github.repository == 'VooZ2/terento' && (github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v'))
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-vps-images.yml
+    with:
+      role: site
+
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v')
+    needs: publish
+    if: github.repository == 'VooZ2/terento' && (github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v'))
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: rukas-site
     env:
-      SITE_SSH_HOST: ${{ secrets.TERENTO_SITE_SSH_HOST }}
-      SITE_SSH_PORT: ${{ secrets.TERENTO_SITE_SSH_PORT }}
-      SITE_SSH_USER: ${{ secrets.TERENTO_SITE_SSH_USER }}
-      SITE_SSH_KEY: ${{ secrets.TERENTO_SITE_SSH_KEY }}
-      SITE_SSH_KNOWN_HOSTS: ${{ secrets.TERENTO_SITE_SSH_KNOWN_HOSTS }}
       OPERATIONS_INGEST_SECRET: ${{ secrets.TERENTO_OPERATIONS_INGEST_SECRET }}
     steps:
       - name: Check out source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
-
-      - name: Validate public website
+        with:
+          persist-credentials: false
+      - name: Deploy immutable site image through its scoped account
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_KEY }}
+          VPS_IMAGE_DIGEST: ${{ needs.publish.outputs.digest }}
+        run: bash scripts/infra/deploy-vps-image.sh site
+      - name: Verify live update manifest
         shell: bash
         run: |
           set -euo pipefail
-          Tests/run-site-tests.sh
-          Tests/run-release-documentation-tests.sh
-          Tests/run-release-legal-content-tests.sh
-
-      - name: Validate deployment configuration
-        shell: bash
-        run: |
-          set -euo pipefail
-          test -n "$SITE_SSH_HOST"
-          test -n "$SITE_SSH_USER"
-          test -n "$SITE_SSH_KEY"
-          test -n "$SITE_SSH_KNOWN_HOSTS"
-          test -n "$OPERATIONS_INGEST_SECRET"
-
-      - name: Configure pinned SSH access
-        shell: bash
-        run: |
-          set -euo pipefail
-          install -d -m 700 "$HOME/.ssh"
-          printf '%s\n' "$SITE_SSH_KEY" > "$HOME/.ssh/terento_site"
-          printf '%s\n' "$SITE_SSH_KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          chmod 600 "$HOME/.ssh/terento_site" "$HOME/.ssh/known_hosts"
-
-      - name: Package site source
-        shell: bash
-        run: |
-          set -euo pipefail
-          tar -czf "$RUNNER_TEMP/terento-site.tgz" site site-deploy
-
-      - name: Upload source to the VPS
-        shell: bash
-        run: |
-          set -euo pipefail
-          port="${SITE_SSH_PORT:-22}"
-          release_id="${GITHUB_SHA:0:12}"
-          remote_stage="/tmp/terento-site-${release_id}"
-          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
-            "rm -rf -- '$remote_stage' && mkdir -m 700 -p '$remote_stage'"
-          scp -i "$HOME/.ssh/terento_site" -P "$port" -o BatchMode=yes \
-            "$RUNNER_TEMP/terento-site.tgz" "$SITE_SSH_USER@$SITE_SSH_HOST:$remote_stage/source.tgz"
-          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
-            "tar -xzf '$remote_stage/source.tgz' -C '$remote_stage' && rm -f '$remote_stage/source.tgz'"
-
-      - name: Build and roll out the web container
-        shell: bash
-        run: |
-          set -euo pipefail
-          port="${SITE_SSH_PORT:-22}"
-          release_id="${GITHUB_SHA:0:12}"
-          ssh -i "$HOME/.ssh/terento_site" -p "$port" -o BatchMode=yes "$SITE_SSH_USER@$SITE_SSH_HOST" \
-            "bash -s -- '$release_id'" <<'REMOTE'
-          set -euo pipefail
-          release_id="$1"
-          stage="/tmp/terento-site-${release_id}"
-          image="terento-site-terento-web:publish-${release_id}"
-          container="terento-site-terento-web-1"
-          rollback="${container}-rollback-${release_id}"
-
-          docker build --pull=false -f "$stage/site-deploy/Dockerfile" -t "$image" "$stage"
-
-          if docker inspect "$container" >/dev/null 2>&1; then
-            # A repeated deployment of the same commit reuses release_id. Remove
-            # only its stale, stopped rollback container before reserving the name.
-            docker rm -f "$rollback" >/dev/null 2>&1 || true
-            docker rename "$container" "$rollback"
-            docker stop "$rollback" >/dev/null
-            old_container="$rollback"
-          else
-            old_container=""
-          fi
-
-          rollback_web() {
-            docker rm -f "$container" >/dev/null 2>&1 || true
-            if [ -n "$old_container" ] && docker inspect "$old_container" >/dev/null 2>&1; then
-              docker rename "$old_container" "$container"
-              docker start "$container" >/dev/null
-            fi
-            rm -rf -- "$stage"
-          }
-
-          if ! docker run -d --name "$container" --restart unless-stopped --network terento-site \
-            --label traefik.enable=true \
-            --label traefik.docker.network=terento-site \
-            --label traefik.http.routers.terento.rule='Host(`terento.app`)' \
-            --label traefik.http.routers.terento.entrypoints=websecure \
-            --label traefik.http.routers.terento.tls=true \
-            --label traefik.http.routers.terento.tls.certresolver=letsencrypt \
-            --label traefik.http.services.terento.loadbalancer.server.port=80 \
-            --label traefik.http.routers.terento-www.rule='Host(`www.terento.app`)' \
-            --label traefik.http.routers.terento-www.entrypoints=websecure \
-            --label traefik.http.routers.terento-www.tls=true \
-            --label traefik.http.routers.terento-www.tls.certresolver=letsencrypt \
-            --label traefik.http.routers.terento-www.middlewares=terento-www-redirect \
-            --label traefik.http.middlewares.terento-www-redirect.redirectregex.regex='^https?://www\.terento\.app/(.*)' \
-            --label traefik.http.middlewares.terento-www-redirect.redirectregex.replacement='https://terento.app/$1' \
-            --label traefik.http.middlewares.terento-www-redirect.redirectregex.permanent=true \
-            "$image"; then
-            rollback_web
-            exit 1
-          fi
-
-          if ! docker exec "$container" sh -c \
-            "test -s /srv/updates/macos-arm64.json && grep -q '\"architecture\"[[:space:]]*:[[:space:]]*\"arm64\"' /srv/updates/macos-arm64.json"; then
-            rollback_web
-            exit 1
-          fi
-
-          manifest_url="https://terento.app/updates/macos-arm64.json"
-          manifest_verified=false
-          deadline=$(( $(date +%s) + 60 ))
-          while [ "$(date +%s)" -lt "$deadline" ]; do
-            if curl --fail --silent --connect-timeout 5 --max-time 10 "$manifest_url" \
-              | grep -q '"architecture"[[:space:]]*:[[:space:]]*"arm64"'; then
-              manifest_verified=true
-              break
-            fi
-
-            sleep 2
-          done
-
-          if [ "$manifest_verified" != true ]; then
-            rollback_web
-            exit 1
-          fi
-
-          if [ -n "$old_container" ]; then
-            docker rm -f "$old_container" >/dev/null
-          fi
-          rm -rf -- "$stage"
-          REMOTE
+          curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+            https://terento.app/updates/macos-arm64.json \
+            | jq -e '.architecture == "arm64"' >/dev/null
 
       - name: Retain website deployment health
         shell: bash

--- a/.github/workflows/publish-vps-images.yml
+++ b/.github/workflows/publish-vps-images.yml
@@ -1,0 +1,86 @@
+name: Publish VPS image
+
+on:
+  workflow_call:
+    inputs:
+      role:
+        required: true
+        type: string
+    outputs:
+      digest:
+        description: Immutable digest of the tested image at the caller commit
+        value: ${{ jobs.publish.outputs.digest }}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: github.repository == 'VooZ2/terento' && (github.ref == 'refs/heads/beta' || startsWith(github.ref, 'refs/tags/v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.image.outputs.digest }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Validate release source and target
+        env:
+          ROLE: ${{ inputs.role }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$ROLE" == site || "$ROLE" == api ]]
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            [[ "$ROLE" == site ]]
+            git merge-base --is-ancestor "$GITHUB_SHA" origin/beta
+          else
+            [[ "$GITHUB_REF" == refs/heads/beta ]]
+          fi
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: '22'
+      - name: Validate public site and release contracts
+        if: inputs.role == 'site'
+        run: |
+          set -euo pipefail
+          Tests/run-site-tests.sh
+          Tests/run-release-documentation-tests.sh
+          Tests/run-release-legal-content-tests.sh
+      - name: Build and publish immutable release
+        id: image
+        env:
+          ROLE: ${{ inputs.role }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_CONFIG: ${{ runner.temp }}/terento-docker
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "$ROLE" in
+            site) image=ghcr.io/vooz2/terento-site; context=.; dockerfile=site-deploy/Dockerfile ;;
+            api) image=ghcr.io/vooz2/terento-catalog; context=backend/catalog-api; dockerfile=backend/catalog-api/Dockerfile ;;
+            *) exit 64 ;;
+          esac
+          docker build --platform linux/amd64 \
+            --label "org.opencontainers.image.source=https://github.com/VooZ2/terento" \
+            --label "org.opencontainers.image.revision=$GITHUB_SHA" \
+            --label "org.opencontainers.image.licenses=GPL-3.0-or-later" \
+            --file "$dockerfile" --tag "$image:sha-$GITHUB_SHA" "$context"
+          trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+          docker push "$image:sha-$GITHUB_SHA"
+          docker pull "$image:sha-$GITHUB_SHA"
+          reference="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image:sha-$GITHUB_SHA")"
+          [[ "$reference" == "$image"@sha256:* ]]
+          digest="${reference#*@}"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          printf 'digest=%s\n' "$digest" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "### $image" "Commit: $GITHUB_SHA" "Digest: $reference" >> "$GITHUB_STEP_SUMMARY"

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -4,12 +4,59 @@
 from __future__ import annotations
 
 import re
+import json
+import os
+import subprocess
+import tempfile
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 PINNED_ACTION = re.compile(r"^\s*uses:\s*[^\s@]+@[0-9a-f]{40}\s*$")
+
+
+def verify_scoped_transport() -> None:
+    """Exercise the real request script with a local SSH spy; no network or secrets."""
+    script = REPO_ROOT / "scripts/infra/deploy-vps-image.sh"
+    subprocess.run(["bash", "-n", str(script)], check=True)
+    with tempfile.TemporaryDirectory() as temporary:
+        root = Path(temporary)
+        spy = root / "ssh"
+        spy.write_text("#!/usr/bin/env python3\n" +
+            "import json, os, pathlib, sys\n" +
+            "args=sys.argv[1:]; key=pathlib.Path(args[args.index('-i')+1])\n" +
+            "assert key.stat().st_mode & 0o777 == 0o600\n" +
+            "assert 'VPS_SSH_KEY' not in os.environ\n" +
+            "pathlib.Path(os.environ['SSH_RECORD']).write_text(json.dumps(args))\n")
+        spy.chmod(0o700)
+        record = root / "record.json"
+        env = dict(os.environ, PATH=str(root)+os.pathsep+os.environ["PATH"],
+                   GITHUB_REPOSITORY="VooZ2/terento", GITHUB_REF="refs/heads/beta",
+                   GITHUB_SHA="a"*40, VPS_IMAGE_DIGEST="sha256:"+"b"*64,
+                   VPS_SSH_KEY="synthetic-test-key", RUNNER_TEMP=temporary,
+                   SSH_RECORD=str(record))
+        for role, ref in (("api", "refs/heads/beta"), ("site", "refs/heads/beta"),
+                          ("site", "refs/tags/v0.1.0")):
+            result = subprocess.run(["bash", str(script), role], env=dict(env, GITHUB_REF=ref), capture_output=True)
+            assert result.returncode == 0, result.stderr.decode()
+            args = json.loads(record.read_text())
+            assert args[-2:] == [f"terento-ci-{role}@179.198.204.47", "deploy sha256:"+"b"*64+" "+"a"*40]
+            assert "StrictHostKeyChecking=yes" in args and "IdentitiesOnly=yes" in args
+            key = Path(args[args.index("-i")+1])
+            assert not key.parent.exists(), "temporary credentials must be removed"
+            record.unlink()
+        rejected = [(["root"], {}), (["site", "extra"], {}),
+                    (["api"], {"GITHUB_REF": "refs/tags/v0.1.0"}),
+                    (["site"], {"GITHUB_REF": "refs/heads/unreviewed"}),
+                    (["site"], {"GITHUB_REPOSITORY": "someone/terento"}),
+                    (["api"], {"VPS_IMAGE_DIGEST": "sha256:"+"b"*64+"; id"}),
+                    (["api"], {"GITHUB_SHA": "a"*40+" x"})]
+        for args, changes in rejected:
+            result = subprocess.run(["bash", str(script), *args], env=dict(env, **changes), capture_output=True)
+            assert result.returncode == 64, (args, changes, result.returncode)
+            assert not record.exists(), "invalid input reached SSH"
+        assert not list(root.glob("rukas-ssh.*"))
 
 
 def main() -> int:
@@ -76,17 +123,37 @@ def main() -> int:
 
     assert "needs: tests" in deploy_api, "catalog deploy must wait for backend tests"
     assert "Retain API deployment health" in deploy_api
-    assert "Synchronize operations ingest secret" in deploy_api
-    assert "OPERATIONS_INGEST_SECRET=%s" in deploy_api
-    assert "OPERATIONS_INGEST_SECRET: \\${OPERATIONS_INGEST_SECRET}" in deploy_api
-    assert "chmod --reference=\"$env_file\"" in deploy_api
-    assert "traefik.http.routers.terento-operations.rule" in deploy_api
-    assert "PathPrefix(\\`/internal/operations/\\`)" in deploy_api
-    assert "COLLECTOR_SCHEDULE_UTC: '03:00'" in deploy_api
     assert "https://api.terento.app/internal/operations/report-context" in deploy_api
-    assert "traefik.http.routers.terento-operations.service" not in deploy_api
+    assert "verify-release-client-contract:" in deploy_api
+    assert "Packaging/validate-live-map-catalog.sh" in deploy_api
+    assert "TERENTO_ADMIN_ACCESS_REQUIRED: 'true'" in deploy_api
     deploy_site = (WORKFLOWS / "deploy-site.yml").read_text(encoding="utf-8")
     assert "Retain website deployment health" in deploy_site
+    publisher = (WORKFLOWS / "publish-vps-images.yml").read_text(encoding="utf-8")
+    assert "workflow_call:" in publisher
+    assert "digest: ${{ steps.image.outputs.digest }}" in publisher
+    assert "value: ${{ jobs.publish.outputs.digest }}" in publisher
+    assert "git merge-base --is-ancestor" in publisher
+    assert "VPS_SSH_KEY" not in publisher and "environment:" not in publisher
+    assert "secrets." not in publisher.replace("secrets.GITHUB_TOKEN", "TOKEN")
+    for gate in ("Tests/run-site-tests.sh", "Tests/run-release-documentation-tests.sh",
+                 "Tests/run-release-legal-content-tests.sh"):
+        assert gate in publisher
+    for role, source in (("api", deploy_api), ("site", deploy_site)):
+        assert "needs: publish" in source
+        assert f"environment: rukas-{role}" in source
+        assert f"bash scripts/infra/deploy-vps-image.sh {role}" in source
+        assert "${{ needs.publish.outputs.digest }}" in source
+        assert "github.ref == 'refs/heads/beta'" in source
+        assert "github.event_name == 'workflow_dispatch' ||" not in source
+        assert "TERENTO_SITE_SSH" not in source
+        assert "scp " not in source and "bash -s" not in source
+        assert "Synchronize operations ingest secret" not in source
+    rejection = (WORKFLOWS / "check-vps-access.yml").read_text(encoding="utf-8")
+    assert "expect 64 id" in rejection
+    assert "expect 0 " not in rejection and "expect 1 " not in rejection
+    assert "f7e394d" not in rejection
+    verify_scoped_transport()
     compatibility_refresh = (WORKFLOWS / "refresh-compatibility-snapshot.yml").read_text(encoding="utf-8")
     for contract in (
         'cron: "30 3 * * *"',

--- a/scripts/infra/deploy-vps-image.sh
+++ b/scripts/infra/deploy-vps-image.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# CI sends only a digest/revision request; root-owned VPS configuration owns execution.
+set -euo pipefail
+role="${1:-}"
+[[ $# == 1 && ( "$role" == site || "$role" == api ) ]] || exit 64
+[[ "${GITHUB_REPOSITORY:-}" == VooZ2/terento ]] || exit 64
+if [[ "${GITHUB_REF:-}" == refs/heads/beta ]]; then
+  :
+elif [[ "$role" == site && "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+  : # The publication job already verifies the tagged commit belongs to beta.
+else
+  exit 64
+fi
+[[ "${VPS_IMAGE_DIGEST:-}" =~ ^sha256:[0-9a-f]{64}$ ]] || exit 64
+[[ "${GITHUB_SHA:-}" =~ ^[0-9a-f]{40}$ ]] || exit 64
+: "${VPS_SSH_KEY:?Scoped environment SSH key required}"
+: "${RUNNER_TEMP:?Runner temporary directory required}"
+umask 077
+keydir="$(mktemp -d "$RUNNER_TEMP/rukas-ssh.XXXXXX")"
+trap 'rm -rf -- "$keydir"' EXIT
+printf '%s\n' "$VPS_SSH_KEY" > "$keydir/key"
+unset VPS_SSH_KEY
+printf '%s\n' '179.198.204.47 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII4/GzEE6xDFxBp4kE17EKNR3q70vpmkOJSp7/otiAq0' > "$keydir/known_hosts"
+ssh -i "$keydir/key" -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes \
+  -o "UserKnownHostsFile=$keydir/known_hosts" -o ConnectTimeout=15 \
+  "terento-ci-$role@179.198.204.47" "deploy $VPS_IMAGE_DIGEST $GITHUB_SHA"

--- a/site-deploy/Dockerfile
+++ b/site-deploy/Dockerfile
@@ -1,4 +1,7 @@
 FROM caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
 
+# Port 80 is allowed by the container sysctl; file capabilities conflict with cap_drop ALL.
+RUN setcap -r /usr/bin/caddy
+
 COPY site-deploy/Caddyfile /etc/caddy/Caddyfile
 COPY site/ /srv

--- a/site-deploy/README.md
+++ b/site-deploy/README.md
@@ -73,3 +73,39 @@ existing application gate or the exact configured Cloudflare Access login redire
 After activation, repository variable `TERENTO_ADMIN_ACCESS_REQUIRED=true`
 requires the edge gate; unrelated redirects and errors fail. Test with
 `python3 Tests/admin-access-boundary-tests.py`.
+
+### Personal VPS production workflow cutover candidate
+
+The scoped deployment workflows publish tested immutable GHCR images in a job
+without VPS credentials, then send only an image digest and matching caller
+revision to the root-owned personal VPS deployment handler. `rukas-site` and
+`rukas-api` each supply their own `VPS_SSH_KEY`; accounts, address and host key
+are pinned in `scripts/infra/deploy-vps-image.sh`. API schema migration and native
+admin checks stay in the installed root-owned handler/verifier. Public Access,
+API contracts, release-client validation and operations observations remain CI
+gates. The image publisher retains the public site/release/legal checks, and API
+publication depends on the existing backend/PostgreSQL quality workflow.
+
+This change is a cutover candidate: merging it replaces demo deployment workflows.
+Do not merge until the final database/assets copy, root-owned API configuration,
+origin protections and personal VPS activation are ready, production DNS routes
+to the personal VPS, and both root-owned `verify-public` markers are installed.
+Before that point public CI checks can reach the demo and cannot establish that a
+personal-VPS deployment is publicly serving traffic. Freeze automated demo deploys
+and scheduler before final data export; never run two writable production copies.
+
+At coordinated cutover, permit branch `beta` in both GitHub environments and tag
+pattern `v*` in `rukas-site` only. Existing site tag releases are preserved; the
+publisher additionally requires the tagged commit to be an ancestor of `beta`.
+API release dispatch remains beta-only. Remove the rehearsal branch policy after
+cutover. Environment policy and secret changes are separate owner-authorized
+infrastructure operations, not effects of merging this candidate. The access-check
+workflow now performs command rejection checks only and cannot replay an old image.
+
+Root provisioning preserves `TERENTO_OPERATIONS_INGEST_SECRET` continuity; CI no
+longer uploads or edits server environment files. Future rotation must update root
+configuration and GitHub together. No Access administrator/service bypass token is
+provided to CI. Keep old demo credentials for the controlled rollback window, then
+revoke them after migration acceptance. Once any new writer runs, including the
+scheduler, returning to the demo requires a freeze and reverse data synchronization;
+image or DNS rollback does not revert database writes or schema migrations.


### PR DESCRIPTION
## Summary

Replace the demo VPS shell/SCP deployments with tested immutable GHCR images and independent site/API forced-command SSH accounts on the personal VPS. Publishing has no VPS credentials; deployment jobs use their own GitHub environments. Preserve site/release/legal, backend/PostgreSQL, public Access/API and native release-client gates. Restrict API to beta; preserve v* site releases with a beta-ancestry check. Access tests now reject commands without replaying an old deployment.

**Draft cutover candidate: do not merge before the new origin, final data/configuration, DNS routing and both server public-verification markers are ready.** Merging replaces production deployment workflows. Environment policies and final migration are intentionally not changed by this PR.

## Validation

- [x] Relevant automated validation passed locally.
- [x] Commands and results recorded below.
- [x] No hardware validation claimed.

Passed: `python3 Tests/run-test-suite.py ci` (2 runners), `python3 Tests/run-test-suite.py site` (11 runners), inventory (67 runners/47 test sources), release documentation/legal checks, YAML parsing, bash syntax for all workflow run steps, and `git diff --check`. Workflow tests exercise the real SSH request script with a local spy: valid requests, malformed/ref/role rejection before SSH, pinned host checking, key permissions, secret removal from subprocess environment and temporary-file cleanup. No live VPS deployment or image publication was performed.

## Safety and compatibility

- [x] Device code and Garmin files are unchanged; existing safety checks remain.
- [x] No secrets, device data, map binaries or proprietary assets added.
- [x] Attribution, notices and trademark wording remain unchanged.

## Real-device testing

Not performed: infrastructure-only change.

## Limitations and follow-up

At coordinated cutover, configure beta in both scoped environments and v* tags in rukas-site only; remove the rehearsal branch policy afterward. Preserve operations ingest secret continuity through root provisioning, not CI shell access. Scheduler/data freeze, native owner login, origin protection, DNS verification and old-credential revocation remain migration tasks. Rollback after any new write requires reverse data synchronization. Site README documents these constraints and the root-owned server boundary.

## Brand and user-facing changes

- [x] Not applicable: no user-facing changes.
