### PR TITLE
fix(admin): clarify overview metric sources

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1012,7 +1012,7 @@ def _overview_trend_chart(
         "<div class='overview-chart-wrap'>"
         f"<svg class='overview-trend-chart' viewBox='0 0 {chart_width} {chart_height}' role='img' aria-label='Map install operations over time'>"
         f"{''.join(bars)}{''.join(labels)}</svg>"
-        "<div class='overview-chart-legend'><span><i class='overview-chart-success'></i>Succeeded</span><span><i class='overview-chart-failed'></i>Failed</span><span><i class='overview-chart-custom'></i>Custom .img</span></div><p class='overview-chart-note'>Custom .img: successful manual installations.</p></div>"
+        "<div class='overview-chart-legend'><span><i class='overview-chart-success'></i>Succeeded</span><span><i class='overview-chart-failed'></i>Failed</span><span><i class='overview-chart-custom'></i>Custom .img</span></div><p class='overview-chart-note'>Custom .img is shown separately; it is not included in map-operation KPI totals.</p></div>"
     )
 
 
@@ -1169,7 +1169,7 @@ def overview_page(
         if review_required else ""
     )
     model_panel = (
-        f"<section class='overview-panel overview-model-panel' aria-labelledby='overview-model-title'><div class='section-heading'><div><p class='section-kicker'>Compatibility evidence</p><h2 id='overview-model-title'>Device/model activity</h2></div></div><p class='overview-chart-note'>Activity is grouped by canonical device model when available.</p>{_overview_model_activity(model_activity)}{review_section}</section>"
+        f"<section class='overview-panel overview-model-panel' aria-labelledby='overview-model-title'><div class='section-heading'><div><p class='section-kicker'>Compatibility evidence</p><h2 id='overview-model-title'>Device/model activity</h2></div></div><p class='overview-chart-note'>Compatibility evidence only · separate from map-operation telemetry.</p>{_overview_model_activity(model_activity)}{review_section}</section>"
         if model_activity or review_required else ""
     )
     primary_grid_class = "overview-primary-grid" if model_panel else "overview-primary-grid overview-primary-grid-single"
@@ -4722,7 +4722,7 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
 .diagnostic-action-form button[type='submit']:hover{background:var(--interactive-hover)}
 .diagnostic-action-form button.secondary-button,.model-administration button.secondary-button{background:var(--surface);color:var(--interactive);border:1px solid var(--border)}
 .timestamp-metric strong{font-size:var(--admin-type-subsection-size)!important;line-height:var(--admin-type-subsection-line)!important}
-.overview-secondary-grid,.overview-primary-grid{align-items:start}
+.overview-secondary-grid{align-items:start}.overview-primary-grid{align-items:stretch}
 .overview-compatibility-summary>summary,.model-administration>summary,.device-information-section>summary{margin-bottom:12px}
 .model-administration,.device-information-section{padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}
 .attention-shortcuts{display:flex;flex-wrap:wrap;gap:8px 18px;margin:12px 0 20px;font-size:13px}

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -431,6 +431,8 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("overview-chart-panel", body)
         self.assertIn("Recent map activity", body)
         self.assertIn("Compatibility evidence", body)
+        self.assertIn("Custom .img is shown separately; it is not included in map-operation KPI totals.", body)
+        self.assertIn(".overview-primary-grid{align-items:stretch}", body)
         self.assertNotIn("Pending metric definition", body)
         self.assertNotIn("<span>Success rate</span>", body)
 
@@ -489,6 +491,7 @@ class AdminSemanticsTests(unittest.TestCase):
             {"username": "operator"}, "csrf",
         ).decode()
         self.assertIn("Device/model activity", body)
+        self.assertIn("Compatibility evidence only · separate from map-operation telemetry.", body)
         self.assertIn("fēnix 8 · 47 mm, AMOLED", body)
         self.assertIn("New / review-required devices", body)
         self.assertIn("Needs attention", body)
@@ -706,7 +709,7 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("Custom .img installed: 3", body)
         self.assertRegex(body, r"class='overview-chart-custom'[^>]*height='220.0'")
         self.assertIn("</i>Custom .img</span>", body)
-        self.assertIn("Custom .img: successful manual installations.", body)
+        self.assertIn("Custom .img is shown separately; it is not included in map-operation KPI totals.", body)
 
     def test_chart_segments_join_without_individual_rounding(self):
         import xml.etree.ElementTree as ET


### PR DESCRIPTION
## Summary\n- keep map-operation telemetry and compatibility evidence explicitly separate in Overview\n- explain that verified custom .img activity is separate from map-operation KPI totals\n- stretch the chart and device/model panels to the same height\n\nNo database, schema, API, or aggregation changes.\n\n## Verification\n- 71 Admin semantics tests\n- shared brand contract tests\n- Overview JavaScript syntax check\n- git diff --check