### PR TITLE
fix(admin): keep detail values inside cards

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -4726,6 +4726,7 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
 .overview-compatibility-summary>summary,.model-administration>summary,.device-information-section>summary{margin-bottom:12px}
 .model-administration,.device-information-section{padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}
 .model-page-section,.model-technical-details{box-sizing:border-box;margin-top:16px;padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}.model-administration>summary,.device-information-section>summary{margin-bottom:0}.model-administration[open]>summary,.device-information-section[open]>summary{margin-bottom:12px}
+.model-information-list dt,.model-information-list dd{min-width:0;overflow-wrap:anywhere;word-break:break-word}.model-technical-details .model-information-list dd{text-align:left}
 .attention-shortcuts{display:flex;flex-wrap:wrap;gap:8px 18px;margin:12px 0 20px;font-size:13px}
 .attention-shortcuts a{color:var(--interactive);text-underline-offset:3px}
 .attention-shortcuts strong{margin-left:4px}

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -1008,6 +1008,8 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn(".device-information-section .model-information-list{max-width:780px}", detail_body)
         self.assertIn(".model-page-section,.model-technical-details{box-sizing:border-box;margin-top:16px;padding:16px", detail_body)
         self.assertIn(".model-administration[open]>summary,.device-information-section[open]>summary{margin-bottom:12px}", detail_body)
+        self.assertIn(".model-information-list dt,.model-information-list dd{min-width:0;overflow-wrap:anywhere;word-break:break-word}", detail_body)
+        self.assertIn(".model-technical-details .model-information-list dd{text-align:left}", detail_body)
         self.assertIn("grid-template-columns:150px minmax(0,1fr)", detail_body)
         self.assertNotIn("Change history", detail_body)
         self.assertIn("placeholder=\"garmin maps\"", campaign_body)


### PR DESCRIPTION
## Summary
- allow model detail labels and values to shrink and wrap inside their grid columns
- left-align technical values so long identifiers remain readable
- preserve the normalized detail card spacing from the previous fix

## Verification
- 71 Admin semantics tests
- shared brand contract
- git diff --check

No database, schema, or API changes.