### PR TITLE
Align GitHub issue report buttons

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -7,6 +7,8 @@ canonical IDs rather than datalist suggestions. Editing the search clears the
 selection, and assignment requires an explicit model choice. Other identity
 actions disable the picker. Backend validation and save semantics are unchanged.
 
+GitHub report actions share inline-flex alignment, zero margins and stretched
+row heights for both the link and button; copy feedback occupies its own row.
 Admin filter actions align with the labelled controls' bottom edge. Mobile
 filter values use regular-weight 16px Inter and retain 44px touch targets;
 the device sort label stacks above its select. Coverage maps initially show

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -5078,6 +5078,8 @@ table code,.technical-value,.provider-table-wrap code,.audit-technical-details c
 .device-detail-grid{gap:16px}
 .device-catalog-details,.model-technical-details{margin-top:16px}
 .secondary-button,.provider-pagination button,.device-pagination button{min-height:var(--admin-control-height);padding:8px 10px}
+.github-actions>.secondary-button{display:inline-flex;align-items:center;justify-content:center;margin:0;align-self:stretch;text-align:center;text-decoration:none;white-space:normal}
+.github-actions>.copy-status{flex-basis:100%}
 .provider-action-overflow>summary{min-height:var(--admin-control-height);padding:8px 12px}
 .provider-action-bar{gap:7px}
 .disclosure-body{margin-top:12px}

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -27,6 +27,12 @@ class Tags(HTMLParser):
 
 
 class AdminAuditTests(unittest.TestCase):
+    def test_github_actions_share_alignment_without_form_button_margin(self):
+        from terento_catalog.admin import _layout
+        markup = _layout('Test', '').decode()
+        self.assertIn('.github-actions>.secondary-button{display:inline-flex;align-items:center;justify-content:center;margin:0;align-self:stretch;text-align:center;text-decoration:none;white-space:normal}', markup)
+        self.assertIn('.github-actions>.copy-status{flex-basis:100%}', markup)
+
     def test_mobile_chart_keeps_last_bucket_and_unique_clip_ids(self):
         import re
         import xml.etree.ElementTree as ET


### PR DESCRIPTION
Owner-authorized deployment of the scoped GitHub report-action alignment fix. Reset inherited form-button margin, align anchor and button with shared flex sizing, and keep copy feedback on its own row. README and regression test included. All 279 backend tests pass; local browser measures identical top and 40px heights. No API, authentication, statistics, or issue-creation behavior changes.