### PR TITLE
fix(admin): keep resolved failures in model activity

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -775,7 +775,7 @@ def _overview_model_activity_item(item: dict[str, Any]) -> str:
     successful = int(item.get("successful_count") or 0)
     failed = int(item.get("failed_count") or 0)
     open_errors = int(item.get("open_error_count") or 0)
-    status = "Needs review" if open_errors else ("Failures" if failed else "Active")
+    status = "Needs review" if open_errors else ("Historical failures" if failed else "Active")
     status_class = "failed" if failed or open_errors else "succeeded"
     device_id = str(item.get("canonical_device_model_id") or "").strip()
     href = (
@@ -1268,7 +1268,7 @@ def overview_page(
         if review_required else ""
     )
     model_panel = (
-        f"<section class='overview-panel overview-model-panel' aria-labelledby='overview-model-title'><div class='section-heading'><div><p class='section-kicker'>Compatibility evidence</p><h2 id='overview-model-title'>Device/model activity</h2></div></div><p class='overview-chart-note'>Activity is grouped by canonical device model when available.</p>{_overview_model_activity(model_activity)}{review_section}</section>"
+        f"<section class='overview-panel overview-model-panel' aria-labelledby='overview-model-title'><div class='section-heading'><div><p class='section-kicker'>Compatibility evidence</p><h2 id='overview-model-title'>Device/model activity</h2></div></div><p class='overview-chart-note'>Includes resolved historical outcomes; Needs attention counts unresolved issues only.</p>{_overview_model_activity(model_activity)}{review_section}</section>"
         if model_activity or review_required else ""
     )
     primary_grid_class = "overview-primary-grid" if model_panel else "overview-primary-grid overview-primary-grid-single"

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -619,7 +619,8 @@ class Database:
                         AS operation_succeeded,
                     bool_or(e.phase_outcome = 'FAILED') AS has_failed,
                     bool_or(e.phase_outcome = 'NOT_STARTED') AS has_not_started,
-                    bool_or(e.canonical_device_model_id IS NULL AND
+                    bool_or(e.diagnostic_status = 'ACTIVE' AND
+                        e.canonical_device_model_id IS NULL AND
                         COALESCE(e.identity_resolution_state, 'UNRESOLVED')
                         NOT IN ('RESOLVED', 'NOT_IDENTIFIABLE')) AS identity_pending,
                     bool_or(
@@ -632,8 +633,7 @@ class Database:
                         )
                     ) AS open_error
                 FROM compatibility_evidence_event AS e
-                WHERE e.diagnostic_status = 'ACTIVE'
-                  AND e.is_local_test IS NOT TRUE
+                WHERE e.is_local_test IS NOT TRUE
                 GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
             )
         """
@@ -714,10 +714,10 @@ class Database:
                     ) AS variant,
                     count(*) AS operation_count,
                     count(*) FILTER (
-                        WHERE write_started AND operation_succeeded
+                        WHERE operation_succeeded
                     ) AS successful_count,
                     count(*) FILTER (
-                        WHERE write_started AND has_failed
+                        WHERE has_failed
                     ) AS failed_count,
                     count(*) FILTER (WHERE open_error) AS open_error_count,
                     max(last_occurred_at) AS last_occurred_at

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -338,6 +338,38 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertNotIn("last_evidence >=", review[0])
         self.assertIn("('TESTED', 'SUPPORTED', 'VERIFIED')", review[0])
 
+    def test_overview_model_activity_keeps_resolved_failures_in_historical_counts(self):
+        source = inspect.getsource(Database.admin_overview_snapshot)
+        self.assertIn("WHERE e.is_local_test IS NOT TRUE", source)
+        self.assertIn("e.diagnostic_status = 'ACTIVE'", source)
+        self.assertNotIn(
+            "WHERE e.diagnostic_status = 'ACTIVE'\n                  AND e.is_local_test IS NOT TRUE",
+            source,
+        )
+        self.assertNotIn("WHERE write_started AND operation_succeeded", source)
+        self.assertNotIn("WHERE write_started AND has_failed", source)
+        body = overview_page(
+            {
+                "period": "7d",
+                "data": {"hasData": True, "completedInstallCount": 1, "recentActivity": [], "attention": [], "trend": [], "bucket": "day"},
+                "compatibility": {
+                    "hasData": True,
+                    "modelActivity": [{
+                        "model": "fēnix 8", "variant": "47 mm",
+                        "operation_count": 3, "successful_count": 1,
+                        "failed_count": 2, "open_error_count": 0,
+                        "last_occurred_at": "2026-09-07T19:43:00+00:00",
+                    }],
+                    "reviewRequired": [], "recentActivity": [], "failureReasons": [],
+                    "writeStartedCount": 3, "variantCount": 1, "evidenceSuccessRate": 33.3,
+                },
+                "providers": [],
+            },
+            {"username": "operator"}, "csrf",
+        ).decode()
+        self.assertIn("1 successful · 2 failed · Historical failures", body)
+        self.assertIn("Includes resolved historical outcomes", body)
+
     def test_revision_ignores_render_time_but_detects_new_events(self):
         import re
         def revision(time, count):


### PR DESCRIPTION
## Problem

The Overview chart included failed map operations, but Device/model activity
excluded compatibility operations after an admin marked them resolved. The two
sections therefore disagreed about the same install history.

## Change

- include resolved compatibility outcomes in period-scoped Overview aggregates;
- keep `Needs attention` and identity-pending queues limited to active issues;
- count failed operations independently of `write_started`, matching the
  historical device and diagnostics totals;
- label a model with closed failures as `Historical failures` and explain the
  active-versus-historical scope in the panel.

## Validation

- `PYTHONPATH=backend/catalog-api/src /Users/gediminas/Documents/Codex/terento/.venv/bin/python -m unittest backend.catalog-api.tests.test_admin_semantics`
- full backend suite: 272 tests PASS
- `git diff --check`

This is an admin read-model change. It does not modify telemetry, device
install/remove behavior, or public compatibility statistics.
