### PR TITLE
feat(admin): add local test data controls

### DIFF
--- a/backend/catalog-api/.env.example
+++ b/backend/catalog-api/.env.example
@@ -7,3 +7,7 @@ ADMIN_BOOTSTRAP_SECRET=replace-with-a-different-long-random-secret
 ADMIN_SESSION_TTL_SECONDS=28800
 PUBLIC_COMPATIBILITY_STATS_ENABLED=false
 OPERATIONS_INGEST_SECRET=replace-with-a-separate-long-random-secret
+# Keep contours disabled in public environments until the physical watch gate passes.
+OPENTOPO_MAP_CONTOUR_MODE=off
+# Used only with OPENTOPO_MAP_CONTOUR_MODE=allowlist; keep this empty in public beta.
+OPENTOPO_MAP_CONTOUR_ALLOWLIST=

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -516,13 +516,17 @@ Accepts at most 8 KiB of schema-version-1 JSON and is rate limited per source
 address. This is deliberately separate from `/compatibility/events` and does
 not accept compatibility, device, manifest, path, serial, Unit ID, raw log, or
 raw error fields. The allowlisted fields are `id`, `operationId`, `timestamp`,
-`providerId`, optional `mapId`/`region`, `eventType`, `outcome`, and optional
-`appBuild`. Event types are `DOWNLOAD_STARTED`, `DOWNLOAD_SUCCEEDED`,
+`providerId`, `releaseLabel`, optional `mapId`/`region`, `eventType`, `outcome`,
+and optional `appBuild`. `releaseLabel` must be a strict SemVer app identity;
+the exact `-local` suffix classifies the row server-side as local test data.
+Event types are `DOWNLOAD_STARTED`, `DOWNLOAD_SUCCEEDED`,
 `DOWNLOAD_FAILED`, `INSTALL_SUCCEEDED`, and `INSTALL_FAILED`; event IDs are
 UUIDs and are idempotent. The server stores only the normalized columns in
 `map_download_event`; it does not retain the raw JSON body. A successful
 insert returns `201`, a duplicate returns `200`, and both return the
-`operationId`.
+`operationId`. Local rows are excluded from production map statistics and can
+be removed only by an authenticated, CSRF-protected admin action at
+`/admin/test-data`; the purge deletes both telemetry streams in one transaction.
 
 This endpoint receives map-usage diagnostics while the independent map-usage
 diagnostics switch is enabled in `Terento → Diagnostics`; it must not be used

--- a/backend/catalog-api/pyproject.toml
+++ b/backend/catalog-api/pyproject.toml
@@ -22,6 +22,7 @@ terento-catalog-collect-devices = "terento_catalog.collect_devices:main"
 terento-catalog-backfill-sizes = "terento_catalog.backfill_sizes:main"
 terento-catalog-schedule = "terento_catalog.scheduler:main"
 terento-catalog-asset = "terento_catalog.asset_admin:main"
+terento-catalog-audit-opentopomap-contours = "terento_catalog.opentopomap_contour_audit:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/backend/catalog-api/reports/opentopomap-contour-allowlist-2026-09-06.json
+++ b/backend/catalog-api/reports/opentopomap-contour-allowlist-2026-09-06.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "mode": "allowlist",
+  "provider": "opentopomap",
+  "status": "INTERNAL_RC_ONLY",
+  "sourceAudit": "opentopomap-contour-audit-2026-09-06.md",
+  "packageIds": [
+    "opentopomap-andorra",
+    "opentopomap-lithuania"
+  ],
+  "selectionRationale": {
+    "opentopomap-andorra": "Representative mountainous contour package; exact Garmin IMG payload identity was validated from the original provider ZIP.",
+    "opentopomap-lithuania": "Normal flat-country contour package retained for the Phase 3 internal RC comparison."
+  },
+  "publicActivation": false,
+  "hardwareGate": "HARDWARE_GATE_A"
+}
+

--- a/backend/catalog-api/reports/opentopomap-contour-audit-2026-09-06.md
+++ b/backend/catalog-api/reports/opentopomap-contour-audit-2026-09-06.md
@@ -1,0 +1,33 @@
+# OpenTopoMap contour shadow audit — 2026-09-06
+
+Command:
+
+```text
+PYTHONPATH=backend/catalog-api/src python3 -m terento_catalog.opentopomap_contour_audit \
+  --sample-region andorra --expected-main-count 177
+```
+
+Observed from the official OpenTopoMap source:
+
+- main packages: `177` / expected `177`;
+- unique contour sources: `176`;
+- package-to-contour attachments: `179`;
+- validated contour measurements: `178` attachments;
+- unavailable contour attachments: `1`;
+- unknown install sizes: `0`;
+- shared contour sources: `1` (Canada relationship);
+- minimum install size: `378,880` bytes;
+- maximum install size: `4,271,505,408` bytes;
+- Andorra representative sample: one Garmin IMG payload, `VALIDATED`, with
+  fixed-header Garmin markers plus printable `OpenTopoMap` and `ANDORRA`
+  identity tokens;
+- unavailable source: `otm-saint-helena-ascension-and-tristan-da-cunha-contours.zip`,
+  reported as an empty payload by the bounded ZIP inspection;
+- the Canada shared source is retained as one source and must be deduplicated
+  before any device write.
+
+This is Phase 2 shadow evidence only. The public catalog remains `off`; no
+provider binary is stored, mirrored, or published by this report. The
+unavailable Saint Helena optional artifact remains isolated from valid main
+maps and is excluded from any internal allowlist.
+

--- a/backend/catalog-api/reports/opentopomap-contour-rc.env.example
+++ b/backend/catalog-api/reports/opentopomap-contour-rc.env.example
@@ -1,0 +1,8 @@
+# Phase 3 internal RC only. Do not use for public beta or production.
+OPENTOPO_MAP_CONTOUR_MODE=allowlist
+OPENTOPO_MAP_CONTOUR_ALLOWLIST=opentopomap-andorra,opentopomap-lithuania
+
+# Debug app launch override; release builds ignore this client-side switch.
+TERENTO_OPENTOPO_MAP_CONTOUR_MODE=allowlist
+TERENTO_OPENTOPO_MAP_CONTOUR_ALLOWLIST=opentopomap-andorra,opentopomap-lithuania
+

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -509,6 +509,7 @@ def _admin_header(user: dict[str, Any], csrf_token: str, *, active: str = "evide
     providers_class = " class='active'" if active == "providers" else ""
     map_statistics_class = " class='active'" if active == "map-statistics" else ""
     system_health_class = " class='active'" if active == "system-health" else ""
+    test_data_class = " class='active'" if active == "test-data" else ""
     review = user.get("admin_review_summary") or {}
     installation_issues = int(review.get("installationIssues") or 0)
     identity_pending = int(review.get("identityPending") or 0)
@@ -528,10 +529,46 @@ def _admin_header(user: dict[str, Any], csrf_token: str, *, active: str = "evide
       <div class="admin-header-zone admin-header-left">{_admin_brand(show_badge=False)}<span class="admin-badge">Admin area</span><a class="admin-website-link" href="https://terento.app/" target="_blank" rel="noopener noreferrer" aria-label="Open Terento website in a new tab">Website <span aria-hidden="true">↗</span></a></div>
       <a class="admin-mobile-review" href="/admin#overview-attention-title" aria-label="Needs attention: {review_total}">Review <span class="needs-review-count">{review_total}</span></a>
       <button id="admin-menu-toggle" class="secondary-button" type="button" aria-controls="admin-menu-panel" aria-expanded="false" hidden>Menu</button>
-      <div id="admin-menu-panel"><nav class="admin-section-nav" aria-label="Admin sections"><a{overview_class} href="/admin">Overview</a><a{system_health_class} href="/admin/system-health">System health</a><a{evidence_class} href="/admin/installations">Installations</a><a{devices_class} href="/admin/devices">Devices</a><a{providers_class} href="/admin/providers">Providers</a><a{map_statistics_class} href="/admin/map-statistics">Map statistics</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a>{review_menu}</nav>
+      <div id="admin-menu-panel"><nav class="admin-section-nav" aria-label="Admin sections"><a{overview_class} href="/admin">Overview</a><a{system_health_class} href="/admin/system-health">System health</a><a{evidence_class} href="/admin/installations">Installations</a><a{devices_class} href="/admin/devices">Devices</a><a{providers_class} href="/admin/providers">Providers</a><a{map_statistics_class} href="/admin/map-statistics">Map statistics</a><a{test_data_class} href="/admin/test-data">Test data</a><a{campaign_class} href="/admin/campaign-links">Campaign links</a>{review_menu}</nav>
       <nav class="admin-nav" aria-label="Admin navigation"><label class="timezone-control"><span class="sr-only">Time zone</span><select id="admin-timezone" aria-label="Time zone" title="Time zone"><option value="browser">Automatic (browser)</option><option value="UTC">UTC</option><option value="Europe/Vilnius">Europe/Vilnius</option><option value="Europe/London">Europe/London</option><option value="Europe/Berlin">Europe/Berlin</option><option value="America/New_York">America/New_York</option><option value="America/Los_Angeles">America/Los_Angeles</option><option value="Asia/Tokyo">Asia/Tokyo</option></select></label><a class="admin-user" href="/admin/account" aria-label="Account settings for {username}">{username}</a>
       <form method="post" action="/admin/logout"><input type="hidden" name="csrf_token" value="{html.escape(csrf_token)}"><button class="link-button" type="submit">Sign out</button></form><a class="admin-mobile-website" href="https://terento.app/" target="_blank" rel="noopener noreferrer">Website ↗</a></nav></div>
     </div></header>"""
+
+
+def local_test_data_page(
+    summary: dict[str, Any], user: dict[str, Any], csrf_token: str,
+    *, success: str | None = None, error: str | None = None,
+) -> bytes:
+    """Authenticated, explicit purge UI for local-only telemetry."""
+    labels = ", ".join(
+        html.escape(str(label)) for label in summary.get("releaseLabels", [])
+    ) or "None"
+    content = f"""
+      {_admin_header(user, csrf_token, active='test-data')}
+      <main id="main-content" class="admin-main" aria-labelledby="test-data-title">
+        <p class="eyebrow">Admin · local only</p>
+        <h1 id="test-data-title">Test data</h1>
+        <p class="lede">Only events classified by the server as local test telemetry are shown here. Production telemetry is excluded and cannot be removed from this page.</p>
+        {_success(success)}{_error(error)}
+        <section class="admin-card" aria-labelledby="local-telemetry-title">
+          <h2 id="local-telemetry-title">Purgeable local telemetry</h2>
+          <dl class="admin-summary-grid">
+            <div><dt>Diagnostic events</dt><dd>{int(summary.get('diagnosticEventCount') or 0)}</dd></div>
+            <div><dt>Map events</dt><dd>{int(summary.get('mapEventCount') or 0)}</dd></div>
+            <div><dt>Shared operations</dt><dd>{int(summary.get('operationCount') or 0)}</dd></div>
+          </dl>
+          <p class="muted-value">Release labels: <code>{labels}</code></p>
+          <form method="post" action="/admin/test-data/purge" class="admin-danger-form">
+            <input type="hidden" name="csrf_token" value="{html.escape(csrf_token, quote=True)}">
+            <label>Type <code>DELETE_LOCAL_TEST_DATA</code> to confirm
+              <input name="confirmation" required autocomplete="off" pattern="DELETE_LOCAL_TEST_DATA" spellcheck="false">
+            </label>
+            <button type="submit" class="danger-button">Delete local test data</button>
+          </form>
+        </section>
+      </main>
+    """
+    return _layout("Test data", content)
 
 
 def setup_page(*, error: str | None = None) -> bytes:
@@ -4891,6 +4928,10 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
 
 def _error(message: str | None) -> str:
     return f"<p class='error'>{html.escape(message)}</p>" if message else ""
+
+
+def _success(message: str | None) -> str:
+    return f"<p class='success'>{html.escape(message)}</p>" if message else ""
 
 
 def _layout(title: str, content: str) -> bytes:

--- a/backend/catalog-api/src/terento_catalog/app.py
+++ b/backend/catalog-api/src/terento_catalog/app.py
@@ -33,6 +33,8 @@ def run_server(settings: Settings, database: Database) -> None:
             admin_session_ttl_seconds=settings.admin_session_ttl_seconds,
             public_compatibility_stats_enabled=settings.public_compatibility_stats_enabled,
             operations_ingest_secret=settings.operations_ingest_secret,
+            opentopomap_contour_mode=settings.opentopomap_contour_mode,
+            opentopomap_contour_allowlist=settings.opentopomap_contour_allowlist,
         ),
         settings.host,
         settings.port,

--- a/backend/catalog-api/src/terento_catalog/catalog.py
+++ b/backend/catalog-api/src/terento_catalog/catalog.py
@@ -9,7 +9,13 @@ from typing import Any
 from . import CATALOG_VERSION
 
 
-def build_catalog(rows: list[dict[str, Any]], updated_at: datetime) -> dict[str, Any]:
+def build_catalog(
+    rows: list[dict[str, Any]],
+    updated_at: datetime,
+    *,
+    contour_mode: str = "off",
+    contour_allowlist: set[str] | frozenset[str] = frozenset(),
+) -> dict[str, Any]:
     """Build the versioned public contract from database rows.
 
     Rows without a normalized version or a known download size are kept out of
@@ -19,7 +25,12 @@ def build_catalog(rows: list[dict[str, Any]], updated_at: datetime) -> dict[str,
     """
 
     if any("package_id" in row for row in rows):
-        return _build_provider_neutral_catalog(rows, updated_at)
+        return _build_provider_neutral_catalog(
+            rows,
+            updated_at,
+            contour_mode=contour_mode,
+            contour_allowlist=contour_allowlist,
+        )
 
     providers: dict[str, dict[str, Any]] = {}
     for row in rows:
@@ -115,7 +126,11 @@ def build_catalog(rows: list[dict[str, Any]], updated_at: datetime) -> dict[str,
 
 
 def _build_provider_neutral_catalog(
-    rows: list[dict[str, Any]], updated_at: datetime
+    rows: list[dict[str, Any]],
+    updated_at: datetime,
+    *,
+    contour_mode: str,
+    contour_allowlist: set[str] | frozenset[str],
 ) -> dict[str, Any]:
     """Serialize the current package/artifact read model.
 
@@ -128,6 +143,12 @@ def _build_provider_neutral_catalog(
     providers: dict[str, dict[str, Any]] = {}
     packages: dict[tuple[str, str], dict[str, Any]] = {}
     for row in rows:
+        if not _contour_is_publishable(
+            row,
+            contour_mode=contour_mode,
+            contour_allowlist=contour_allowlist,
+        ):
+            continue
         provider_id = str(row["provider_id"])
         provider = providers.setdefault(
             provider_id,
@@ -250,6 +271,32 @@ def _build_provider_neutral_catalog(
         "updatedAt": _format_timestamp(updated_at),
         "providers": [providers[key] for key in sorted(providers)],
     }
+
+
+def _contour_is_publishable(
+    row: dict[str, Any],
+    *,
+    contour_mode: str,
+    contour_allowlist: set[str] | frozenset[str],
+) -> bool:
+    """Keep rollout policy at the public serialization boundary.
+
+    The database may retain shadow health evidence, but the client must never
+    receive optional contours while the rollout is off or shadow. A malformed
+    mode fails closed to the existing main-only behavior.
+    """
+
+    if str(row.get("artifact_kind") or "main").lower() != "contours":
+        return True
+    normalized_mode = str(contour_mode or "off").strip().lower()
+    if normalized_mode == "public":
+        return str(row.get("artifact_validation_status") or "").upper() == "VALIDATED"
+    if normalized_mode == "allowlist":
+        return (
+            str(row.get("package_id") or "") in contour_allowlist
+            and str(row.get("artifact_validation_status") or "").upper() == "VALIDATED"
+        )
+    return False
 
 
 def _release_version(

--- a/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
+++ b/backend/catalog-api/src/terento_catalog/compatibility_evidence.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
+from .telemetry import validate_release_label
+
 MAX_EVENT_BYTES = 16_384
 # `custom` is a local IMG source, not a map provider. It is accepted here so
 # shared custom installs can contribute device compatibility evidence while
@@ -173,6 +175,10 @@ def _validate_v3(event: dict[str, Any]) -> None:
             or "file://" in event[key]
         ):
             raise EvidenceValidationError(f"invalid_{key}")
+    try:
+        event["releaseLabel"] = validate_release_label(event["releaseLabel"])
+    except ValueError as exc:
+        raise EvidenceValidationError("invalid_releaseLabel") from exc
     for key in ("writeStarted", "remoteObjectCreated", "cleanupAttempted", "cleanupSucceeded"):
         if not isinstance(event[key], bool):
             raise EvidenceValidationError(f"invalid_{key}")

--- a/backend/catalog-api/src/terento_catalog/config.py
+++ b/backend/catalog-api/src/terento_catalog/config.py
@@ -17,6 +17,8 @@ class Settings:
     admin_session_ttl_seconds: int = 28_800
     public_compatibility_stats_enabled: bool = False
     operations_ingest_secret: str | None = None
+    opentopomap_contour_mode: str = "off"
+    opentopomap_contour_allowlist: tuple[str, ...] = ()
 
     @classmethod
     def from_env(cls) -> "Settings":
@@ -41,6 +43,8 @@ class Settings:
             admin_session_ttl_seconds=_positive_int("ADMIN_SESSION_TTL_SECONDS", 28_800),
             public_compatibility_stats_enabled=_boolean("PUBLIC_COMPATIBILITY_STATS_ENABLED", False),
             operations_ingest_secret=_optional_secret("OPERATIONS_INGEST_SECRET"),
+            opentopomap_contour_mode=_contour_mode(),
+            opentopomap_contour_allowlist=_csv("OPENTOPO_MAP_CONTOUR_ALLOWLIST"),
         )
 
 
@@ -76,3 +80,20 @@ def _optional_secret(name: str) -> str | None:
     if len(value) < 32 or len(value) > 512:
         raise RuntimeError(f"{name} must contain 32–512 characters")
     return value
+
+
+def _contour_mode() -> str:
+    value = os.environ.get("OPENTOPO_MAP_CONTOUR_MODE", "off").strip().lower()
+    if value not in {"off", "shadow", "allowlist", "public"}:
+        raise RuntimeError(
+            "OPENTOPO_MAP_CONTOUR_MODE must be off, shadow, allowlist, or public"
+        )
+    return value
+
+
+def _csv(name: str) -> tuple[str, ...]:
+    return tuple(
+        item.strip()
+        for item in os.environ.get(name, "").split(",")
+        if item.strip()
+    )

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -17,6 +17,7 @@ from .map_capability import classify_map_capable
 from .provider_catalog import ProviderDefinition, ProviderSnapshot
 from .provider_health import ProviderHealthResult
 from .github_issue_sync import sync_health
+from .telemetry import is_local_release_label
 
 
 def _overview_time_zone(value: str) -> ZoneInfo:
@@ -140,11 +141,13 @@ class Database:
             connection.execute("""
                 SELECT event_id, operation_id, app_build, failure_stage, failure_code,
                        native_failure_code, transfer_progress_bucket, identity_resolution_code,
-                       deletion_token_hash FROM compatibility_evidence_event WHERE FALSE
+                       deletion_token_hash, release_label, is_local_test
+                FROM compatibility_evidence_event WHERE FALSE
             """)
             connection.execute("""
                 SELECT event_id, operation_id, provider_id, map_package_id, region,
-                       event_type, outcome, occurred_at, app_build
+                       event_type, outcome, occurred_at, app_build,
+                       release_label, is_local_test
                 FROM map_download_event WHERE FALSE
             """)
         return True
@@ -254,7 +257,7 @@ class Database:
                 selected_map_count, app_build, release_label, failure_stage, failure_code,
                 native_failure_code, write_started, remote_object_created,
                 cleanup_attempted, cleanup_succeeded, transfer_progress_bucket,
-                raw_mtp_model, identity_resolution_code
+                raw_mtp_model, identity_resolution_code, is_local_test
             ) VALUES (
                 %(id)s, %(timestamp)s, %(model)s, %(compatibilityIdentity)s, %(variant)s, %(caseSizeMm)s,
                 %(displayType)s, %(canonicalDeviceId)s, %(identityResolutionState)s,
@@ -266,7 +269,8 @@ class Database:
                 %(selectedMapCount)s, %(appBuild)s, %(releaseLabel)s, %(failureStage)s,
                 %(failureCode)s, %(nativeFailureCode)s, %(writeStarted)s,
                 %(remoteObjectCreated)s, %(cleanupAttempted)s, %(cleanupSucceeded)s,
-                %(transferProgressBucket)s, %(rawMTPModel)s, %(identityResolutionCode)s
+                %(transferProgressBucket)s, %(rawMTPModel)s, %(identityResolutionCode)s,
+                %(isLocalTest)s
             ) ON CONFLICT (event_id) DO NOTHING
             RETURNING event_id
         """
@@ -300,6 +304,7 @@ class Database:
             "transferProgressBucket": event.get("transferProgressBucket"),
             "rawMTPModel": event.get("rawMTPModel"),
             "identityResolutionCode": event.get("identityResolutionCode"),
+            "isLocalTest": is_local_release_label(event.get("releaseLabel")),
         }
         with self.connection() as connection:
             # The client contract remains unchanged: canonicalDeviceId is
@@ -400,6 +405,7 @@ class Database:
             FROM compatibility_evidence_event
             LEFT JOIN admin_user ON admin_user.id = compatibility_evidence_event.resolved_by
             WHERE diagnostic_status = %s
+              AND is_local_test IS NOT TRUE
             ORDER BY occurred_at DESC, operation_key, map_result_index NULLS FIRST
             LIMIT %s
         """
@@ -524,6 +530,7 @@ class Database:
                     ) AS identity_pending
                 FROM compatibility_evidence_event
                 WHERE diagnostic_status = 'ACTIVE'
+                  AND is_local_test IS NOT TRUE
                 GROUP BY COALESCE(operation_id::text, 'legacy:' || event_id::text)
             ), publication_reviews AS (
                 SELECT count(*) AS ready_to_publish
@@ -616,6 +623,7 @@ class Database:
                     ) AS open_error
                 FROM compatibility_evidence_event AS e
                 WHERE e.diagnostic_status = 'ACTIVE'
+                  AND e.is_local_test IS NOT TRUE
                 GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
             )
         """
@@ -811,7 +819,7 @@ class Database:
             # for a young installation with only a few days of history.
             with self.connection() as connection:
                 extent = connection.execute(
-                    "SELECT min(occurred_at) AS first_occurred_at, max(occurred_at) AS last_occurred_at FROM (SELECT occurred_at FROM map_download_event UNION ALL SELECT occurred_at FROM compatibility_evidence_event WHERE provider = 'custom') AS chart_events"
+                    "SELECT min(occurred_at) AS first_occurred_at, max(occurred_at) AS last_occurred_at FROM (SELECT occurred_at FROM map_download_event WHERE is_local_test IS NOT TRUE UNION ALL SELECT occurred_at FROM compatibility_evidence_event WHERE provider = 'custom' AND is_local_test IS NOT TRUE) AS chart_events"
                 ).fetchone() or {}
             first = extent.get("first_occurred_at")
             last = extent.get("last_occurred_at")
@@ -831,6 +839,7 @@ class Database:
             LEFT JOIN map_provider AS p ON p.id = e.provider_id
             LEFT JOIN map_package AS mp ON mp.id = e.map_package_id
             WHERE e.occurred_at >= %s
+              AND e.is_local_test IS NOT TRUE
         """
         with self.connection() as connection:
             summary = connection.execute(
@@ -881,12 +890,14 @@ class Database:
                         timezone(%s, e.occurred_at) AS local_occurred_at
                     FROM map_download_event AS e
                     WHERE e.occurred_at >= %s
+                      AND e.is_local_test IS NOT TRUE
                     UNION ALL
                     SELECT
                         e.operation_id, 'CUSTOM_SUCCEEDED', 'SUCCEEDED',
                         timezone(%s, max(e.occurred_at)) AS local_occurred_at
                     FROM compatibility_evidence_event AS e
                     WHERE e.provider = 'custom'
+                      AND e.is_local_test IS NOT TRUE
                     GROUP BY e.operation_id,
                         CASE WHEN e.operation_id IS NULL THEN e.event_id END
                     HAVING max(e.occurred_at) >= %s
@@ -2300,8 +2311,9 @@ class Database:
                 """
                 INSERT INTO map_download_event (
                     event_id, operation_id, provider_id, map_package_id,
-                    region, event_type, outcome, occurred_at, app_build
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    region, event_type, outcome, occurred_at, app_build,
+                    release_label, is_local_test
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT DO NOTHING
                 RETURNING event_id
                 """,
@@ -2309,13 +2321,122 @@ class Database:
                     event["id"], event["operationId"], event["providerId"],
                     map_package_id, event.get("region"), event["eventType"],
                     event["outcome"], event["timestamp"], event.get("appBuild"),
+                    event["releaseLabel"], is_local_release_label(event.get("releaseLabel")),
                 ),
             ).fetchone()
         return row is not None
 
+    def local_test_telemetry_summary(self) -> dict[str, Any]:
+        """Return only purgeable local-test telemetry for the admin screen."""
+        with self.connection() as connection:
+            diagnostics = connection.execute(
+                """
+                SELECT count(*) AS event_count,
+                       count(DISTINCT operation_id) AS operation_count,
+                       COALESCE(array_agg(DISTINCT release_label ORDER BY release_label)
+                           FILTER (WHERE release_label IS NOT NULL), ARRAY[]::text[]) AS labels
+                FROM compatibility_evidence_event
+                WHERE is_local_test IS TRUE
+                """
+            ).fetchone() or {}
+            maps = connection.execute(
+                """
+                SELECT count(*) AS event_count,
+                       count(DISTINCT operation_id) AS operation_count,
+                       COALESCE(array_agg(DISTINCT release_label ORDER BY release_label)
+                           FILTER (WHERE release_label IS NOT NULL), ARRAY[]::text[]) AS labels
+                FROM map_download_event
+                WHERE is_local_test IS TRUE
+                """
+            ).fetchone() or {}
+            operations = connection.execute(
+                """
+                SELECT count(*) AS operation_count
+                FROM (
+                    SELECT operation_id
+                    FROM compatibility_evidence_event
+                    WHERE is_local_test IS TRUE
+                      AND operation_id IS NOT NULL
+                    UNION
+                    SELECT operation_id
+                    FROM map_download_event
+                    WHERE is_local_test IS TRUE
+                      AND operation_id IS NOT NULL
+                ) local_operations
+                """
+            ).fetchone() or {}
+        labels = sorted(set(diagnostics.get("labels") or []) | set(maps.get("labels") or []))
+        return {
+            "diagnosticEventCount": int(diagnostics.get("event_count") or 0),
+            "mapEventCount": int(maps.get("event_count") or 0),
+            "operationCount": int(operations.get("operation_count") or 0),
+            "releaseLabels": labels,
+        }
+
+    def purge_local_test_telemetry(
+        self,
+        *,
+        admin_user_id: int | None,
+        request_id: str | None = None,
+    ) -> dict[str, int]:
+        """Atomically delete only server-classified local test events.
+
+        The shared operation UUID is intentionally not used as the delete
+        predicate: ``is_local_test`` is the immutable server-side boundary,
+        so a malformed client can never cause production rows to be removed.
+        """
+        with self.connection() as connection:
+            operation_row = connection.execute(
+                """
+                SELECT count(DISTINCT operation_id) AS operation_count
+                FROM (
+                    SELECT operation_id FROM compatibility_evidence_event
+                    WHERE is_local_test IS TRUE
+                    UNION
+                    SELECT operation_id FROM map_download_event
+                    WHERE is_local_test IS TRUE
+                ) AS local_operations
+                """
+            ).fetchone() or {}
+            diagnostic_row = connection.execute(
+                """
+                WITH deleted AS (
+                    DELETE FROM compatibility_evidence_event
+                    WHERE is_local_test IS TRUE
+                    RETURNING event_id
+                )
+                SELECT count(*) AS event_count FROM deleted
+                """
+            ).fetchone() or {}
+            map_row = connection.execute(
+                """
+                WITH deleted AS (
+                    DELETE FROM map_download_event
+                    WHERE is_local_test IS TRUE
+                    RETURNING event_id
+                )
+                SELECT count(*) AS event_count FROM deleted
+                """
+            ).fetchone() or {}
+            counts = {
+                "diagnosticEventCount": int(diagnostic_row.get("event_count") or 0),
+                "mapEventCount": int(map_row.get("event_count") or 0),
+                "operationCount": int(operation_row.get("operation_count") or 0),
+            }
+            self._insert_admin_audit(
+                connection,
+                admin_user_id=admin_user_id,
+                action="telemetry.local_test_purged",
+                target="local-test-telemetry",
+                request_id=request_id,
+                reason="Authenticated admin purge of server-classified local telemetry",
+                details=counts,
+            )
+        return counts
+
     @staticmethod
     def _map_statistics_filter(filters: dict[str, Any], alias: str = "e") -> tuple[list[str], list[Any]]:
-        clauses = ["1 = 1"]
+        clauses = [f"{alias}.is_local_test IS NOT TRUE"]
         values: list[Any] = []
         if filters.get("provider"):
             clauses.append(f"{alias}.provider_id = %s")
@@ -2408,6 +2529,7 @@ class Database:
                         AS operation_succeeded
                 FROM compatibility_evidence_event AS e
                 WHERE e.operation_id IS NOT NULL
+                  AND e.is_local_test IS NOT TRUE
                 GROUP BY e.operation_id
             ), linked_operations AS (
                 SELECT
@@ -2787,6 +2909,7 @@ class Database:
                         min(e.received_at) AS received_at
                     FROM compatibility_evidence_event AS e
                     WHERE e.canonical_device_model_id = dm.id
+                      AND e.is_local_test IS NOT TRUE
                     GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
                 ) AS o
                 CROSS JOIN compatibility_device_card_failure_epoch AS epoch

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -26,6 +26,7 @@ from .admin import (
     diagnostics_page,
     devices_page,
     map_statistics_page,
+    local_test_data_page,
     overview_page,
     provider_detail_page,
     providers_page,
@@ -106,6 +107,8 @@ class CatalogService:
         admin_session_ttl_seconds: int = 28_800,
         public_compatibility_stats_enabled: bool = False,
         operations_ingest_secret: str | None = None,
+        opentopomap_contour_mode: str = "off",
+        opentopomap_contour_allowlist: tuple[str, ...] = (),
     ) -> None:
         self.database = database
         self.asset_storage = asset_storage
@@ -113,6 +116,8 @@ class CatalogService:
         self.admin_session_ttl_seconds = admin_session_ttl_seconds
         self.public_compatibility_stats_enabled = public_compatibility_stats_enabled
         self.operations_ingest_secret = operations_ingest_secret
+        self.opentopomap_contour_mode = opentopomap_contour_mode
+        self.opentopomap_contour_allowlist = frozenset(opentopomap_contour_allowlist)
 
     def health(self) -> bool:
         self.database.prune_compatibility_events()
@@ -160,7 +165,14 @@ class CatalogService:
 
     def catalog_response(self) -> tuple[bytes, str, datetime]:
         rows, updated_at = self.database.catalog_snapshot()
-        body = serialize_catalog(build_catalog(rows, updated_at))
+        body = serialize_catalog(
+            build_catalog(
+                rows,
+                updated_at,
+                contour_mode=self.opentopomap_contour_mode,
+                contour_allowlist=self.opentopomap_contour_allowlist,
+            )
+        )
         return body, catalog_etag(body), updated_at
 
     def device_catalog_response(self) -> tuple[bytes, str, datetime]:
@@ -579,6 +591,17 @@ class CatalogService:
 
     def admin_review_summary(self) -> dict[str, int]:
         return self.database.admin_review_summary()
+
+    def local_test_data(self) -> dict[str, Any]:
+        return self.database.local_test_telemetry_summary()
+
+    def purge_local_test_data(
+        self, *, admin_user_id: int | None, request_id: str | None = None,
+    ) -> dict[str, int]:
+        return self.database.purge_local_test_telemetry(
+            admin_user_id=admin_user_id,
+            request_id=request_id,
+        )
 
     def admin_is_configured(self) -> bool:
         return self.database.admin_user_count() > 0
@@ -1050,6 +1073,30 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
                     "readyToPublish": 0,
                     "total": 0,
                 }}
+            if request_path in {"/admin/test-data", "/admin/test-data/"}:
+                query = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
+                try:
+                    body = local_test_data_page(
+                        service.local_test_data(),
+                        session,
+                        csrf_token,
+                        success=(
+                            "Local test telemetry deleted."
+                            if query.get("purged", [""])[-1] == "1" else None
+                        ),
+                    )
+                except Exception:
+                    LOGGER.exception("admin local test data page failed")
+                    self._send_json(
+                        HTTPStatus.SERVICE_UNAVAILABLE,
+                        {"error": "local_test_data_unavailable"},
+                        send_body=send_body,
+                        cache_control="no-store",
+                        noindex=True,
+                    )
+                    return
+                self._send_admin_html(body, send_body=send_body)
+                return
             if request_path in {"/admin/providers", "/admin/providers/"}:
                 try:
                     body = providers_page(service.admin_providers(), session, csrf_token)
@@ -1467,6 +1514,31 @@ def make_handler(service: CatalogService) -> type[BaseHTTPRequestHandler]:
             if request_path == "/admin/logout":
                 service.logout_admin(session_token)
                 self._redirect("/admin/login", send_body=True, clear_cookie=True)
+                return
+            if request_path == "/admin/test-data/purge":
+                if form.get("confirmation", "") != "DELETE_LOCAL_TEST_DATA":
+                    try:
+                        body = local_test_data_page(
+                            service.local_test_data(),
+                            session,
+                            self._csrf_cookie() or "",
+                            error="Type DELETE_LOCAL_TEST_DATA exactly to confirm the purge.",
+                        )
+                        self._send_admin_html(body, send_body=True, status=HTTPStatus.BAD_REQUEST)
+                    except Exception:
+                        LOGGER.exception("admin local test data validation failed")
+                        self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid_purge_confirmation"}, send_body=True, cache_control="no-store")
+                    return
+                try:
+                    service.purge_local_test_data(
+                        admin_user_id=int(session["id"]),
+                        request_id=self._request_id(),
+                    )
+                except Exception:
+                    LOGGER.exception("admin local test data purge failed")
+                    self._send_json(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "local_test_data_purge_unavailable"}, send_body=True, cache_control="no-store")
+                    return
+                self._redirect("/admin/test-data?purged=1", send_body=True)
                 return
             if request_path == "/admin/account":
                 try:

--- a/backend/catalog-api/src/terento_catalog/map_events.py
+++ b/backend/catalog-api/src/terento_catalog/map_events.py
@@ -8,6 +8,8 @@ import re
 from typing import Any
 from uuid import UUID
 
+from .telemetry import validate_release_label
+
 
 MAX_EVENT_BYTES = 8 * 1024
 ALLOWED_EVENT_KEYS = {
@@ -21,6 +23,7 @@ ALLOWED_EVENT_KEYS = {
     "eventType",
     "outcome",
     "appBuild",
+    "releaseLabel",
 }
 ALLOWED_EVENT_TYPES = {
     "DOWNLOAD_STARTED",
@@ -48,7 +51,7 @@ def validate_map_event(raw: bytes) -> dict[str, Any]:
         raise MapEventValidationError("unknown_fields")
     required = {
         "schemaVersion", "id", "operationId", "timestamp", "providerId",
-        "eventType", "outcome",
+        "eventType", "outcome", "releaseLabel",
     }
     if required - set(event):
         raise MapEventValidationError("missing_fields")
@@ -73,6 +76,10 @@ def validate_map_event(raw: bytes) -> dict[str, Any]:
             not isinstance(value, str) or not value.strip() or len(value) > 80
         ):
             raise MapEventValidationError(f"invalid_{key}")
+    try:
+        event["releaseLabel"] = validate_release_label(event["releaseLabel"])
+    except ValueError as exc:
+        raise MapEventValidationError("invalid_releaseLabel") from exc
     if not isinstance(event["eventType"], str) or event["eventType"] not in ALLOWED_EVENT_TYPES:
         raise MapEventValidationError("invalid_event_type")
     if not isinstance(event["outcome"], str) or event["outcome"] not in ALLOWED_OUTCOMES:

--- a/backend/catalog-api/src/terento_catalog/migrations/035_local_test_telemetry.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/035_local_test_telemetry.sql
@@ -1,0 +1,142 @@
+-- Keep local/debug telemetry separate from production compatibility and map
+-- statistics, while allowing an authenticated operator to purge it.
+ALTER TABLE map_download_event
+    ADD COLUMN release_label TEXT;
+
+ALTER TABLE map_download_event
+    ADD COLUMN is_local_test BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE compatibility_evidence_event
+    ADD COLUMN is_local_test BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE map_download_event
+SET is_local_test = TRUE
+WHERE release_label ~ '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9A-Za-z.][0-9A-Za-z.-]*-)?local$';
+
+UPDATE compatibility_evidence_event
+SET is_local_test = TRUE
+WHERE release_label ~ '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-([0-9A-Za-z.][0-9A-Za-z.-]*-)?local$';
+
+CREATE INDEX compatibility_evidence_event_local_test_idx
+    ON compatibility_evidence_event (is_local_test, occurred_at);
+
+CREATE INDEX map_download_event_local_test_idx
+    ON map_download_event (is_local_test, occurred_at);
+
+CREATE OR REPLACE VIEW compatibility_model_statistics AS
+WITH normalized_events AS (
+    SELECT
+        e.*,
+        COALESCE(e.canonical_device_model_id, 'identity:' || e.compatibility_identity) AS aggregate_key,
+        COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text) AS operation_key,
+        COALESCE(e.write_started, true) AS compatibility_write_started
+    FROM compatibility_evidence_event e
+    WHERE e.diagnostic_status = 'ACTIVE'
+      AND e.is_local_test IS NOT TRUE
+),
+operation_stats AS (
+    SELECT
+        e.aggregate_key,
+        e.operation_key,
+        min(e.compatibility_identity) AS compatibility_identity,
+        min(e.model) AS model,
+        min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
+        min(e.case_size_mm) FILTER (WHERE e.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(e.display_type) FILTER (WHERE e.display_type IS NOT NULL AND btrim(e.display_type) <> '') AS display_type,
+        min(e.canonical_device_model_id) FILTER (WHERE e.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        bool_or(e.compatibility_write_started) AS write_started,
+        bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED')
+            AND count(*) = max(COALESCE(e.selected_map_count, 1)) AS operation_succeeded,
+        bool_or(e.reconnect_verified) AS reconnect_verified,
+        min(NULLIF(e.firmware_version, '')) AS successful_firmware_version,
+        min(e.occurred_at) AS occurred_at,
+        count(*) AS map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS successful_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'NOT_STARTED') AS not_started_map_result_count
+    FROM normalized_events e
+    GROUP BY e.aggregate_key, e.operation_key
+),
+event_stats AS (
+    SELECT
+        o.aggregate_key,
+        min(o.compatibility_identity) AS compatibility_identity,
+        min(o.model) AS model,
+        min(o.variant) FILTER (WHERE o.variant IS NOT NULL) AS variant,
+        min(o.case_size_mm) FILTER (WHERE o.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(o.display_type) FILTER (WHERE o.display_type IS NOT NULL) AS display_type,
+        min(o.canonical_device_model_id) FILTER (WHERE o.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        string_agg(DISTINCT COALESCE(o.successful_firmware_version, 'unknown'), ', ' ORDER BY COALESCE(o.successful_firmware_version, 'unknown')) AS firmware_versions,
+        count(*) FILTER (WHERE o.write_started) AS attempted_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded) AS successful_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded AND o.reconnect_verified) AS reconnect_verified_install_count,
+        count(*) FILTER (WHERE o.write_started AND NOT o.operation_succeeded) AS failed_install_count,
+        count(DISTINCT o.successful_firmware_version) FILTER (WHERE o.write_started AND o.operation_succeeded) AS firmware_version_count,
+        round(100.0 * count(*) FILTER (WHERE o.write_started AND o.operation_succeeded)
+            / NULLIF(count(*) FILTER (WHERE o.write_started), 0), 1) AS success_rate,
+        max(o.occurred_at) FILTER (WHERE o.write_started AND o.operation_succeeded) AS last_success,
+        max(o.occurred_at) FILTER (WHERE NOT o.operation_succeeded) AS last_failure,
+        max(o.occurred_at) AS last_evidence,
+        sum(o.map_result_count) AS map_result_count,
+        sum(o.successful_map_result_count) AS successful_map_result_count,
+        sum(o.failed_map_result_count) AS failed_map_result_count,
+        sum(o.not_started_map_result_count) AS not_started_map_result_count,
+        count(*) FILTER (WHERE NOT o.write_started) AS prewrite_failure_count
+    FROM operation_stats o
+    GROUP BY o.aggregate_key
+),
+error_stats AS (
+    SELECT
+        e.aggregate_key,
+        jsonb_object_agg(e.error_key, e.error_count) AS error_categories
+    FROM (
+        SELECT
+            n.aggregate_key,
+            COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown') AS error_key,
+            count(*) AS error_count
+        FROM normalized_events n
+        WHERE n.phase_outcome = 'FAILED'
+        GROUP BY n.aggregate_key, COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown')
+    ) e
+    GROUP BY e.aggregate_key
+)
+SELECT
+    COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
+    e.model, e.variant, e.case_size_mm, e.display_type, e.canonical_device_model_id,
+    e.firmware_versions, e.attempted_install_count, e.successful_install_count,
+    e.reconnect_verified_install_count, e.failed_install_count, e.firmware_version_count,
+    e.success_rate, e.last_success, e.last_failure, e.last_evidence,
+    e.map_result_count, e.successful_map_result_count, e.failed_map_result_count,
+    e.not_started_map_result_count, e.prewrite_failure_count,
+    COALESCE(errors.error_categories, '{}'::jsonb) AS error_categories,
+    terento_compatibility_status(e.successful_install_count, dm.map_capable IS TRUE) AS calculated_status,
+    (dm.map_capable IS TRUE) AS recognized_map_capable_evidence,
+    COALESCE(r.physical_device_evidence_count, 0) AS physical_device_evidence_count,
+    COALESCE(r.review_notes, '') AS review_notes,
+    COALESCE(r.review_status, 'PENDING') AS review_status,
+    COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
+    COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
+FROM event_stats e
+LEFT JOIN error_stats errors ON errors.aggregate_key = e.aggregate_key
+LEFT JOIN device_model dm ON dm.id = e.canonical_device_model_id
+LEFT JOIN LATERAL (
+    SELECT review.*
+    FROM compatibility_model_review review
+    WHERE COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity
+       OR (
+            e.canonical_device_model_id IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM compatibility_evidence_event linked_event
+                WHERE linked_event.canonical_device_model_id = e.canonical_device_model_id
+                  AND linked_event.compatibility_identity = COALESCE(NULLIF(review.identity_key, ''), review.model)
+                  AND linked_event.is_local_test IS NOT TRUE
+            )
+       )
+    ORDER BY
+        (COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity) DESC,
+        (review.review_status = 'APPROVED') DESC,
+        review.updated_at DESC
+    LIMIT 1
+) r ON true;
+

--- a/backend/catalog-api/src/terento_catalog/opentopomap_contour_audit.py
+++ b/backend/catalog-api/src/terento_catalog/opentopomap_contour_audit.py
@@ -1,0 +1,249 @@
+"""Fail-closed OpenTopoMap contour source audit.
+
+The audit is intentionally separate from the public collector. It may inspect
+every contour link and record shadow health, but it never changes the public
+catalog mode and never stores provider binaries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
+from pathlib import Path
+import tempfile
+from typing import Any
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+import zipfile
+
+from .collectors.freizeitkarte.range_zip import ZipRangeError
+from .provider_catalog import (
+    OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT,
+    OPENTOPO_MAP,
+    OpenTopoMapFetcher,
+    OpenTopoMapLink,
+    parse_opentopomap_catalog,
+)
+
+
+@dataclass(frozen=True)
+class ContourPayloadCheck:
+    region: str
+    source_url: str
+    payload_path: str | None
+    download_size_bytes: int | None
+    install_size_bytes: int | None
+    status: str
+    reason: str | None = None
+    header_identity: str | None = None
+
+
+@dataclass(frozen=True)
+class OpenTopoMapContourAuditReport:
+    schema_version: int
+    source_url: str
+    main_package_count: int
+    expected_main_package_count: int
+    unique_contour_source_count: int
+    package_to_contour_attachment_count: int
+    validated_contours: int
+    missing_contours: int
+    unavailable_contours: int
+    rejected_contours: int
+    shared_contour_sources: int
+    unknown_install_sizes: int
+    duplicate_identities: int
+    payload_path_patterns: tuple[str, ...]
+    minimum_install_size_bytes: int | None
+    maximum_install_size_bytes: int | None
+    sample_region: str | None
+    sample_status: str
+    sample_reason: str | None
+    contours: tuple[ContourPayloadCheck, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def audit_opentopomap_contours(
+    *,
+    fetcher: OpenTopoMapFetcher | None = None,
+    expected_main_package_count: int = OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT,
+    sample_region: str | None = None,
+    max_workers: int = 8,
+) -> OpenTopoMapContourAuditReport:
+    fetcher = fetcher or OpenTopoMapFetcher()
+    html = fetcher.fetch_text(OPENTOPO_MAP.catalog_url)
+    links = parse_opentopomap_catalog(html, OPENTOPO_MAP.catalog_url)
+    main_links = [link for link in links if link.kind == "main"]
+    contour_links = [link for link in links if link.kind == "contours"]
+
+    if len(main_links) != expected_main_package_count:
+        raise RuntimeError(
+            "OpenTopoMap main catalog count changed: "
+            f"expected {expected_main_package_count}, found {len(main_links)}"
+        )
+
+    duplicate_identities = len(contour_links) - len({
+        (link.provider_region_id, link.source_url) for link in contour_links
+    })
+    source_counts: dict[str, int] = {}
+    for link in contour_links:
+        source_counts[link.source_url] = source_counts.get(link.source_url, 0) + 1
+
+    def inspect(link: OpenTopoMapLink) -> ContourPayloadCheck:
+        try:
+            measurement = fetcher.measure_zip(link.source_url)
+            install_size = measurement.install_size_bytes
+            status = "VALIDATED" if install_size is not None and install_size > 0 else "UNKNOWN_SIZE"
+            return ContourPayloadCheck(
+                region=link.provider_region_id,
+                source_url=link.source_url,
+                payload_path=measurement.payload_path,
+                download_size_bytes=measurement.download_size_bytes,
+                install_size_bytes=install_size,
+                status=status,
+                reason=None if status == "VALIDATED" else "exact install size unavailable",
+            )
+        except (OSError, ValueError, ZipRangeError) as exc:
+            return ContourPayloadCheck(
+                region=link.provider_region_id,
+                source_url=link.source_url,
+                payload_path=None,
+                download_size_bytes=None,
+                install_size_bytes=None,
+                status="UNAVAILABLE",
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+
+    checks_by_url: dict[str, ContourPayloadCheck] = {}
+    with ThreadPoolExecutor(max_workers=max(1, min(max_workers, 16))) as executor:
+        pending = {
+            executor.submit(inspect, link): link.source_url
+            for link in contour_links
+        }
+        for future in as_completed(pending):
+            check = future.result()
+            checks_by_url.setdefault(check.source_url, check)
+    checks = [
+        checks_by_url[link.source_url]
+        for link in contour_links
+        if link.source_url in checks_by_url
+    ]
+
+    sample_check = _sample_contour_payload(contour_links, sample_region)
+    sizes = [item.install_size_bytes for item in checks if item.install_size_bytes]
+    payload_paths = tuple(sorted({item.payload_path for item in checks if item.payload_path}))
+    return OpenTopoMapContourAuditReport(
+        schema_version=1,
+        source_url=OPENTOPO_MAP.catalog_url,
+        main_package_count=len(main_links),
+        expected_main_package_count=expected_main_package_count,
+        unique_contour_source_count=len(source_counts),
+        package_to_contour_attachment_count=len(contour_links),
+        validated_contours=sum(item.status == "VALIDATED" for item in checks),
+        missing_contours=len(main_links) - len({item.region for item in contour_links}),
+        unavailable_contours=sum(item.status == "UNAVAILABLE" for item in checks),
+        rejected_contours=sum(item.status == "REJECTED" for item in checks),
+        shared_contour_sources=sum(count > 1 for count in source_counts.values()),
+        unknown_install_sizes=sum(item.status == "UNKNOWN_SIZE" for item in checks),
+        duplicate_identities=max(0, duplicate_identities),
+        payload_path_patterns=payload_paths,
+        minimum_install_size_bytes=min(sizes) if sizes else None,
+        maximum_install_size_bytes=max(sizes) if sizes else None,
+        sample_region=sample_region,
+        sample_status=sample_check[0],
+        sample_reason=sample_check[1],
+        contours=tuple(checks),
+    )
+
+
+def _sample_contour_payload(
+    links: list[OpenTopoMapLink],
+    requested_region: str | None,
+) -> tuple[str, str | None]:
+    if not requested_region:
+        return "NOT_REQUESTED", None
+    normalized = requested_region.strip().casefold()
+    link = next(
+        (item for item in links if item.provider_region_id.casefold() == normalized),
+        None,
+    )
+    if link is None:
+        return "REJECTED", "requested sample region has no contour source"
+
+    parsed = urlparse(link.source_url)
+    if parsed.scheme != "https" or parsed.hostname != "garmin.opentopomap.org":
+        return "REJECTED", "sample source is outside the reviewed OpenTopoMap host"
+
+    try:
+        request = Request(
+            link.source_url,
+            headers={"User-Agent": OpenTopoMapFetcher.user_agent},
+        )
+        with urlopen(request, timeout=60) as response:
+            final_url = response.geturl()
+            if urlparse(final_url).hostname != parsed.hostname:
+                return "REJECTED", "sample download redirected to another host"
+            with tempfile.TemporaryDirectory(prefix="terento-otm-contour-sample-") as directory:
+                archive = Path(directory) / "sample.zip"
+                with archive.open("wb") as output:
+                    total = 0
+                    while True:
+                        chunk = response.read(1024 * 1024)
+                        if not chunk:
+                            break
+                        total += len(chunk)
+                        if total > 512 * 1024 * 1024:
+                            return "REJECTED", "sample archive exceeded bounded audit size"
+                        output.write(chunk)
+                with zipfile.ZipFile(archive) as package:
+                    names = [
+                        name for name in package.namelist()
+                        if not name.endswith("/") and name.casefold().endswith(".img")
+                    ]
+                    if len(names) != 1:
+                        return "REJECTED", "sample contour ZIP does not have one IMG payload"
+                    payload = package.open(names[0])
+                    header = payload.read(4096)
+                    if header[0x10:0x16] != b"DSKIMG" or header[0x41:0x47] != b"GARMIN":
+                        return "REJECTED", "sample payload is not a Garmin IMG"
+                    printable = "".join(
+                        chr(byte) if 32 <= byte <= 126 else " "
+                        for byte in header
+                    ).casefold()
+                    normalized_header = "".join(
+                        character for character in printable if character.isalnum()
+                    )
+                    normalized_region = "".join(
+                        character
+                        for character in link.provider_region_id.casefold()
+                        if character.isalnum()
+                    )
+                    if "opentopomap" not in normalized_header:
+                        return "REJECTED", "sample IMG does not identify OpenTopoMap"
+                    if normalized_region not in normalized_header:
+                        return "REJECTED", "sample IMG does not identify the selected region"
+                    return "VALIDATED", f"OpenTopoMap:{link.provider_region_id}:{names[0]}"
+    except (OSError, ValueError, zipfile.BadZipFile, zipfile.LargeZipFile) as exc:
+        return "UNAVAILABLE", f"{type(exc).__name__}: {exc}"
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Audit OpenTopoMap contour metadata")
+    parser.add_argument("--sample-region", default="andorra")
+    parser.add_argument("--expected-main-count", type=int, default=OPENTOPO_MAP_BETA8_MAIN_PACKAGE_COUNT)
+    args = parser.parse_args()
+    report = audit_opentopomap_contours(
+        expected_main_package_count=args.expected_main_count,
+        sample_region=args.sample_region,
+    )
+    print(json.dumps(report.as_dict(), indent=2, sort_keys=True, default=str))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/backend/catalog-api/src/terento_catalog/provider_catalog.py
+++ b/backend/catalog-api/src/terento_catalog/provider_catalog.py
@@ -208,16 +208,19 @@ def snapshot_from_freizeitkarte_records(
 class OpenTopoMapFetcher:
     user_agent = "TerentoCatalog/0.1 (+https://terento.app)"
 
+    def __init__(self, *, timeout_seconds: int = 30) -> None:
+        self.timeout_seconds = max(1, timeout_seconds)
+
     def fetch_text(self, url: str) -> str:
         request = Request(url, headers={"User-Agent": self.user_agent})
         with urlopen(request, timeout=30) as response:
             return response.read().decode("utf-8", errors="replace")
 
     def head_size(self, url: str) -> int | None:
-        return HTTPRangeFetcher(timeout_seconds=30).head_size(url)
+        return HTTPRangeFetcher(timeout_seconds=self.timeout_seconds).head_size(url)
 
     def measure_zip(self, url: str) -> Any:
-        fetcher = HTTPRangeFetcher(timeout_seconds=30)
+        fetcher = HTTPRangeFetcher(timeout_seconds=self.timeout_seconds)
         return ZipRangeInspector(fetcher).inspect(url, expected_payload_path=None)
 
 

--- a/backend/catalog-api/src/terento_catalog/telemetry.py
+++ b/backend/catalog-api/src/terento_catalog/telemetry.py
@@ -1,0 +1,44 @@
+"""Shared validation and classification for privacy-minimised telemetry."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+# SemVer 2.0-compatible release identity.  Labels are deliberately bounded by
+# the event validators as well, so this helper only answers format/classification.
+SEMVER_RELEASE_LABEL = re.compile(
+    r"^(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)\."
+    r"(0|[1-9][0-9]*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+
+
+def validate_release_label(value: Any) -> str:
+    """Return a safe release label or raise the public event error."""
+
+    if (
+        not isinstance(value, str)
+        or value != value.strip()
+        or not value
+        or len(value) > 80
+        or "/Users/" in value
+        or "file://" in value
+        or SEMVER_RELEASE_LABEL.fullmatch(value) is None
+    ):
+        raise ValueError("invalid_releaseLabel")
+    return value
+
+
+def is_local_release_label(value: Any) -> bool:
+    """Classify only a valid SemVer label with the exact ``-local`` suffix."""
+
+    return (
+        isinstance(value, str)
+        and SEMVER_RELEASE_LABEL.fullmatch(value) is not None
+        and value.endswith("-local")
+    )
+

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -16,6 +16,8 @@ from terento_catalog.map_events import (
     validate_map_event,
     validate_statistics_filters,
 )
+from terento_catalog.opentopomap_contour_audit import audit_opentopomap_contours
+from terento_catalog.telemetry import is_local_release_label
 from terento_catalog.provider_catalog import (
     OPENTOPO_MAP,
     OpenTopoMapProviderAdapter,
@@ -39,6 +41,7 @@ class FakeProviderDatabase:
         self.run_overrides: dict[str, list[dict]] = {}
         self.map_statistic_filters: list[dict] = []
         self.overview_map_requests: list[tuple[datetime, str, str]] = []
+        self.local_purge_calls: list[dict] = []
 
     def admin_user_count(self) -> int:
         return 1
@@ -50,6 +53,18 @@ class FakeProviderDatabase:
             "readyToPublish": 0,
             "total": 0,
         }
+
+    def local_test_telemetry_summary(self):
+        return {
+            "diagnosticEventCount": 2,
+            "mapEventCount": 3,
+            "operationCount": 1,
+            "releaseLabels": ["1.0.0-beta.10-local"],
+        }
+
+    def purge_local_test_telemetry(self, **kwargs):
+        self.local_purge_calls.append(kwargs)
+        return {"diagnosticEventCount": 2, "mapEventCount": 3, "operationCount": 1}
 
     def admin_overview_snapshot(self, since):
         return {
@@ -307,6 +322,74 @@ class Beta8APITests(unittest.TestCase):
         self.assertEqual(artifact["downloadSizeBytes"], 219000000)
         self.assertEqual(artifact["validationState"], "validated")
 
+    def test_contour_rollout_modes_are_fail_closed_at_public_catalog_boundary(self):
+        common = {
+            "provider_id": "opentopomap",
+            "provider_name": "OpenTopoMap",
+            "provider_adapter_id": "opentopomap",
+            "provider_status": "PAUSED",
+            "provider_health": "UNKNOWN",
+            "provider_website": "https://opentopomap.org/",
+            "provider_attribution": "OpenTopoMap",
+            "provider_license_information": "ODbL",
+            "package_id": "opentopomap-andorra",
+            "provider_region_id": "andorra",
+            "canonical_region_id": "ANDORRA",
+            "package_name": "OpenTopoMap Andorra",
+            "package_region": "ANDORRA",
+            "package_country": "Andorra",
+            "release": "2026-05",
+            "release_id": "2026-05",
+            "version_label": "2026-05",
+            "country_codes": [],
+            "region_kind": "country",
+            "capabilities": ["main", "contours"],
+            "artifact_source_url": "https://garmin.opentopomap.org/europe/andorra/otm-andorra.zip",
+            "artifact_size_bytes": 100,
+            "artifact_install_size_bytes": 120,
+            "artifact_required": True,
+            "artifact_validation_status": "VALIDATED",
+        }
+        rows = [
+            {**common, "artifact_id": "opentopomap-andorra-main", "artifact_kind": "main"},
+            {
+                **common,
+                "artifact_id": "opentopomap-andorra-contours",
+                "artifact_kind": "contours",
+                "artifact_source_url": "https://garmin.opentopomap.org/europe/andorra/otm-andorra-contours.zip",
+                "artifact_required": False,
+            },
+        ]
+        timestamp = datetime(2026, 8, 31, tzinfo=UTC)
+        for mode, allowlist, expected in (
+            ("off", set(), 1),
+            ("shadow", set(), 1),
+            ("allowlist", {"opentopomap-andorra"}, 2),
+            ("public", set(), 2),
+        ):
+            document = build_catalog(
+                rows,
+                timestamp,
+                contour_mode=mode,
+                contour_allowlist=allowlist,
+            )
+            self.assertEqual(len(document["providers"][0]["maps"][0]["artifacts"]), expected)
+
+    def test_phase3_allowlist_fixture_is_internal_only_and_reviewed(self):
+        fixture_path = (
+            Path(__file__).parents[1]
+            / "reports"
+            / "opentopomap-contour-allowlist-2026-09-06.json"
+        )
+        fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        self.assertEqual(fixture["status"], "INTERNAL_RC_ONLY")
+        self.assertFalse(fixture["publicActivation"])
+        self.assertEqual(
+            fixture["packageIds"],
+            ["opentopomap-andorra", "opentopomap-lithuania"],
+        )
+        self.assertEqual(fixture["hardwareGate"], "HARDWARE_GATE_A")
+
         unknown_install = build_catalog([
             {
                     "provider_id": "freizeitkarte",
@@ -437,6 +520,7 @@ class Beta8APITests(unittest.TestCase):
             "eventType": "INSTALL_SUCCEEDED",
             "outcome": "SUCCEEDED",
             "appBuild": "beta.8",
+            "releaseLabel": "1.0.0-beta.8",
         }).encode())
         self.assertEqual(event["providerId"], "freizeitkarte")
         self.assertEqual(event["mapId"], "fzk-ltu")
@@ -453,6 +537,7 @@ class Beta8APITests(unittest.TestCase):
             "providerId": "freizeitkarte",
             "eventType": "DOWNLOAD_STARTED",
             "outcome": "UNKNOWN",
+            "releaseLabel": "1.0.0-beta.8",
             "unitId": "must-not-be-accepted",
         }
         with self.assertRaises(MapEventValidationError):
@@ -470,6 +555,24 @@ class Beta8APITests(unittest.TestCase):
             validate_map_event(json.dumps(custom_payload).encode())
         with self.assertRaises(MapEventValidationError):
             validate_statistics_filters({"region": "LT", "dateFrom": "2026-09-01T00:00:00Z", "dateTo": "2026-08-31T00:00:00Z"})
+
+    def test_release_label_is_strict_and_local_classification_is_exact(self):
+        base = {
+            "schemaVersion": 1,
+            "id": "a8098c1a-f86e-11da-bd1a-00112444be1e",
+            "operationId": "b8098c1a-f86e-11da-bd1a-00112444be1e",
+            "timestamp": "2026-08-31T10:00:00Z",
+            "providerId": "freizeitkarte",
+            "eventType": "DOWNLOAD_STARTED",
+            "outcome": "UNKNOWN",
+        }
+        accepted = validate_map_event(json.dumps({**base, "releaseLabel": "1.0.0"}).encode())
+        self.assertFalse(is_local_release_label(accepted["releaseLabel"]))
+        local = validate_map_event(json.dumps({**base, "releaseLabel": "1.0.0-beta.10-local"}).encode())
+        self.assertTrue(is_local_release_label(local["releaseLabel"]))
+        for label in (None, "", "development", "1.0", "1.0.0-local ", "v1.0.0"):
+            with self.subTest(label=label), self.assertRaises(MapEventValidationError):
+                validate_map_event(json.dumps({**base, "releaseLabel": label}).encode())
 
     def test_opentopomap_parser_accepts_only_provider_zip_sources(self):
         html = """
@@ -587,6 +690,47 @@ class Beta8APITests(unittest.TestCase):
             OpenTopoMapProviderAdapter(
                 fetcher=Fetcher(), expected_main_package_count=2
             ).collect()
+
+    def test_opentopomap_contour_audit_is_shadow_only_and_counts_shared_sources(self):
+        html = """
+        <table>
+          <tr class="country"><td>Andorra</td>
+            <td><a href="europe/andorra/otm-andorra.zip">Garmin</a></td>
+            <td><a href="europe/andorra/otm-andorra-contours.zip">Contours</a></td>
+          </tr>
+          <tr class="country"><td>Canada East</td>
+            <td><a href="north-america/canada-east/otm-canada-east.zip">Garmin</a></td>
+            <td><a href="north-america/canada/otm-canada-contours.zip">Contours</a></td>
+          </tr>
+          <tr class="country"><td>Canada West</td>
+            <td><a href="north-america/canada-west/otm-canada-west.zip">Garmin</a></td>
+          </tr>
+        </table>
+        """
+
+        class Measurement:
+            download_size_bytes = 100
+            install_size_bytes = 120
+            payload_path = "gmapsupp.img"
+
+        class Fetcher:
+            def fetch_text(self, url):
+                return html
+
+            def measure_zip(self, url):
+                return Measurement()
+
+        report = audit_opentopomap_contours(
+            fetcher=Fetcher(),
+            expected_main_package_count=3,
+            sample_region=None,
+        )
+        self.assertEqual(report.main_package_count, 3)
+        self.assertEqual(report.unique_contour_source_count, 2)
+        self.assertEqual(report.package_to_contour_attachment_count, 3)
+        self.assertEqual(report.shared_contour_sources, 1)
+        self.assertEqual(report.validated_contours, 3)
+        self.assertEqual(report.sample_status, "NOT_REQUESTED")
 
     def test_opentopomap_russia_packages_emit_policy_country_code(self):
         html = """
@@ -709,6 +853,29 @@ class Beta8APITests(unittest.TestCase):
             self.assertEqual(json.loads(body)["providers"][0]["id"], "freizeitkarte")
             self.assertEqual(response.headers["X-Robots-Tag"], "noindex, nofollow")
 
+            test_data, test_data_body = self._request(
+                server, "GET", "/admin/test-data", headers={"Cookie": cookie}
+            )
+            self.assertEqual(test_data.status, 200)
+            self.assertIn(b"1.0.0-beta.10-local", test_data_body)
+            invalid_purge, _ = self._request(
+                server,
+                "POST",
+                "/admin/test-data/purge",
+                b"csrf_token=csrf&confirmation=wrong",
+                {"Content-Type": "application/x-www-form-urlencoded", "Cookie": cookie},
+            )
+            self.assertEqual(invalid_purge.status, 400)
+            purge, _ = self._request(
+                server,
+                "POST",
+                "/admin/test-data/purge",
+                b"csrf_token=csrf&confirmation=DELETE_LOCAL_TEST_DATA",
+                {"Content-Type": "application/x-www-form-urlencoded", "Cookie": cookie, "X-Request-Id": "local-test-1"},
+            )
+            self.assertEqual(purge.status, 303)
+            self.assertEqual(database.local_purge_calls[0]["request_id"], "local-test-1")
+
             event = json.dumps({
                 "schemaVersion": 1,
                 "id": "a8098c1a-f86e-11da-bd1a-00112444be1e",
@@ -720,6 +887,7 @@ class Beta8APITests(unittest.TestCase):
                 "eventType": "INSTALL_SUCCEEDED",
                 "outcome": "SUCCEEDED",
                 "appBuild": "beta.8",
+                "releaseLabel": "1.0.0-beta.8",
             }).encode()
             first, first_body = self._request(server, "POST", "/map-events", event, {"Content-Type": "application/json"})
             second, second_body = self._request(server, "POST", "/map-events", event, {"Content-Type": "application/json"})

--- a/backend/catalog-api/tests/test_local_telemetry.py
+++ b/backend/catalog-api/tests/test_local_telemetry.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+import unittest
+
+from terento_catalog.db import Database
+
+
+class Result:
+    def __init__(self, row=None):
+        self.row = row
+
+    def fetchone(self):
+        return self.row
+
+
+class Connection:
+    def __init__(self):
+        self.queries: list[tuple[str, object]] = []
+
+    def execute(self, query, params=None):
+        self.queries.append((query, params))
+        if "array_agg" in query:
+            if "compatibility_evidence_event" in query:
+                return Result({"event_count": 2, "operation_count": 1, "labels": ["1.0.0-beta.10-local"]})
+            return Result({"event_count": 3, "operation_count": 1, "labels": ["1.0.0-beta.10-local"]})
+        if "local_operations" in query and "count(DISTINCT operation_id)" not in query:
+            return Result({"operation_count": 1})
+        if "count(DISTINCT operation_id)" in query:
+            return Result({"operation_count": 4})
+        if "DELETE FROM compatibility_evidence_event" in query:
+            return Result({"event_count": 6})
+        if "DELETE FROM map_download_event" in query:
+            return Result({"event_count": 8})
+        return Result({})
+
+
+class LocalTelemetryDatabase(Database):
+    def __init__(self, connection):
+        super().__init__("unused")
+        self._test_connection = connection
+
+    @contextmanager
+    def connection(self):
+        yield self._test_connection
+
+
+class LocalTelemetryTests(unittest.TestCase):
+    def test_summary_is_local_only(self):
+        connection = Connection()
+        database = LocalTelemetryDatabase(connection)
+        self.assertEqual(
+            database.local_test_telemetry_summary(),
+            {
+                "diagnosticEventCount": 2,
+                "mapEventCount": 3,
+                "operationCount": 1,
+                "releaseLabels": ["1.0.0-beta.10-local"],
+            },
+        )
+        self.assertTrue(all("is_local_test IS TRUE" in query for query, _ in connection.queries))
+
+    def test_purge_is_transactional_and_cannot_target_production_rows(self):
+        connection = Connection()
+        database = LocalTelemetryDatabase(connection)
+        result = database.purge_local_test_telemetry(
+            admin_user_id=7,
+            request_id="local-test-1",
+        )
+        self.assertEqual(
+            result,
+            {"diagnosticEventCount": 6, "mapEventCount": 8, "operationCount": 4},
+        )
+        delete_queries = [query for query, _ in connection.queries if query.lstrip().startswith("WITH deleted")]
+        self.assertEqual(len(delete_queries), 2)
+        self.assertTrue(all("WHERE is_local_test IS TRUE" in query for query in delete_queries))
+        audit = next((params for query, params in connection.queries if "INSERT INTO admin_audit_log" in query), None)
+        self.assertIsNotNone(audit)
+        self.assertEqual(audit[1], "telemetry.local_test_purged")
+        self.assertEqual(audit[7], "local-test-1")
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/backend/catalog-api/tests/test_shared_contracts.py
+++ b/backend/catalog-api/tests/test_shared_contracts.py
@@ -124,6 +124,7 @@ class SharedContractTests(unittest.TestCase):
             {'model': '/Users/synthetic/watch'}, {'usbVendorID': 70000},
             {'rawMTPModel': 'model\nserial'}, {'identityResolutionCode': 'UNIT_ID:123'},
             {'releaseLabel': 'file:///Users/synthetic/build'},
+            {'releaseLabel': 'development'}, {'releaseLabel': '1.0'},
             {'nativeFailureCode': 'RAW: log'}, {'remoteObjectCreated': True, 'writeStarted': False},
             {'cleanupSucceeded': True, 'cleanupAttempted': False},
             {'mapVisibleAfterReconnect': True, 'reconnectVerified': False},

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -49,6 +49,10 @@ Custom IMG compatibility events use coarse `custom` labels; map events exclude
 custom imports. No change to collection defaults, retention or privacy policy
 is authorized by these schemas.
 
+Current map events and compatibility diagnostic versions 3–4 require a strict
+SemVer `releaseLabel`. A valid label ending exactly in `-local` is classified
+server-side as local test telemetry; it is excluded from production aggregates
+and can only be purged through the authenticated admin test-data flow.
 Compatibility versions 1–3 retain the historical `deletionToken` field; version
 4 forbids it. This documents old request acceptance, not a restored deletion
 feature. Versions 3–4 check structured diagnostic types and consistency.

--- a/contracts/compatibility-event.schema.json
+++ b/contracts/compatibility-event.schema.json
@@ -423,7 +423,7 @@
           "releaseLabel": {
             "type": "string",
             "maxLength": 80,
-            "pattern": "^(?![\\s\\S]*(?:/Users/|file://))[\\s\\S]*\\S[\\s\\S]*$"
+            "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
           },
           "writeStarted": {
             "type": "boolean"

--- a/contracts/fixtures/compatibility-event.invalid-disallowed-field.json
+++ b/contracts/fixtures/compatibility-event.invalid-disallowed-field.json
@@ -17,7 +17,7 @@
   "mapResultIndex": 0,
   "selectedMapCount": 1,
   "appBuild": "1",
-  "releaseLabel": "contract-test",
+  "releaseLabel": "1.0.0-beta.10",
   "writeStarted": true,
   "remoteObjectCreated": true,
   "cleanupAttempted": false,

--- a/contracts/fixtures/compatibility-event.invalid-inconsistent-success.json
+++ b/contracts/fixtures/compatibility-event.invalid-inconsistent-success.json
@@ -17,7 +17,7 @@
   "mapResultIndex": 0,
   "selectedMapCount": 1,
   "appBuild": "1",
-  "releaseLabel": "contract-test",
+  "releaseLabel": "1.0.0-beta.10",
   "writeStarted": true,
   "remoteObjectCreated": true,
   "cleanupAttempted": false,

--- a/contracts/fixtures/compatibility-event.valid.json
+++ b/contracts/fixtures/compatibility-event.valid.json
@@ -17,7 +17,7 @@
   "mapResultIndex": 0,
   "selectedMapCount": 1,
   "appBuild": "1",
-  "releaseLabel": "contract-test",
+  "releaseLabel": "1.0.0-beta.10",
   "writeStarted": true,
   "remoteObjectCreated": true,
   "cleanupAttempted": false,

--- a/contracts/fixtures/map-event.invalid-custom-provider.json
+++ b/contracts/fixtures/map-event.invalid-custom-provider.json
@@ -4,6 +4,7 @@
   "operationId": "00000000-0000-4000-8000-000000000002",
   "timestamp": "2026-09-01T12:00:00Z",
   "providerId": "custom",
+  "releaseLabel": "1.0.0-beta.10",
   "mapId": "freizeitkarte-deu",
   "region": "DE",
   "eventType": "INSTALL_SUCCEEDED",

--- a/contracts/fixtures/map-event.invalid-disallowed-field.json
+++ b/contracts/fixtures/map-event.invalid-disallowed-field.json
@@ -4,6 +4,7 @@
   "operationId": "00000000-0000-4000-8000-000000000002",
   "timestamp": "2026-09-01T12:00:00Z",
   "providerId": "freizeitkarte",
+  "releaseLabel": "1.0.0-beta.10",
   "mapId": "freizeitkarte-deu",
   "region": "DE",
   "eventType": "INSTALL_SUCCEEDED",

--- a/contracts/fixtures/map-event.valid.json
+++ b/contracts/fixtures/map-event.valid.json
@@ -4,6 +4,7 @@
   "operationId": "00000000-0000-4000-8000-000000000002",
   "timestamp": "2026-09-01T12:00:00Z",
   "providerId": "freizeitkarte",
+  "releaseLabel": "1.0.0-beta.10",
   "mapId": "freizeitkarte-deu",
   "region": "DE",
   "eventType": "INSTALL_SUCCEEDED",

--- a/contracts/map-event.schema.json
+++ b/contracts/map-event.schema.json
@@ -73,6 +73,10 @@
       ],
       "maxLength": 80,
       "pattern": "\\S"
+    },
+    "releaseLabel": {
+      "$ref": "#/$defs/releaseLabel",
+      "description": "SemVer app release identity. Local debug builds end in -local and are purgeable only in the authenticated admin test-data flow."
     }
   },
   "required": [
@@ -81,6 +85,7 @@
     "operationId",
     "timestamp",
     "providerId",
+    "releaseLabel",
     "eventType",
     "outcome"
   ],
@@ -89,6 +94,11 @@
     "safeId": {
       "type": "string",
       "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,159}$"
+    },
+    "releaseLabel": {
+      "type": "string",
+      "maxLength": 80,
+      "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add authenticated Admin `Test data` view and explicit local telemetry purge
- classify telemetry server-side with strict release labels and shared operation IDs
- keep production aggregates and public telemetry immutable from the purge path
- include migration 035 and regression coverage

## Validation
- `PYTHONPATH=/private/tmp/terento-test-deps Tests/run-backend-tests.sh`
- 251 backend tests passed locally
- public OpenTopoMap contour mode remains `off`

This PR is intended for the `beta` deployment path.
