### PR TITLE
fix(admin): link historical model failures

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -778,8 +778,9 @@ def _overview_model_activity_item(item: dict[str, Any]) -> str:
     status = "Needs review" if open_errors else ("Historical failures" if failed else "Active")
     status_class = "failed" if failed or open_errors else "succeeded"
     device_id = str(item.get("canonical_device_model_id") or "").strip()
+    detail_state = "open" if open_errors else "resolved-errors" if failed else None
     href = (
-        _device_detail_url(device_id, origin="installations", state="open", anchor="installations")
+        _device_detail_url(device_id, origin="installations", state=detail_state, anchor="installations")
         if device_id else _diagnostics_url(item)
     )
     result = f"{successful} successful · {failed} failed" if successful or failed else f"{operation_count} operation{'s' if operation_count != 1 else ''}"

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -358,6 +358,7 @@ class AdminSemanticsTests(unittest.TestCase):
                         "model": "fēnix 8", "variant": "47 mm",
                         "operation_count": 3, "successful_count": 1,
                         "failed_count": 2, "open_error_count": 0,
+                        "canonical_device_model_id": "garmin-fenix-8-47",
                         "last_occurred_at": "2026-09-07T19:43:00+00:00",
                     }],
                     "reviewRequired": [], "recentActivity": [], "failureReasons": [],
@@ -369,6 +370,7 @@ class AdminSemanticsTests(unittest.TestCase):
         ).decode()
         self.assertIn("1 successful · 2 failed · Historical failures", body)
         self.assertIn("Includes resolved historical outcomes", body)
+        self.assertIn("state=resolved-errors#installations", body)
 
     def test_revision_ignores_render_time_but_detects_new_events(self):
         import re


### PR DESCRIPTION
## Follow-up

Historical failures in Device/model activity now link directly to the device
history with `state=resolved-errors`, so an operator can see the fixed failure
records that the card counts.

## Validation

- targeted admin semantics tests pass (73 tests)
- `git diff --check`

This keeps active `Needs attention` links separate from historical failure
history and changes no device or telemetry behavior.
