### PR TITLE
fix(admin): preserve context for low-volume install charts

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import html
 import json
+import math
 import re
 import secrets
 import unicodedata
@@ -1056,7 +1057,11 @@ def _overview_trend_chart(
         for item in trend
     ]
     maximum = max((sum(series) for series in values), default=1) or 1
-    scale_maximum = maximum
+    # Keep low-volume periods readable. A single operation should remain a
+    # single operation visually, rather than filling the entire plot because
+    # it happens to be the local maximum. Larger volumes get a little headroom
+    # so bars do not touch the top gridline.
+    scale_maximum = max(4, math.ceil(maximum * 1.2))
     chart_width, chart_height = 720, 260
     left, top, bottom = 38, 20, 34
     plot_height = chart_height - top - bottom
@@ -1093,8 +1098,8 @@ def _overview_trend_chart(
             if timestamps:
                 title = f"{label}: {count} · " + ', '.join(str(value) for value in timestamps) + f" · {time_zone}" + (' · first 20 times' if len(timestamps) == 20 else '')
             bars.append(
-                f"<rect class='overview-chart-{name}' x='{x:.1f}' y='{y:.1f}' "
-                f"width='{bar_width:.1f}' height='{height:.1f}' tabindex='0' "
+                f"<rect class='overview-chart-{name}' x='{x:.1f}' y='{y:.2f}' "
+                f"width='{bar_width:.1f}' height='{height:.2f}' tabindex='0' "
                 f"role='img' aria-label='{html.escape(title, quote=True)}'>"
                 f"<title>{html.escape(title)}</title></rect>"
             )
@@ -1106,7 +1111,7 @@ def _overview_trend_chart(
         "<div class='overview-chart-wrap'>"
         f"<svg class='overview-trend-chart' viewBox='0 0 {chart_width} {chart_height}' role='img' aria-label='Map install operations over time'>"
         f"{''.join(grid)}{''.join(bars)}{''.join(labels)}</svg>"
-        "<div class='overview-chart-legend'><span><i class='overview-chart-success'></i>Succeeded</span><span><i class='overview-chart-failed'></i>Failed</span><span><i class='overview-chart-custom'></i>Custom .img</span></div><p class='overview-chart-note'>Custom .img: successful manual installations.</p></div>"
+        "<div class='overview-chart-legend'><span><i class='overview-chart-success'></i>Succeeded</span><span><i class='overview-chart-failed'></i>Failed</span><span><i class='overview-chart-custom'></i>Custom .img</span></div></div>"
     )
 
 

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -88,7 +88,9 @@ class AdminAuditTests(unittest.TestCase):
         markup = _overview_trend_chart([{'bucket':'2026-09-07T16:00:00Z','success_count':1,'success_times':['2026-09-07 19:43']}], 'hour', 'Europe/Vilnius')
         self.assertIn('2026-09-07 19:43', markup)
         self.assertIn("text-anchor='end'>1</text>", markup)
+        self.assertIn("text-anchor='end'>4</text>", markup)
         self.assertIn("text-anchor='end'>0</text>", markup)
+        self.assertRegex(markup, r"class='overview-chart-success'[^>]*height='51.50'")
 
     def test_collection_changes_have_readable_regions_and_escape_values(self):
         from terento_catalog.admin import _provider_audit_row

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -725,9 +725,9 @@ class AdminSemanticsTests(unittest.TestCase):
             "bucket": "2026-09-05T00:00:00Z", "custom_count": 3,
         }], "hour")
         self.assertIn("Custom .img installed: 3", body)
-        self.assertRegex(body, r"class='overview-chart-custom'[^>]*height='206.0'")
+        self.assertRegex(body, r"class='overview-chart-custom'[^>]*height='154.50'")
         self.assertIn("</i>Custom .img</span>", body)
-        self.assertIn("Custom .img: successful manual installations.", body)
+        self.assertNotIn("Custom .img: successful manual installations.", body)
 
     def test_chart_segments_join_without_individual_rounding(self):
         import xml.etree.ElementTree as ET


### PR DESCRIPTION
A chart with one install used the bucket maximum as its full y-axis, so one event filled the plot and looked disproportionately large. Keep raw counts and exact event timestamps, but use a minimum four-operation linear scale plus 20% headroom for larger totals. SVG segment coordinates now use two decimal places so stacked outcomes meet without subpixel gaps. Remove the redundant Custom .img explanatory sentence while retaining the color legend.\n\nValidation: 271 backend tests PASS, including integer axis, exact event time, low-volume bar height, stacked segment joins and the reduced legend copy. No database, telemetry, native installation or public catalog behavior changes.