### PR TITLE
Polish all public site interfaces

### DIFF
--- a/Tests/shared-brand-contract-tests.py
+++ b/Tests/shared-brand-contract-tests.py
@@ -26,7 +26,7 @@ LOGO_PATH = ROOT / "brand" / "logo" / "logo.svg"
 HEX_RE = re.compile(r"#[0-9A-Fa-f]{3,8}\b")
 SITE_BEGIN = "/* BEGIN GENERATED TERENTO BRAND TOKENS */"
 SITE_END = "/* END GENERATED TERENTO BRAND TOKENS */"
-STYLE_VERSION = "20260908-provider-width-v5"
+STYLE_VERSION = "20260909-interface-polish-v2"
 SHELL_VERSION = "20260905-in-page-language-v1"
 LOGO_SHA256 = "6fd490112b8cb34e9a0f699a38f16ddf6d3a0848981ec15c694710946421dc13"
 

--- a/Tests/site-home-copy-cta-tests.cjs
+++ b/Tests/site-home-copy-cta-tests.cjs
@@ -153,7 +153,7 @@ const anchorFor = (page, className) => {
 
 for (const [locale, expected] of locales) {
   const page = pageFor(locale);
-  assert.match(page, /<link rel="stylesheet" href="\/styles\.css\?v=20260908-provider-width-v5">/, `${locale}: Home stylesheet cache bust`);
+  assert.match(page, /<link rel="stylesheet" href="\/styles\.css\?v=20260909-interface-polish-v2">/, `${locale}: Home stylesheet cache bust`);
   assert.match(page, /<script defer src="\/home-features\.js\?v=20260904-home-workflow-tabs"><\/script>/, `${locale}: Home feature script cache bust`);
   assert.match(page, /installing-maps-1600\.png\?v=20260905-app-screens-v1/, `${locale}: installation screenshot cache bust`);
   const heroArtwork = page.match(/<figure class="app-shot app-shot--hero">[\s\S]*?<\/figure>/)?.[0];
@@ -287,6 +287,18 @@ for (const declaration of [
   assert.match(sharedTextLink[1], new RegExp(declaration.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 }
 assert.match(styles, /\.primary-nav a,\s*\.footer-nav a,\s*\.text-link\s*\{[^}]*text-decoration: none/s);
+const desktopNavLinks = styles.match(/\.primary-nav a,\s*\.footer-nav a\s*\{([^}]*)\}/s);
+assert.ok(desktopNavLinks, "missing desktop navigation hit-area block");
+assert.match(desktopNavLinks[1], /display: inline-flex/);
+assert.match(desktopNavLinks[1], /align-items: center/);
+assert.match(desktopNavLinks[1], /min-height: 40px/);
+const aboutSocialLink = styles.match(/\.about-social-link\s*\{([^}]*)\}/s);
+assert.ok(aboutSocialLink, "missing About social-link style block");
+assert.match(aboutSocialLink[1], /min-height: 40px/);
+assert.match(styles, /\.compatibility-summary-line strong\s*\{[^}]*font-variant-numeric: tabular-nums/s);
+assert.match(styles, /\.compatibility-results-count\s*\{[^}]*font-variant-numeric: tabular-nums/s);
+assert.match(styles, /\.watch-install-count\s*\{[^}]*font-variant-numeric: tabular-nums/s);
+assert.match(styles, /summary:not\(\.language-trigger\)::after\s*\{[^}]*border-right: 1\.5px solid currentColor[^}]*transition: transform 160ms ease-out/s);
 assert.match(styles, /\.text-link:hover\s*\{[^}]*color: var\(--link-text-hover\)/s);
 const heroAction = styles.match(/\.hero-download-action\s*\{([^}]*)\}/s);
 assert.ok(heroAction, "missing Hero Download CTA sizing block");

--- a/Tests/site-public-page-layout-contract-tests.cjs
+++ b/Tests/site-public-page-layout-contract-tests.cjs
@@ -7,7 +7,7 @@ const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "u
 const styles = read("site/styles.css");
 const shellSource = read("site/site-shell.js");
 const languageSource = read("site/language.js");
-const styleVersion = "20260908-provider-width-v5";
+const styleVersion = "20260909-interface-polish-v2";
 const localizedContentVersion = "20260904-pass3-internal-link-events-v1";
 const mobileLanguageNames = { en: "English", de: "Deutsch", fr: "Français", pl: "Polski", cs: "Čeština", it: "Italiano" };
 
@@ -53,6 +53,13 @@ assert.match(cssBlock(".download-details"), /border-top:\s*1px solid var\(--bord
 assert.match(cssBlock(".download-detail"), /background:\s*var\(--surface\)/);
 assert.match(cssBlock(".download-detail"), /border-radius:\s*16px/);
 assert.match(styles, /a:focus-visible,[\s\S]*?outline:\s*3px solid var\(--focus-ring\)/);
+assert.match(styles, /h1,\s*\nh2,\s*\nh3\s*\{[\s\S]*?text-wrap:\s*balance;/, "marketing headings must balance their lines");
+assert.match(styles, /\.hero-lede,\s*\n\.download-intro,\s*\n\.provider-summary,\s*\n\.provider-addon-copy\s*\{[\s\S]*?text-wrap:\s*pretty;/, "short supporting copy should avoid awkward final lines");
+assert.match(cssBlock(".download-action"), /transition-property:\s*scale, background-color/);
+assert.match(styles, /\.download-action:active\s*\{[^}]*scale:\s*0\.96/);
+assert.match(styles, /\.provider-addon > summary\.provider-addon-toggle::after,[\s\S]*?transition:\s*transform 160ms ease-out;/);
+assert.match(cssBlock(".provider-count"), /font-variant-numeric:\s*tabular-nums/);
+assert.match(cssBlock(".provider-addon-count"), /font-variant-numeric:\s*tabular-nums/);
 
 const locales = {
   en: {
@@ -190,7 +197,7 @@ assert.match(cssBlock(".language-option > span:not(.language-option-flag)"), /te
 assert.match(styles, /\.mobile-language-menu \.language-options\s*\{[^}]*grid-template-columns:\s*1fr/s);
 assert.match(styles, /\.mobile-language-menu \.language-option\s*\{[^}]*width:\s*100%[^}]*min-height:\s*44px/s);
 
-assert.match(cssBlock(".about-social-link"), /min-height:\s*36px/);
+assert.match(cssBlock(".about-social-link"), /min-height:\s*40px/);
 assert.match(cssBlock(".about-social-link"), /padding:\s*7px 11px/);
 assert.match(cssBlock(".about-social-link"), /border-radius:\s*8px/);
 assert.match(cssBlock(".about-bullet-list"), /gap:\s*12px/);

--- a/scripts/normalize-public-shell.py
+++ b/scripts/normalize-public-shell.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SHELL_VERSION = "20260905-in-page-language-v1"
 PROVIDER_SCRIPT_VERSION = "20260908-provider-disclosure-v4"
-STYLE_VERSION = "20260908-provider-width-v5"
+STYLE_VERSION = "20260909-interface-polish-v2"
 IMAGE_VERSION = "20260905-app-screens-v1"
 LANGUAGE_VERSION = "20260905-language-selector-full-name-v1"
 LOCALIZED_CONTENT_VERSION = "20260904-pass3-internal-link-events-v1"

--- a/site/404.html
+++ b/site/404.html
@@ -12,7 +12,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#7898A8">
     <link rel="manifest" href="/manifest.webmanifest">
-<link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+<link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
   </head>
   <body>

--- a/site/about/index.html
+++ b/site/about/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/compatibility/index.html
+++ b/site/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/cs/about/index.html
+++ b/site/cs/about/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/cs/compatibility/index.html
+++ b/site/cs/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Ověřte kompatibilitu hodinek Garmin s Terento podle skutečných instalací pro konkrétní model a variantu.">
     <meta name="robots" content="index,follow">

--- a/site/cs/download/index.html
+++ b/site/cs/download/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Stáhněte si bezplatnou, notářsky ověřenou betu Terento pro Macy s Apple Silicon k instalaci a správě map třetích stran na kompatibilních hodinkách Garmin.">
     <meta name="robots" content="index,follow">

--- a/site/cs/guides/install-garmin-maps-mac/index.html
+++ b/site/cs/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/cs/index.html
+++ b/site/cs/index.html
@@ -2,7 +2,7 @@
 <html lang="cs" data-language="cs">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/de/about/index.html
+++ b/site/de/about/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/de/compatibility/index.html
+++ b/site/de/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/de/download/index.html
+++ b/site/de/download/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Lade die kostenlose, notarielle Terento-Beta für Apple-Silicon-Macs herunter, um Drittanbieter-Karten auf kompatiblen Garmin-Smartwatches zu installieren und zu verwalten.">
     <meta name="robots" content="index,follow">

--- a/site/de/guides/install-garmin-maps-mac/index.html
+++ b/site/de/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/de/index.html
+++ b/site/de/index.html
@@ -2,7 +2,7 @@
 <html lang="de" data-language="de">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/download/index.html
+++ b/site/download/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/fr/about/index.html
+++ b/site/fr/about/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/fr/compatibility/index.html
+++ b/site/fr/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Vérifiez la compatibilité des montres Garmin avec Terento grâce aux résultats réels par modèle et variante.">
     <meta name="robots" content="index,follow">

--- a/site/fr/download/index.html
+++ b/site/fr/download/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Téléchargez la bêta Terento gratuite et notariée pour Mac Apple Silicon afin d’installer et de gérer des cartes tierces sur les montres Garmin compatibles.">
     <meta name="robots" content="index,follow">

--- a/site/fr/guides/install-garmin-maps-mac/index.html
+++ b/site/fr/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/fr/index.html
+++ b/site/fr/index.html
@@ -2,7 +2,7 @@
 <html lang="fr" data-language="fr">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/guides/install-garmin-maps-mac/index.html
+++ b/site/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/index.html
+++ b/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/it/about/index.html
+++ b/site/it/about/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/it/compatibility/index.html
+++ b/site/it/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Verifica la compatibilità degli smartwatch Garmin con Terento tramite risultati reali per modello e variante.">
     <meta name="robots" content="index,follow">

--- a/site/it/download/index.html
+++ b/site/it/download/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Scarica la beta gratuita e notarizzata di Terento per Mac Apple Silicon per installare e gestire mappe di terze parti sugli smartwatch Garmin compatibili.">
     <meta name="robots" content="index,follow">

--- a/site/it/guides/install-garmin-maps-mac/index.html
+++ b/site/it/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/it/index.html
+++ b/site/it/index.html
@@ -2,7 +2,7 @@
 <html lang="it" data-language="it">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/legal/index.html
+++ b/site/legal/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en" data-page="legal">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/pl/about/index.html
+++ b/site/pl/about/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl" data-page="about">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/pl/compatibility/index.html
+++ b/site/pl/compatibility/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl" data-page="compatibility">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2"><script defer src="/privacy-consent.js?v=20260905-campaign-url-only-v1"></script>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Sprawdź kompatybilność zegarków Garmin z Terento na podstawie rzeczywistych instalacji dla modelu i wariantu.">
     <meta name="robots" content="index,follow">

--- a/site/pl/download/index.html
+++ b/site/pl/download/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover"><meta name="theme-color" content="#F7F3EC">
     <meta name="description" content="Pobierz bezpłatną, notaryzowaną betę Terento na Maci z Apple Silicon, aby instalować i zarządzać mapami innych firm na zgodnych zegarkach Garmin.">
     <meta name="robots" content="index,follow">

--- a/site/pl/guides/install-garmin-maps-mac/index.html
+++ b/site/pl/guides/install-garmin-maps-mac/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl" data-page="guide">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <script defer src="/reading-state.js?v=20260902-reading-state"></script>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">

--- a/site/pl/index.html
+++ b/site/pl/index.html
@@ -2,7 +2,7 @@
 <html lang="pl" data-language="pl">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-language="en" data-page="privacy">
   <head>
     <script defer src="/site-shell.js?v=20260905-in-page-language-v1"></script>
-    <link rel="stylesheet" href="/styles.css?v=20260908-provider-width-v5">
+    <link rel="stylesheet" href="/styles.css?v=20260909-interface-polish-v2">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#F7F3EC">

--- a/site/styles.css
+++ b/site/styles.css
@@ -177,6 +177,13 @@ summary:focus-visible {
   text-decoration: none;
 }
 
+.primary-nav a,
+.footer-nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+}
+
 .primary-nav a:hover,
 .footer-nav a:hover,
 .text-link:hover {
@@ -444,7 +451,7 @@ button.language-option {
 
 .hero-grid {
   display: grid;
-  grid-template-columns: minmax(360px, .82fr) minmax(0, 1.18fr);
+  grid-template-columns: minmax(500px, .92fr) minmax(0, 1.08fr);
   gap: clamp(42px, 5.5vw, 80px);
   align-items: center;
 }
@@ -486,6 +493,14 @@ h3 {
   font-family: var(--font-brand);
   font-weight: 600;
   letter-spacing: -0.045em;
+  text-wrap: balance;
+}
+
+.hero-lede,
+.download-intro,
+.provider-summary,
+.provider-addon-copy {
+  text-wrap: pretty;
 }
 
 h1 {
@@ -634,7 +649,7 @@ h1 {
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  min-height: 36px;
+  min-height: 40px;
   padding: 7px 11px;
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -759,11 +774,18 @@ h1 {
   font-size: 14px;
   font-weight: 600;
   text-decoration: none;
+  transition-property: scale, background-color;
+  transition-duration: 150ms, 200ms;
+  transition-timing-function: ease-out, ease;
 }
 
 .download-action:hover,
 .download-action:focus-visible {
   background: var(--interactive-hover);
+}
+
+.download-action:active {
+  scale: 0.96;
 }
 
 .hero-download-action {
@@ -1432,6 +1454,7 @@ h1 {
   font-size: 13px;
   font-weight: 650;
   line-height: 1.5;
+  font-variant-numeric: tabular-nums;
 }
 
 .provider-summary {
@@ -1469,6 +1492,7 @@ h1 {
   content: "";
   font-size: 0;
   transform: rotate(45deg) translateY(-2px);
+  transition: transform 160ms ease-out;
 }
 
 .provider-addon[open] > summary.provider-addon-toggle::after {
@@ -1490,6 +1514,7 @@ h1 {
   margin: 8px 0 0;
   color: var(--secondary);
   font-size: 13px;
+  font-variant-numeric: tabular-nums;
 }
 
 .provider-controls {
@@ -1667,16 +1692,19 @@ summary::-webkit-details-marker {
 }
 
 summary:not(.language-trigger)::after {
-  content: "+";
+  width: 8px;
+  height: 8px;
   flex: 0 0 auto;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  content: "";
   color: var(--link-text);
-  font-size: 25px;
-  font-weight: 400;
-  line-height: 1;
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform 160ms ease-out;
 }
 
 details[open] summary:not(.language-trigger)::after {
-  content: "−";
+  transform: rotate(-135deg) translate(-2px, -1px);
 }
 
 details p {
@@ -1914,6 +1942,10 @@ details p {
 
   .section {
     padding: 64px 0;
+  }
+
+  .about-social-link {
+    min-height: 44px;
   }
 
   .experience.section {
@@ -2286,6 +2318,7 @@ details p {
   font-size: 21px;
   font-weight: 600;
   letter-spacing: -.03em;
+  font-variant-numeric: tabular-nums;
 }
 
 .compatibility-how {
@@ -2431,6 +2464,7 @@ details p {
   color: var(--secondary);
   font-size: 13px;
   font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .watch-grid {
@@ -2576,6 +2610,7 @@ details p {
   color: var(--graphite);
   font-size: 15px;
   font-weight: 650;
+  font-variant-numeric: tabular-nums;
 }
 
 .watch-card-meta {


### PR DESCRIPTION
## Summary
- improve navigation and social-link hit areas across desktop/mobile layouts
- stabilize compatibility counts with tabular numerals
- add animated disclosure chevrons and bump public stylesheet cache version
- keep beta.10 build15 release metadata unchanged

## Verification
- `Tests/run-site-tests.sh`
- `Tests/run-release-documentation-tests.sh`
- `Tests/run-release-legal-content-tests.sh`
- `git diff --check`

This PR is limited to the public site and its deterministic contract tests.