### PR TITLE
Align admin result-count status and custom navigation

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -321,7 +321,12 @@ and 390 px, the mobile menu, and automatic resolution of the two active
 diagnostics linked to closed GitHub issue #94. Historical failure results were
 retained. Deployment workflow: https://github.com/VooZ2/terento/actions/runs/33925498939.
 
-### Admin installation counting — 2026-09-10 (local, not deployed)
+### Admin installation counting — 2026-09-10
+
+Initial counting change published in PR #147. Follow-up keeps the table status
+on the same complete-session basis as the device card, directs custom activity
+to Installations rather than catalog-only statistics, and corrects the device
+counter help text. Regression tests explicitly cover these display contracts.
 
 Admin attempts count retained map results, not batch/session IDs: a custom IMG
 plus OTM session contributes two attempts and two successes when both verify.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1041,6 +1041,8 @@ def _admin_map_display_name(*values: Any) -> str:
 
 
 def _overview_map_event_context(event: dict[str, Any]) -> str:
+    if event.get("provider_id") == "custom":
+        return "Custom .img"
     display_name = _admin_map_display_name(
         event.get("display_name")
         or event.get("map_package_name")
@@ -1059,6 +1061,8 @@ def _overview_map_event_context(event: dict[str, Any]) -> str:
 
 
 def _overview_map_event_href(event: dict[str, Any]) -> str:
+    if event.get("provider_id") == "custom":
+        return "/admin/installations"
     parameters = {
         "eventType": str(event.get("event_type") or ""),
         "provider": str(event.get("provider_id") or ""),
@@ -3297,7 +3301,7 @@ def device_detail_page(
       <main class='dashboard model-detail-page' id='main-content'>
         <p class='back-link'><a href='{back_href}'>{_admin_icon('arrow-left')} {back_label}</a></p>
         <header class='model-page-header'>{image}<div class='model-page-heading'><p class='eyebrow'>Garmin device</p><h1>{html.escape(model)}{f' · <span>{html.escape(variant)}</span>' if variant != '—' else ''}</h1><div class='model-page-badges'>{summary_badges}</div></div>{public_link}</header>
-        <section class='diagnostic-model-metrics model-statistics' aria-label='Model installation statistics'><article class='attempts-metric' aria-label='Attempts. Successful history plus failures received since the device counter baseline. Resolved failures are counted once.' title='Device snapshot totals information: successful history plus failures since the counter baseline; resolved failures count once. Installations uses write-started evidence.'><span>Attempts</span><strong>{attempts}</strong></article><article><span>Successful</span><strong>{successful}</strong></article><article><span>Failed</span><strong>{failed}</strong></article><article><span>Open errors</span><strong>{open_errors}</strong></article><article class='timestamp-metric'><span>Last activity</span><strong>{last_activity}</strong></article></section>
+        <section class='diagnostic-model-metrics model-statistics' aria-label='Model installation statistics'><article class='attempts-metric' aria-label='Attempts. Each map result counts once, including custom .img and resolved failures.' title='Each map installation counts separately. Compatibility status uses complete verified sessions.'><span>Attempts</span><strong>{attempts}</strong></article><article><span>Successful</span><strong>{successful}</strong></article><article><span>Failed</span><strong>{failed}</strong></article><article><span>Open errors</span><strong>{open_errors}</strong></article><article class='timestamp-metric'><span>Last activity</span><strong>{last_activity}</strong></article></section>
         {alert}
         <section class='diagnostics-detail-section model-page-section' id='installations' aria-labelledby='installation-history-title'>
           <div class='section-heading'><div><p class='section-kicker'>Operational history</p><h2 id='installation-history-title'>Installation history</h2></div><p class='table-help'>Failed results remain historical after their error is resolved.</p></div>
@@ -3808,7 +3812,7 @@ def _statistics_row(
     successful = int(summary["successful"]) if "successful" in summary else int(row.get("successful_install_count") or 0)
     failed = int(summary["failed"]) if "failed" in summary else int(row.get("failed_install_count") or 0)
     open_errors = int(summary.get("open_errors") or 0)
-    status_value = _row_compatibility_status({**row, "successful_install_count": successful})
+    status_value = _row_compatibility_status(row)
     status = status_value.value if status_value else ""
     search_text = " ".join((model, variant, str(row.get("family") or ""), identity)).strip()
     activity = max((_timestamp_iso(row.get(key)) for key in ("last_success", "last_failure", "last_evidence")), default="")

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -1816,7 +1816,7 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("SEND_OBJECT_FAILED", body)
         self.assertIn("Failure reason:", body)
         self.assertIn("data-history-filter='failed'", body)
-        self.assertIn("Device snapshot totals information", body)
+        self.assertIn("Each map installation counts separately", body)
         self.assertIn("maxlength='500'", body)
         self.assertIn("link.closest('.github-issue-controls, .github-review')", body)
         self.assertNotIn("\x08", body)

--- a/backend/catalog-api/tests/test_installation_result_counts.py
+++ b/backend/catalog-api/tests/test_installation_result_counts.py
@@ -4,6 +4,20 @@ from terento_catalog.admin import _diagnostic_summary_by_identity, _group_operat
 
 
 class InstallationResultCountsTests(unittest.TestCase):
+    def test_custom_activity_does_not_link_to_catalog_statistics(self):
+        from terento_catalog.admin import _overview_map_event_context, _overview_map_event_href
+        event = {'provider_id': 'custom', 'region': 'custom'}
+        self.assertEqual(_overview_map_event_context(event), 'Custom .img')
+        self.assertEqual(_overview_map_event_href(event), '/admin/installations')
+
+    def test_table_status_uses_sessions_not_package_summary(self):
+        from terento_catalog.admin import _statistics_row
+        markup = _statistics_row({'model': 'Watch', 'compatibility_identity': 'Watch',
+                                  'successful_install_count': 2, 'map_capable': True},
+                                 {'attempts': 3, 'successful': 3, 'failed': 0})
+        self.assertIn('Tested:', markup)
+        self.assertNotIn('Supported:', markup)
+
     def events(self):
         return [dict(event_id=f'result-{index}', operation_id='mixed-session',
                      compatibility_identity='Test watch', map_result_index=index,


### PR DESCRIPTION
Follow-up from authorized deployment verification: preserve complete-session status in the Installations table, route custom results to Installations and correct counter help text. Individual result counts unchanged. Local backend regression tests cover both display contracts.