### PR TITLE
Fix admin filter initialization after dashboard audit

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -734,3 +734,5 @@ binaries and is returned with `Cache-Control: no-store`.
 ## Admin audit update — 2026-09-07
 
 Provider summaries expose `packageReleases` and the newest non-retired package release; individual regions retain their own release. Healthy system cards collapse by default and link to collection history and packages. Installation coverage normalizes provider country aliases, supports zoom/pan and region highlighting, and explicitly reports unmapped installations. Compatibility fallback validates the complete operation before filtering and preserves each provider/region. Local test activity remains isolated by `is_local_test=true` and is visible only in Test data; public beta events remain in user statistics. The local release-label guard requires Debug labels ending in `-local` and rejects those labels for public Release builds. No native application artifact is released by this API deployment.
+
+Post-deploy verification caught missing form bindings in the preserved Clear handlers. These handlers now resolve their own form directly so provider actions, map rendering and diagnostic controls initialize reliably.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -2185,7 +2185,7 @@ def _providers_list_script() -> str:
         if (count) count.textContent = `${visible} provider${visible === 1 ? '' : 's'}`;
       };
       search?.addEventListener('input', refresh);
-      form?.addEventListener('terento-admin-clear-filters', () => {
+      document.querySelector('#provider-filters')?.addEventListener('terento-admin-clear-filters', () => {
         if (search) search.value = '';
         refresh();
       });
@@ -2557,7 +2557,7 @@ def _map_statistics_script() -> str:
         if (status) status.textContent = 'Loading…';
         try { const response = await fetch(`/admin/map-statistics.json?${parameters}`, {credentials: 'same-origin', headers: {'Accept': 'application/json'}}); const payload = await response.json(); if (!response.ok) throw new Error(payload.error || 'Statistics unavailable'); render(payload); } catch (error) { if (status) status.textContent = error.message || 'Statistics unavailable'; }
       };
-      form?.addEventListener('terento-admin-clear-filters', () => {
+      document.querySelector('#map-statistics-filters')?.addEventListener('terento-admin-clear-filters', () => {
         range.value = 'all';
         provider.value = '';
         map.value = '';
@@ -4332,7 +4332,7 @@ def _diagnostics_script() -> str:
         page = 1;
         refresh();
       }));
-      filterForm?.addEventListener('terento-admin-clear-filters', () => {
+      document.querySelector('#diagnostic-filters')?.addEventListener('terento-admin-clear-filters', () => {
         selectedFilter = 'all';
         page = 1;
         const parameters = new URLSearchParams(window.location.search);

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -76,6 +76,13 @@ class AdminAuditTests(unittest.TestCase):
                 if allowed:
                     self.assertEqual(is_local_release_label(label),configuration=='Debug')
 
+    def test_clear_handlers_resolve_their_form_before_registering(self):
+        from terento_catalog.admin import _providers_list_script, _map_statistics_script, _diagnostics_script
+        for script, selector in [(_providers_list_script(), '#provider-filters'), (_map_statistics_script(), '#map-statistics-filters'), (_diagnostics_script(), '#diagnostic-filters')]:
+            self.assertIn("document.querySelector('" + selector + "')?.addEventListener('terento-admin-clear-filters'", script)
+            self.assertNotIn("form?.addEventListener('terento-admin-clear-filters'", script)
+            self.assertNotIn("filterForm?.addEventListener('terento-admin-clear-filters'", script)
+
     def test_disclosure_navigation_script_syntax(self):
         result=subprocess.run([os.environ.get('TERENTO_NODE_BIN','node'),'--check'],input=_admin_disclosure_script(),capture_output=True,text=True)
         self.assertEqual(result.returncode,0,result.stderr)


### PR DESCRIPTION
Production verification found retained Clear handlers referencing missing form variables, preventing map tables and some controls from initializing. Resolve each form directly at handler registration. Validation: 261 backend tests pass, including regression coverage for all three handlers.