### PR TITLE
Keep provider artifact details readable

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -737,7 +737,7 @@ Provider summaries expose `packageReleases` and the newest non-retired package r
 
 Post-deploy verification caught missing form bindings in the preserved Clear handlers. These handlers now resolve their own form directly so provider actions, map rendering and diagnostic controls initialize reliably.
 
-## Admin refinement — local, 2026-09-07
+## Admin refinement and contour activation — 2026-09-07
 
 Overview includes integer quantity ticks and up to 20 exact local event timestamps per series/bucket. Collection snapshot transactions retain changed map releases and regions in provider history from this version forward; previous per-map changes cannot be reconstructed from old summary-only runs. Healthy disclosure summaries use centered CSS chevrons; device information columns are 1:1. Health checks use aligned label/status rows. Map diagnostics stay collapsed, popularity explicitly says Top 5, and country geometry uses local Natural Earth 50m data.
 
@@ -746,8 +746,9 @@ CI selects test-file suites by their scope; packaging selects app/release and re
 On 2026-09-07 the owner-authorized root console on rukas was used to set
 `OPENTOPO_MAP_CONTOUR_MODE=public` in the shared API/scheduler environment and
 recreate both containers with their existing images. Both processes report
-public and API health passes. The existing image collects main only; contour
-publication remains pending deployment of this collector and migration 036.
+public and API health passes. Deployment `c352a6177fe730f608d516ab0d9f571ee379688e` applied the collector
+and migration 036. Production collection run 13 succeeded with 177 main packages
+and 157 validated contour attachments from 156 sources (334 artifacts).
 
 The collector independently inspects optional official contour sources using
 bounded HTTP ranges (8 MiB total, 4 MiB per request), exact root IMG path,
@@ -765,9 +766,14 @@ retains 177 main packages and 157 validated contour attachments; the combined
 candidate plus current FZK metadata passes 24 beta.9 provider-neutral tests.
 Optional artifact `version` is the independent HTTP source year/month for the
 legacy decoder; `sourceProof.revision` remains the actual metadata identity,
-not a main-map release or payload checksum. PostgreSQL integration is required
-in CI before deployment. This candidate is not yet published.
+not a main-map release or payload checksum. PostgreSQL integration passed in CI, including source-proof round trips,
+Overview queries and exclusion of optional contours from provider availability
+probes. The published catalog passed the same 24 beta.9 checks. Main URL,
+download size, install size and version fields match the pre-deployment catalog.
 
 Provider-wide availability probes sample active required main artifacts only.
 Optional contour failure cannot mark the whole provider unavailable; contour
 validation remains attached to the independently collected optional artifact.
+
+Artifact details are disclosed under the wide region/package column, with
+readable header widths and top-aligned cells; the count column remains numeric.

--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -777,3 +777,6 @@ validation remains attached to the independently collected optional artifact.
 
 Artifact details are disclosed under the wide region/package column, with
 readable header widths and top-aligned cells; the count column remains numeric.
+
+Map accessibility labels use standard country display names rather than
+normalized alias tokens, preserving spaces and accented country names.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1838,8 +1838,8 @@ def _provider_package_row(package: dict[str, Any]) -> str:
     if artifact_details:
         artifact_details = f"<details class='admin-disclosure' style='text-align:left;overflow-wrap:anywhere'><summary>Artifact details</summary>{artifact_details}</details>"
     return (
-        f"<tr class='{row_class.strip()}' data-package-search='{html.escape(search, quote=True)}' data-package-broken='{str(bool(broken_count)).lower()}'><td><span class='provider-package-name'>{html.escape(package_name)}</span><code class='provider-package-id'>{html.escape(package_id)}</code>{f'<small>{html.escape(region)}</small>' if region and region.casefold() != package_name.casefold() else ''}</td>"
-        f"<td>{html.escape(str(package.get('release') or '—'))}</td><td class='numeric'>{int(package.get('artifact_count') or 0)}{artifact_details}</td>"
+        f"<tr class='{row_class.strip()}' data-package-search='{html.escape(search, quote=True)}' data-package-broken='{str(bool(broken_count)).lower()}'><td><span class='provider-package-name'>{html.escape(package_name)}</span><code class='provider-package-id'>{html.escape(package_id)}</code>{f'<small>{html.escape(region)}</small>' if region and region.casefold() != package_name.casefold() else ''}{artifact_details}</td>"
+        f"<td>{html.escape(str(package.get('release') or '—'))}</td><td class='numeric'>{int(package.get('artifact_count') or 0)}</td>"
         f"<td>{broken_markup}{f' <small>{broken_count} broken</small>' if broken_count else ''}</td></tr>"
     )
 
@@ -5125,7 +5125,7 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
   .provider-history-wrap th:nth-child(5){width:10%}.provider-history-wrap th:nth-child(6){width:10%}
   .provider-history-wrap th:nth-child(7){width:24%}
   .provider-source-table th:nth-child(1){width:14%}.provider-source-table th:nth-child(2){width:50%}.provider-source-table th:nth-child(3){width:12%}.provider-source-table th:nth-child(4){width:24%}
-  .provider-package-table th:nth-child(1){width:55%}.provider-package-table th:nth-child(2){width:20%}.provider-package-table th:nth-child(3){width:10%}.provider-package-table th:nth-child(4){width:15%}
+  .provider-package-table{min-width:640px!important}.provider-package-table th:nth-child(1){width:49%}.provider-package-table th:nth-child(2){width:18%}.provider-package-table th:nth-child(3){width:16%}.provider-package-table th:nth-child(4){width:17%}.provider-package-table td{vertical-align:top}.provider-package-table details{margin-top:8px;font-weight:400}
   .provider-run-table th:nth-child(1){width:6%}.provider-run-table th:nth-child(2),.provider-run-table th:nth-child(3){width:16%}.provider-run-table th:nth-child(4){width:12%}.provider-run-table th:nth-child(5),.provider-run-table th:nth-child(6){width:10%}.provider-run-table th:nth-child(7){width:30%}
   .provider-component{white-space:normal;flex-wrap:wrap}.provider-component-list{min-width:0}
   .provider-component .provider-status{white-space:normal;line-height:1.3}

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -2346,6 +2346,12 @@ def _map_statistics_script() -> str:
       Object.entries(countryAliases).forEach(([key, code]) => {
         if (key.length > 3 && !countryNames[code]) countryNames[code] = humanize(key.toLowerCase());
       });
+      if (typeof Intl.DisplayNames === 'function') {
+        const regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
+        Object.values(countryAliases).forEach((code) => {
+          countryNames[code] = regionNames.of(code.toUpperCase()) || countryNames[code];
+        });
+      }
       const normalizeCountryToken = (value) => String(value || '').normalize('NFKD').replace(/[\u0300-\u036f]/g, '').replace(/[^A-Za-z0-9]+/g, '').toUpperCase();
       const countryCode = (row) => {
         const candidates = [row.region_country, row.canonical_region_id, row.region_identity, row.region, row.region_display_name];


### PR DESCRIPTION
Provider artifact details were compressed into the narrow numeric count column. They now expand beneath the region/package name, with readable column widths, normal body weight and top-aligned cells.

Validated in the browser with actual Lithuania source metadata and with 12 focused admin tests. Catalog data and native behavior are unchanged. Documentation records the completed production contour activation and beta.9 checks.
