### PR TITLE
Count individual map installation results in admin

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -321,7 +321,24 @@ and 390 px, the mobile menu, and automatic resolution of the two active
 diagnostics linked to closed GitHub issue #94. Historical failure results were
 retained. Deployment workflow: https://github.com/VooZ2/terento/actions/runs/33925498939.
 
-### Admin custom IMG chart series — 2026-09-05
+### Admin installation counting — 2026-09-10 (local, not deployed)
+
+Admin attempts count retained map results, not batch/session IDs: a custom IMG
+plus OTM session contributes two attempts and two successes when both verify.
+The installation overview, identity table, watch counters and chart use this
+unit. Resolved failures stay in all-time attempt/failure totals; unstarted
+siblings do not become fabricated attempts. Immutable event IDs provide replay
+idempotency. Diagnostic review actions remain grouped by the original session.
+
+Overview reconciles map events against compatibility results by session,
+provider and region. One catalog event cannot suppress a custom result or a
+different region. Map statistics remains catalog-only. Existing retained mixed
+sessions recalculate on read; no production event rewrite or backfill is needed.
+Public compatibility gates intentionally retain verified complete-session
+counts, exposed separately from admin package counts. No native telemetry or
+public status thresholds changed.
+
+### Admin custom IMG chart series — 2026-09-05 (historical implementation)
 
 The Overview chart adds a separately labelled green Custom .img series from
 successful, verified, complete compatibility operations whose provider is custom.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -377,13 +377,13 @@ def _diagnostic_summary_by_identity(
     grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
     for event in events:
         identity = _identity_group_key(event)
-        key = _operation_key(event)
+        key = str(event.get("event_id") or f"{_operation_key(event)}:{event.get('map_result_index', 0)}")
         if identity and key:
             grouped.setdefault(identity, {}).setdefault(key, []).append(event)
     resolved_grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
     for event in resolved_events or []:
         identity = _identity_group_key(event)
-        key = _operation_key(event)
+        key = str(event.get("event_id") or f"{_operation_key(event)}:{event.get('map_result_index', 0)}")
         if identity and key:
             resolved_grouped.setdefault(identity, {}).setdefault(key, []).append(event)
     for identity in set(grouped) | set(resolved_grouped):
@@ -1374,8 +1374,8 @@ def overview_page(
         <div class='heading-row overview-heading'><div><p class='eyebrow'>Operations</p><h1>Overview</h1><p class='lede'>Current Terento health and activity that needs attention.</p></div><form class='filter-bar overview-period-form' id='overview-period-form' method='get' action='/admin'><label><span class='sr-only'>Time period</span><select id='overview-period' name='period'>{period_options}</select></label></form></div>
         <p class='telemetry-scope-note'>User telemetry · Local tests excluded. <a href='/admin/test-data'>View test data →</a></p>
         <section class='overview-kpis' aria-label='Operational summary'>
-          <a class='overview-kpi' href='{html.escape(map_statistics_href, quote=True)}'><span>Map install operations</span><strong>{event_metric(completed_installs + failed_installs)}</strong><small>{'Install actions in this period' if has_map_data else 'No map telemetry in this period'}</small></a>
-          <a class='overview-kpi' href='{html.escape(map_statistics_href, quote=True)}'><span>Map operation success</span><strong>{success_rate}</strong><small>Successful install actions</small></a>
+          <a class='overview-kpi' href='/admin/installations'><span>Map install operations</span><strong>{event_metric(completed_installs + failed_installs)}</strong><small>{'Individual maps, including custom .img' if has_map_data else 'No map telemetry in this period'}</small></a>
+          <a class='overview-kpi' href='/admin/installations'><span>Map operation success</span><strong>{success_rate}</strong><small>Successful map results, including custom .img</small></a>
           <a class='overview-kpi overview-kpi-attention' href='{html.escape(failure_href, quote=True)}'><span>Failed map operations</span><strong>{event_metric(failed_installs)}</strong><small>{'Failed install actions in this period' if has_map_data else 'No map telemetry in this period'}</small></a>
           <a class='overview-kpi overview-kpi-attention' href='/admin/installations?state=open'><span>Open errors</span><strong>{open_error_metric(open_errors)}</strong><small>All unresolved compatibility errors</small></a>
           <a class='overview-kpi' href='/admin/providers'><span>Providers</span><strong>{healthy} / {provider_count}</strong><small>Healthy providers</small></a>
@@ -1686,7 +1686,7 @@ def dashboard_page(
     content = f"""
       {_admin_header(user, csrf_token, active='installations')}
       <main class="dashboard" id="main-content">
-        <div class="heading-row installation-heading"><div><p class="eyebrow">Compatibility</p><h1>Installations</h1><p class="lede">All-time compatibility evidence from Terento users. Each attempt is a watch installation that reached the transfer stage; it may contain several map packages.</p></div><p class="page-meta">{latest_copy}</p></div>
+        <div class="heading-row installation-heading"><div><p class="eyebrow">Compatibility</p><h1>Installations</h1><p class="lede">Each map installation counts as one attempt, including custom .img files. A session with two maps counts as two attempts. Compatibility status still uses complete verified sessions.</p></div><p class="page-meta">{latest_copy}</p></div>
         <p class='telemetry-scope-note'>User telemetry · Local tests excluded. <a href='/admin/test-data'>View test data →</a></p>
         <section class="admin-kpi-grid installation-kpis" aria-label="Installation summary">
           <article><span>Variants</span><strong>{len(rows)}</strong></article>
@@ -3162,7 +3162,7 @@ def device_detail_page(
         successful_install_count=successful,
         recognized_map_capable_evidence=device.get("mapCapable") is True,
     )
-    status_value = status.value if status else ""
+    status_value = device.get("evidenceStatus") or (status.value if status else "")
     last_activity = _timestamp_markup(stats.get("lastEvidenceAt")) if stats.get("lastEvidenceAt") else "—"
     publication = device.get("publicCompatibility") or {}
     map_label, map_kind = _admin_map_capability(device.get("mapCapable"))
@@ -3365,11 +3365,12 @@ def diagnostics_page(
     diagnostic_groups.extend((key, results, True) for key, results in resolved_groups.items())
     diagnostic_groups.sort(key=lambda item: _timestamp_iso(item[1][0].get("occurred_at")), reverse=True)
     model, variant = _display_identity(identity, model_row)
-    attempts = int(model_row.get("attempted_install_count") or 0) if model_row else len(active_groups) + len(resolved_groups)
-    successes = int(model_row.get("successful_install_count") or 0) if model_row else sum(
-        1 for results in list(active_groups.values()) + list(resolved_groups.values())
-        if _operation_result(results) == "SUCCEEDED"
-    )
+    result_summary = _diagnostic_summary_by_identity(active_events, resolved_events)
+    attempts = sum(item["attempts"] for item in result_summary.values())
+    successes = sum(item["successful"] for item in result_summary.values())
+    if not active_events and not resolved_events and model_row:
+        attempts = int(model_row.get("attempted_install_count") or 0)
+        successes = int(model_row.get("successful_install_count") or 0)
     errors = sum(1 for results in active_diagnostics.values() if _operation_is_problematic(results))
     status = _row_compatibility_status(model_row) if model_row else None
     filters = """<label><span class='sr-only'>Filter installation history</span><select id='diagnostic-state-filter'><option value='all' selected>All</option><option value='succeeded'>Successful</option><option value='failed'>Failed</option><option value='open'>Open</option><option value='resolved'>Resolved</option><option value='identity-pending'>Identity review</option><option value='with-issue'>With issue</option></select></label><button type='button' class='secondary-button filter-clear' data-filter-clear aria-label='Clear diagnostic filters'>Clear</button>"""
@@ -3475,7 +3476,7 @@ def _admin_device_payload(
             # evidence that the catalog classifier has not learned yet.
             map_capable = True
         evidence_status = calculate_compatibility_status(
-            successful_install_count=successful,
+            successful_install_count=int(row.get("compatibility_successful_install_count", successful) or 0),
             recognized_map_capable_evidence=map_capable is True,
         )
         authorization_label, _, authorization_code = _admin_installation_authorization(

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -577,7 +577,7 @@ class Database:
         """Return bounded operational aggregates for the authenticated Overview.
 
         This deliberately uses the existing compatibility evidence table and
-        groups rows by the persisted operation identity before counting. It
+        counts each retained map result independently of its batch identity. It
         does not create telemetry, alter the public API, or pretend that the
         compatibility and map-operation success rates are interchangeable.
         """
@@ -610,12 +610,12 @@ class Database:
                         WHERE e.error_category IS NOT NULL AND btrim(e.error_category) <> ''
                     ) AS error_category,
                     max(e.occurred_at) AS last_occurred_at,
-                    bool_or(COALESCE(e.write_started, TRUE)) AS write_started,
+                    bool_or(COALESCE(e.write_started, TRUE) OR
+                        e.phase_outcome IN ('SUCCEEDED', 'FAILED')) AS write_started,
                     bool_and(
                         e.phase_outcome = 'SUCCEEDED'
                         AND e.automatic_finishing_result = 'VERIFIED'
                     )
-                    AND count(*) = max(COALESCE(e.selected_map_count, 1))
                         AS operation_succeeded,
                     bool_or(e.phase_outcome = 'FAILED') AS has_failed,
                     bool_or(e.phase_outcome = 'NOT_STARTED') AS has_not_started,
@@ -634,7 +634,7 @@ class Database:
                     ) AS open_error
                 FROM compatibility_evidence_event AS e
                 WHERE e.is_local_test IS NOT TRUE
-                GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
+                GROUP BY e.event_id
             )
         """
         scoped = f"{operation_cte}, scoped_operations AS (\n                SELECT *\n                FROM operation_rows\n                WHERE last_occurred_at >= %s\n            )"
@@ -807,10 +807,10 @@ class Database:
         """Return map-operation aggregates for the authenticated Overview.
 
         The native map-event stream and compatibility evidence share the same
-        random operation ID when both are available. A successful compatibility
-        operation is used as a display-only fallback when its map event was not
-        uploaded, while custom IMG evidence remains a separately labelled chart
-        series and is excluded from provider KPI totals.
+        random operation ID when both are available. Match provider and region
+        within that session before suppressing a compatibility result. Custom
+        IMG results count in Overview totals and their own success chart series,
+        but never in the catalog-only Map statistics page. No records are changed.
         """
         # Keep the date_trunc field as a trusted SQL literal. PostgreSQL can
         # resolve a bound value here in some driver/server combinations, but
@@ -859,28 +859,24 @@ class Database:
         compatibility_fallback_cte = """
             WITH compatibility_fallback AS (
                 SELECT
-                    COALESCE(e.operation_id::text, 'compatibility:' || e.event_id::text)
-                        AS operation_key,
+                    e.event_id::text AS operation_key,
                     e.operation_id,
-                    min(e.provider) AS provider_id,
-                    CASE WHEN count(DISTINCT e.region) = 1 THEN min(e.region) END AS region,
-                    max(e.occurred_at) AS occurred_at
+                    e.provider AS provider_id,
+                    e.region,
+                    e.occurred_at,
+                    e.phase_outcome AS outcome
                 FROM compatibility_evidence_event AS e
                 WHERE e.is_local_test IS NOT TRUE
-                GROUP BY
-                    COALESCE(e.operation_id::text, 'compatibility:' || e.event_id::text),
-                    e.operation_id,
-                    CASE WHEN e.operation_id IS NULL THEN e.event_id END
-                HAVING max(e.occurred_at) >= %s
-                   AND bool_and(
+                   AND e.occurred_at >= %s
+                   AND (e.phase_outcome = 'FAILED' OR (
                        e.phase_outcome = 'SUCCEEDED'
-                       AND e.automatic_finishing_result = 'VERIFIED'
-                   )
-                   AND count(*) = max(COALESCE(e.selected_map_count, 1))
+                       AND e.automatic_finishing_result = 'VERIFIED'))
                    AND NOT EXISTS (
                        SELECT 1
                        FROM map_download_event AS installed
                        WHERE installed.operation_id = e.operation_id
+                         AND installed.provider_id = e.provider
+                         AND installed.region IS NOT DISTINCT FROM e.region
                          AND installed.is_local_test IS NOT TRUE
                          AND installed.event_type IN ('INSTALL_SUCCEEDED', 'INSTALL_FAILED')
                    )
@@ -893,19 +889,19 @@ class Database:
                 SELECT
                     count(*) + (
                         SELECT count(*) FROM compatibility_fallback
-                        WHERE provider_id <> 'custom'
                     ) AS event_count,
-                    count(DISTINCT e.operation_id) FILTER (
+                    count(*) FILTER (
                         WHERE e.event_type = 'INSTALL_SUCCEEDED'
                           AND e.outcome = 'SUCCEEDED'
                     ) + (
                         SELECT count(*) FROM compatibility_fallback
-                        WHERE provider_id <> 'custom'
+                        WHERE outcome = 'SUCCEEDED'
                     ) AS completed_install_count,
-                    count(DISTINCT e.operation_id) FILTER (
+                    count(*) FILTER (
                         WHERE e.event_type = 'INSTALL_FAILED'
                           AND e.outcome = 'FAILED'
-                    ) AS failed_install_count
+                    ) + (SELECT count(*) FROM compatibility_fallback
+                         WHERE outcome = 'FAILED') AS failed_install_count
                 {event_scope}
                 """,
                 (since, since),
@@ -935,13 +931,13 @@ class Database:
                     c.region AS map_package_name,
                     COALESCE(c.region, 'Multiple map regions') AS display_name,
                     c.region AS region,
-                    'INSTALL_SUCCEEDED' AS event_type,
-                    'SUCCEEDED' AS outcome,
+                    CASE WHEN c.outcome = 'FAILED' THEN 'INSTALL_FAILED'
+                         ELSE 'INSTALL_SUCCEEDED' END AS event_type,
+                    c.outcome,
                     NULL AS app_build,
                     c.occurred_at
                 FROM compatibility_fallback AS c
                 LEFT JOIN map_provider AS p ON p.id = c.provider_id
-                WHERE c.provider_id <> 'custom'
                 ORDER BY occurred_at DESC
                 LIMIT %s
                 """,
@@ -955,7 +951,7 @@ class Database:
                 f"""
                 {compatibility_fallback_cte}, localized_events AS (
                     SELECT
-                        e.operation_id::text AS operation_key,
+                        e.event_id::text AS operation_key,
                         e.event_type,
                         e.outcome,
                         timezone(%s, e.occurred_at) AS local_occurred_at
@@ -965,11 +961,12 @@ class Database:
                     UNION ALL
                     SELECT
                         c.operation_key,
-                        CASE WHEN c.provider_id = 'custom'
+                        CASE WHEN c.outcome = 'FAILED' THEN 'INSTALL_FAILED'
+                            WHEN c.provider_id = 'custom'
                             THEN 'CUSTOM_SUCCEEDED'
                             ELSE 'INSTALL_SUCCEEDED'
                         END AS event_type,
-                        'SUCCEEDED' AS outcome,
+                        c.outcome,
                         timezone(%s, c.occurred_at) AS local_occurred_at
                     FROM compatibility_fallback AS c
                 )
@@ -2596,8 +2593,8 @@ class Database:
         """Build the provider-only compatibility fallback filter.
 
         Compatibility evidence has no package ID by design. A package filter
-        therefore cannot safely claim a match, and only complete successful
-        install operations can be projected into map statistics.
+        therefore cannot safely claim a match. Only final failed or verified
+        successful map results can be projected into map statistics.
         """
         clauses = [
             f"{alias}.is_local_test IS NOT TRUE",
@@ -2612,8 +2609,12 @@ class Database:
         if filters.get("region"):
             clauses.append(f"{alias}.region = %s")
             values.append(filters["region"])
-        if filters.get("eventType") and filters["eventType"] != "INSTALL_SUCCEEDED":
-            clauses.append("1 = 0")
+        if filters.get("eventType"):
+            if filters["eventType"] in {"INSTALL_SUCCEEDED", "INSTALL_FAILED"}:
+                clauses.append(f"{alias}.phase_outcome = %s")
+                values.append("FAILED" if filters["eventType"] == "INSTALL_FAILED" else "SUCCEEDED")
+            else:
+                clauses.append("1 = 0")
         for key, operator in (("dateFrom", ">="), ("dateTo", "<=")):
             if filters.get(key):
                 clauses.append(f"{alias}.occurred_at {operator} %s")
@@ -2632,39 +2633,33 @@ class Database:
         query = f"""
             WITH complete_compatibility_operations AS (
                 SELECT
-                    COALESCE(e.operation_id::text, 'compatibility:' || e.event_id::text)
-                        AS operation_key,
-                    e.operation_id
+                    e.event_id::text AS operation_key,
+                    e.operation_id, e.event_id
                 FROM compatibility_evidence_event AS e
                 WHERE e.is_local_test IS NOT TRUE
-                GROUP BY
-                    COALESCE(e.operation_id::text, 'compatibility:' || e.event_id::text),
-                    e.operation_id,
-                    CASE WHEN e.operation_id IS NULL THEN e.event_id END
-                HAVING bool_and(
+                AND (e.phase_outcome = 'FAILED' OR (
                     e.phase_outcome = 'SUCCEEDED'
-                    AND e.automatic_finishing_result = 'VERIFIED'
-                )
-                AND count(*) = max(COALESCE(e.selected_map_count, 1))
+                    AND e.automatic_finishing_result = 'VERIFIED'))
                 AND NOT EXISTS (
                     SELECT 1
                     FROM map_download_event AS installed
                     WHERE installed.operation_id = e.operation_id
+                      AND installed.provider_id = e.provider
+                      AND installed.region IS NOT DISTINCT FROM e.region
                       AND installed.is_local_test IS NOT TRUE
                       AND installed.event_type IN ('INSTALL_SUCCEEDED', 'INSTALL_FAILED')
                 )
             ), compatibility_fallback AS (
-                -- Validate the complete operation before applying region/date
-                -- filters. Preserve each provider/region rather than min(region).
+                -- Each retained map result counts independently of its siblings.
                 SELECT c.operation_key, e.provider AS provider_id, e.region,
+                       e.phase_outcome AS outcome,
                        min(e.occurred_at) AS first_occurred_at,
                        max(e.occurred_at) AS last_occurred_at
                 FROM complete_compatibility_operations AS c
                 JOIN compatibility_evidence_event AS e
-                  ON COALESCE(e.operation_id::text, 'compatibility:' || e.event_id::text)
-                     = c.operation_key
+                  ON e.event_id = c.event_id
                 WHERE {' AND '.join(compatibility_clauses)}
-                GROUP BY c.operation_key, e.provider, e.region
+                GROUP BY c.operation_key, e.provider, e.region, e.phase_outcome
             ), event_rows AS (
                 SELECT
                     COALESCE(e.operation_id::text, e.event_id::text) AS operation_key,
@@ -2692,8 +2687,9 @@ class Database:
                     COALESCE(c.region, mp.region) AS region,
                     mp.canonical_region_id,
                     mp.country AS region_country,
-                    'INSTALL_SUCCEEDED' AS event_type,
-                    'SUCCEEDED' AS outcome,
+                    CASE WHEN c.outcome = 'FAILED' THEN 'INSTALL_FAILED'
+                         ELSE 'INSTALL_SUCCEEDED' END AS event_type,
+                    c.outcome,
                     c.last_occurred_at AS occurred_at
                 FROM compatibility_fallback AS c
                 LEFT JOIN map_provider AS p ON p.id = c.provider_id
@@ -3089,6 +3085,7 @@ class Database:
                 COALESCE(usb.identities, '[]'::jsonb) AS usb_identities,
                 COALESCE(evidence.attempts, 0) AS attempted_install_count,
                 COALESCE(evidence.successful, 0) AS successful_install_count,
+                COALESCE(public_review.successful_install_count, 0) AS compatibility_successful_install_count,
                 COALESCE(evidence.failed, 0) AS failed_install_count,
                 evidence.first_success,
                 evidence.last_success,
@@ -3130,34 +3127,33 @@ class Database:
             ) AS usb ON TRUE
             LEFT JOIN LATERAL (
                 SELECT
-                    count(*) FILTER (
-                        WHERE o.operation_succeeded OR o.received_at >= epoch.starts_at
-                    ) AS attempts,
+                    count(*) AS attempts,
                     count(*) FILTER (WHERE o.operation_succeeded) AS successful,
                     count(*) FILTER (
-                        WHERE NOT o.operation_succeeded AND o.received_at >= epoch.starts_at
+                        WHERE o.has_failed
                     ) AS failed,
                     min(o.occurred_at) FILTER (WHERE o.operation_succeeded) AS first_success,
                     max(o.occurred_at) FILTER (WHERE o.operation_succeeded) AS last_success,
-                    max(o.occurred_at) FILTER (
-                        WHERE o.operation_succeeded OR o.received_at >= epoch.starts_at
-                    ) AS last_evidence
+                    max(o.occurred_at) AS last_evidence
                 FROM (
                     SELECT
                         COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text) AS operation_key,
                         bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED')
-                            AND count(*) = max(COALESCE(e.selected_map_count, 1)) AS operation_succeeded,
+                            AS operation_succeeded,
+                        bool_or(e.phase_outcome = 'FAILED') AS has_failed,
                         min(e.occurred_at) AS occurred_at,
                         min(e.received_at) AS received_at
                     FROM compatibility_evidence_event AS e
                     WHERE e.canonical_device_model_id = dm.id
                       AND e.is_local_test IS NOT TRUE
-                    GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)
+                      AND (COALESCE(e.write_started, TRUE)
+                           OR e.phase_outcome IN ('SUCCEEDED', 'FAILED'))
+                    GROUP BY e.event_id
                 ) AS o
-                CROSS JOIN compatibility_device_card_failure_epoch AS epoch
             ) AS evidence ON TRUE
             LEFT JOIN LATERAL (
                 SELECT s.compatibility_identity, s.review_status,
+                       s.successful_install_count,
                        s.public_statistics_enabled, s.public_display_name,
                        s.last_evidence
                 FROM compatibility_model_statistics AS s

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -223,10 +223,11 @@ class AdminAuditTests(unittest.TestCase):
             def connection(self): yield Connection()
         QueryDatabase('unused').map_statistics({'region':'SVN+'})
         query, parameters = calls[0]
-        # Region filtering cannot turn one result of an incomplete two-map
-        # operation into a complete install, or drop its other map region.
+        # A verified result is counted even if its sibling is missing/failed.
         complete, filtered = query.split('), compatibility_fallback AS (', 1)
-        self.assertIn("count(*) = max(COALESCE(e.selected_map_count, 1))", complete)
+        self.assertIn("e.event_id::text AS operation_key", complete)
+        self.assertIn("installed.provider_id = e.provider", complete)
+        self.assertNotIn("selected_map_count", complete)
         self.assertIn('installed.is_local_test IS NOT TRUE', complete)
         self.assertNotIn('e.region = %s', complete)
         self.assertIn('e.region = %s', filtered)

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -798,10 +798,11 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("AT TIME ZONE %s", trend_query)
         self.assertNotIn("date_trunc(%s", trend_query)
         self.assertEqual(trend_parameters, (since, "UTC", since, "UTC", "UTC"))
-        self.assertIn("CASE WHEN c.provider_id = 'custom'", trend_query)
+        self.assertIn("WHEN c.provider_id = 'custom'", trend_query)
         self.assertIn("NOT EXISTS", trend_query)
         self.assertIn("AS custom_count", trend_query)
-        self.assertIn("AND count(*) = max(COALESCE(e.selected_map_count, 1))", trend_query)
+        self.assertNotIn("selected_map_count", trend_query)
+        self.assertIn("installed.provider_id = e.provider", trend_query)
 
     def test_installation_authorization_is_separate_from_compatibility_evidence(self):
         source = inspect.getsource(Database.update_device_support_status)
@@ -970,15 +971,15 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertEqual(audit_call[1][6], "Exact model confirmed")
         self.assertFalse(any("phase_outcome" in query for query, _ in database.calls if "UPDATE compatibility_evidence_event" in query))
 
-    def test_operation_level_aggregation_is_shared_by_admin_and_current_view(self):
+    def test_admin_result_counts_are_separate_from_public_session_gate(self):
         db_source = inspect.getsource(Database.admin_device_snapshot)
         migration = CURRENT_MIGRATION.read_text(encoding="utf-8")
         operation_group = "GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)"
-        self.assertIn(operation_group, db_source)
-        self.assertIn("compatibility_device_card_failure_epoch AS epoch", db_source)
-        self.assertIn("WHERE o.operation_succeeded OR o.received_at >= epoch.starts_at", db_source)
+        self.assertNotIn(operation_group, db_source)
+        self.assertNotIn("compatibility_device_card_failure_epoch AS epoch", db_source)
+        self.assertIn("GROUP BY e.event_id", db_source)
         self.assertIn(
-            "WHERE NOT o.operation_succeeded AND o.received_at >= epoch.starts_at",
+            "WHERE o.has_failed",
             db_source,
         )
         self.assertNotIn("e.diagnostic_status = 'ACTIVE'", db_source)

--- a/backend/catalog-api/tests/test_compatibility_evidence.py
+++ b/backend/catalog-api/tests/test_compatibility_evidence.py
@@ -499,7 +499,7 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         rendered = body.decode()
         self.assertIn("fēnix 7 Pro", rendered)
         self.assertNotIn("custom-installation-indicator", rendered)
-        self.assertIn("All-time compatibility evidence from Terento users.", rendered)
+        self.assertIn("Each map installation counts as one attempt", rendered)
         self.assertNotIn("Map install operations", rendered)
 
     def test_database_binds_omitted_optional_fields_as_null(self):
@@ -554,7 +554,7 @@ class CompatibilityEvidenceTests(unittest.TestCase):
         }
         body = dashboard_page([row], {"username": "gediminas"}, "csrf", public_stats_enabled=True).decode()
         self.assertIn("Installations", body)
-        self.assertIn("All-time compatibility evidence from Terento users.", body)
+        self.assertIn("Each map installation counts as one attempt", body)
         self.assertIn('class="admin-kpi-grid installation-kpis"', body)
         self.assertIn("<span>Installation attempts</span><strong>1</strong>", body)
         self.assertIn('class="filter-bar admin-filter-bar"', body)

--- a/backend/catalog-api/tests/test_installation_result_counts.py
+++ b/backend/catalog-api/tests/test_installation_result_counts.py
@@ -1,0 +1,44 @@
+"""The batch is correlation context, never the admin attempt denominator."""
+import unittest
+from terento_catalog.admin import _diagnostic_summary_by_identity, _group_operations
+
+
+class InstallationResultCountsTests(unittest.TestCase):
+    def events(self):
+        return [dict(event_id=f'result-{index}', operation_id='mixed-session',
+                     compatibility_identity='Test watch', map_result_index=index,
+                     selected_map_count=2, provider=provider, write_started=True,
+                     phase_outcome='SUCCEEDED', automatic_finishing_result='VERIFIED')
+                for index, provider in enumerate(('custom', 'opentopomap'))]
+
+    def summary(self, events, resolved=None):
+        return next(iter(_diagnostic_summary_by_identity(events, resolved).values()))
+
+    def test_mixed_session_is_two_successes_but_one_diagnostic_group(self):
+        events = self.events()
+        summary = self.summary(events)
+        self.assertEqual((summary['attempts'], summary['successful'], summary['failed']), (2, 2, 0))
+        self.assertEqual(len(_group_operations(events)), 1)
+
+    def test_failed_sibling_does_not_cancel_success(self):
+        events = self.events()
+        events[1].update(phase_outcome='FAILED', automatic_finishing_result='FAILED')
+        summary = self.summary(events)
+        self.assertEqual((summary['attempts'], summary['successful'], summary['failed']), (2, 1, 1))
+
+    def test_duplicate_delivery_does_not_add_attempts(self):
+        events = self.events()
+        self.assertEqual(self.summary(events + events)['attempts'], 2)
+
+    def test_resolved_failures_remain_in_denominator(self):
+        events = self.events()
+        for event in events:
+            event.update(phase_outcome='FAILED', diagnostic_status='RESOLVED')
+        summary = self.summary([], events)
+        self.assertEqual((summary['attempts'], summary['failed'], summary['open_errors']), (2, 2, 0))
+
+    def test_missing_or_not_started_sibling_is_not_invented(self):
+        events = self.events()
+        self.assertEqual(self.summary(events[:1])['attempts'], 1)
+        events[1].update(phase_outcome='NOT_STARTED', write_started=False)
+        self.assertEqual(self.summary(events)['attempts'], 1)

--- a/backend/catalog-api/tools/check_catalog_database.py
+++ b/backend/catalog-api/tools/check_catalog_database.py
@@ -25,3 +25,67 @@ assert database.admin_overview_map_snapshot(now, time_zone='Europe/Vilnius') is 
 assert database.provider_detail('opentopomap') is not None
 assert [row['source_url'] for row in database.provider_download_urls('opentopomap')] == [main.source_url]
 print('PASS: PostgreSQL snapshot update, source proof, main compatibility fields and Overview SQL')
+
+# Synthetic results only in the explicitly guarded disposable CI database.
+# Reproduce the retained mixed custom + catalog session without production data.
+from uuid import uuid4
+from datetime import timedelta
+operation_id = uuid4()
+with database.connection() as connection:
+    device = connection.execute('SELECT id FROM device_model ORDER BY id LIMIT 1').fetchone()['id']
+    for index, provider in enumerate(('custom', 'opentopomap')):
+        connection.execute('''
+            INSERT INTO compatibility_evidence_event
+                (event_id, operation_id, map_result_index, selected_map_count,
+                 occurred_at, model, compatibility_identity, canonical_device_model_id,
+                 usb_vendor_id, usb_product_id, transport, provider, region,
+                 map_release, terento_version, macos_version, phase_outcome,
+                 automatic_finishing_result, write_started)
+            VALUES (%s,%s,%s,2,%s,'CI watch','CI watch',%s,2334,1,'MTP',%s,%s,
+                    '2026-05','1.0.0','26','SUCCEEDED','VERIFIED',true)
+        ''', (uuid4(), operation_id, index, now, device, provider,
+              'custom' if provider == 'custom' else 'ANDORRA'))
+    connection.execute('''
+        INSERT INTO map_download_event
+            (event_id,operation_id,provider_id,map_package_id,region,event_type,outcome,occurred_at)
+        VALUES (%s,%s,'opentopomap','opentopomap-andorra','ANDORRA',
+                'INSTALL_SUCCEEDED','SUCCEEDED',%s)
+    ''', (uuid4(), operation_id, now))
+since = now - timedelta(seconds=1)
+overview = database.admin_overview_map_snapshot(since, time_zone='Europe/Vilnius')
+assert overview['completedInstallCount'] == 2, overview
+assert sum(row['success_count'] for row in overview['trend']) == 1
+assert sum(row['custom_count'] for row in overview['trend']) == 1
+assert database.admin_overview_snapshot(since)['successfulInstallCount'] == 2
+statistics = database.map_statistics({})
+assert sum(row['operation_count'] for row in statistics if row['event_type'] == 'INSTALL_SUCCEEDED') == 1
+devices, _ = database.admin_device_snapshot()
+watch = next(row for row in devices if row['device_id'] == device)
+assert watch['attempted_install_count'] == 2 and watch['successful_install_count'] == 2, watch
+assert watch['compatibility_successful_install_count'] == 1, watch
+print('PASS: mixed session = two admin successes, one catalog success, one custom chart result; public session gate unchanged')
+
+with database.connection() as connection:
+    connection.execute("UPDATE compatibility_evidence_event SET phase_outcome='FAILED', automatic_finishing_result='FAILED' WHERE operation_id=%s AND provider='custom'", (operation_id,))
+overview = database.admin_overview_map_snapshot(since)
+assert (overview['completedInstallCount'], overview['failedInstallCount']) == (1, 1)
+assert sum(row['failed_count'] for row in overview['trend']) == 1
+assert sum(row['custom_count'] for row in overview['trend']) == 0
+devices, _ = database.admin_device_snapshot()
+watch = next(row for row in devices if row['device_id'] == device)
+assert (watch['attempted_install_count'], watch['successful_install_count'], watch['failed_install_count']) == (2, 1, 1)
+with database.connection() as connection:
+    connection.execute("UPDATE compatibility_evidence_event SET is_local_test=true WHERE operation_id=%s AND provider='custom'", (operation_id,))
+    connection.execute("UPDATE map_download_event SET is_local_test=true WHERE operation_id=%s", (operation_id,))
+    connection.execute("UPDATE compatibility_evidence_event SET selected_map_count=3 WHERE operation_id=%s", (operation_id,))
+overview = database.admin_overview_map_snapshot(since)
+assert (overview['completedInstallCount'], overview['failedInstallCount']) == (1, 0)
+statistics = database.map_statistics({})
+assert sum(row['operation_count'] for row in statistics if row['event_type'] == 'INSTALL_SUCCEEDED') == 1
+print('PASS: partial failure, local exclusion and missing sibling retain independent result counts')
+with database.connection() as connection:
+    connection.execute("UPDATE compatibility_evidence_event SET phase_outcome='FAILED', automatic_finishing_result='FAILED' WHERE operation_id=%s AND provider='opentopomap'", (operation_id,))
+statistics = database.map_statistics({'eventType': 'INSTALL_FAILED'})
+assert sum(row['operation_count'] for row in statistics) == 1, statistics
+assert database.map_statistics({'eventType': 'INSTALL_SUCCEEDED'}) == []
+print('PASS: catalog failure fallback respects outcome filters')


### PR DESCRIPTION
Counts each retained map result in admin Installations, watch counters and Overview. Reconciles catalog events per session/provider/region so a custom sibling is not suppressed. Catalog statistics excludes custom; public compatibility session gates stay unchanged. No telemetry rewrite. Verified with 285 local unit tests and disposable PostgreSQL migration and mixed-result integration tests. Owner requested deployment after required checks.