### PR TITLE
fix(admin): align device detail sections

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -4725,6 +4725,7 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
 .overview-secondary-grid{align-items:start}.overview-primary-grid{align-items:stretch}
 .overview-compatibility-summary>summary,.model-administration>summary,.device-information-section>summary{margin-bottom:12px}
 .model-administration,.device-information-section{padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}
+.model-page-section,.model-technical-details{box-sizing:border-box;margin-top:16px;padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}.model-administration>summary,.device-information-section>summary{margin-bottom:0}.model-administration[open]>summary,.device-information-section[open]>summary{margin-bottom:12px}
 .attention-shortcuts{display:flex;flex-wrap:wrap;gap:8px 18px;margin:12px 0 20px;font-size:13px}
 .attention-shortcuts a{color:var(--interactive);text-underline-offset:3px}
 .attention-shortcuts strong{margin-left:4px}

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -1006,6 +1006,8 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("Garmin device", detail_body)
         self.assertIn("device-information-section", detail_body)
         self.assertIn(".device-information-section .model-information-list{max-width:780px}", detail_body)
+        self.assertIn(".model-page-section,.model-technical-details{box-sizing:border-box;margin-top:16px;padding:16px", detail_body)
+        self.assertIn(".model-administration[open]>summary,.device-information-section[open]>summary{margin-bottom:12px}", detail_body)
         self.assertIn("grid-template-columns:150px minmax(0,1fr)", detail_body)
         self.assertNotIn("Change history", detail_body)
         self.assertIn("placeholder=\"garmin maps\"", campaign_body)


### PR DESCRIPTION
## Summary
- normalize Administration, Device information, and Technical details card padding and spacing
- keep collapsed summaries compact while preserving expanded-content spacing
- prevent uneven card heights and drifting vertical gaps

## Verification
- 71 Admin semantics tests
- shared brand contract
- git diff --check

No database, schema, or API changes.