### PR TITLE
Unify public and admin compatibility result counts

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -323,10 +323,10 @@ retained. Deployment workflow: https://github.com/VooZ2/terento/actions/runs/339
 
 ### Admin installation counting — 2026-09-10
 
-Initial counting change published in PR #147. Follow-up keeps the table status
-on the same complete-session basis as the device card, directs custom activity
-to Installations rather than catalog-only statistics, and corrects the device
-counter help text. Regression tests explicitly cover these display contracts.
+Initial counting changes published in PR #147 and #149. Migration 038 (local,
+not deployed) unifies public compatibility and admin counters and statuses on
+individual verified map results. Migration 037 is reserved for the parallel
+MapRando work; no existing migration is rewritten.
 
 Admin attempts count retained map results, not batch/session IDs: a custom IMG
 plus OTM session contributes two attempts and two successes when both verify.
@@ -339,9 +339,15 @@ Overview reconciles map events against compatibility results by session,
 provider and region. One catalog event cannot suppress a custom result or a
 different region. Map statistics remains catalog-only. Existing retained mixed
 sessions recalculate on read; no production event rewrite or backfill is needed.
-Public compatibility gates intentionally retain verified complete-session
-counts, exposed separately from admin package counts. No native telemetry or
-public status thresholds changed.
+The public API, watch cards and Installations use compatibility_model_statistics
+as the authoritative full-history source; the 500-row diagnostics display limit
+cannot truncate totals. A custom + catalog batch contributes two successes when
+both verify, even before other selected results arrive. Failed/unverified results
+never advance status. Thresholds remain 0 TESTING, 1–2 TESTED, 3–4 SUPPORTED,
+5+ VERIFIED. Local telemetry stays excluded, resolved failures stay in historical
+counts, and existing exact-model administrator publication approval is preserved.
+Native telemetry contracts, provider-only Map statistics and review actions are
+unchanged. These counts represent map installations, not unique users or watches.
 
 ### Admin custom IMG chart series — 2026-09-05 (historical implementation)
 

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1668,6 +1668,8 @@ def dashboard_page(
     )
     def metric(row: dict[str, Any], summary_key: str, row_key: str) -> int:
         summary = diagnostic_summary.get(_identity_group_key(row), {})
+        if row_key in row:
+            return int(row[row_key] or 0)
         return int(summary[summary_key]) if summary_key in summary else int(row.get(row_key) or 0)
 
     attempts = sum(metric(row, "attempts", "attempted_install_count") for row in rows)
@@ -1690,7 +1692,7 @@ def dashboard_page(
     content = f"""
       {_admin_header(user, csrf_token, active='installations')}
       <main class="dashboard" id="main-content">
-        <div class="heading-row installation-heading"><div><p class="eyebrow">Compatibility</p><h1>Installations</h1><p class="lede">Each map installation counts as one attempt, including custom .img files. A session with two maps counts as two attempts. Compatibility status still uses complete verified sessions.</p></div><p class="page-meta">{latest_copy}</p></div>
+        <div class="heading-row installation-heading"><div><p class="eyebrow">Compatibility</p><h1>Installations</h1><p class="lede">Each map installation counts as one attempt, including custom .img files. A session with two maps counts as two attempts. Verified successful map installations determine compatibility status.</p></div><p class="page-meta">{latest_copy}</p></div>
         <p class='telemetry-scope-note'>User telemetry · Local tests excluded. <a href='/admin/test-data'>View test data →</a></p>
         <section class="admin-kpi-grid installation-kpis" aria-label="Installation summary">
           <article><span>Variants</span><strong>{len(rows)}</strong></article>
@@ -3301,7 +3303,7 @@ def device_detail_page(
       <main class='dashboard model-detail-page' id='main-content'>
         <p class='back-link'><a href='{back_href}'>{_admin_icon('arrow-left')} {back_label}</a></p>
         <header class='model-page-header'>{image}<div class='model-page-heading'><p class='eyebrow'>Garmin device</p><h1>{html.escape(model)}{f' · <span>{html.escape(variant)}</span>' if variant != '—' else ''}</h1><div class='model-page-badges'>{summary_badges}</div></div>{public_link}</header>
-        <section class='diagnostic-model-metrics model-statistics' aria-label='Model installation statistics'><article class='attempts-metric' aria-label='Attempts. Each map result counts once, including custom .img and resolved failures.' title='Each map installation counts separately. Compatibility status uses complete verified sessions.'><span>Attempts</span><strong>{attempts}</strong></article><article><span>Successful</span><strong>{successful}</strong></article><article><span>Failed</span><strong>{failed}</strong></article><article><span>Open errors</span><strong>{open_errors}</strong></article><article class='timestamp-metric'><span>Last activity</span><strong>{last_activity}</strong></article></section>
+        <section class='diagnostic-model-metrics model-statistics' aria-label='Model installation statistics'><article class='attempts-metric' aria-label='Attempts. Each map result counts once, including custom .img and resolved failures.' title='Each map installation counts separately. Verified successful map installations determine compatibility status.'><span>Attempts</span><strong>{attempts}</strong></article><article><span>Successful</span><strong>{successful}</strong></article><article><span>Failed</span><strong>{failed}</strong></article><article><span>Open errors</span><strong>{open_errors}</strong></article><article class='timestamp-metric'><span>Last activity</span><strong>{last_activity}</strong></article></section>
         {alert}
         <section class='diagnostics-detail-section model-page-section' id='installations' aria-labelledby='installation-history-title'>
           <div class='section-heading'><div><p class='section-kicker'>Operational history</p><h2 id='installation-history-title'>Installation history</h2></div><p class='table-help'>Failed results remain historical after their error is resolved.</p></div>
@@ -3372,7 +3374,7 @@ def diagnostics_page(
     result_summary = _diagnostic_summary_by_identity(active_events, resolved_events)
     attempts = sum(item["attempts"] for item in result_summary.values())
     successes = sum(item["successful"] for item in result_summary.values())
-    if not active_events and not resolved_events and model_row:
+    if model_row:
         attempts = int(model_row.get("attempted_install_count") or 0)
         successes = int(model_row.get("successful_install_count") or 0)
     errors = sum(1 for results in active_diagnostics.values() if _operation_is_problematic(results))
@@ -3808,9 +3810,9 @@ def _statistics_row(
 ) -> str:
     model, variant, identity = _identity_parts(row)
     summary = diagnostic_summary or {}
-    attempted = int(summary["attempts"]) if "attempts" in summary else int(row.get("attempted_install_count") or 0)
-    successful = int(summary["successful"]) if "successful" in summary else int(row.get("successful_install_count") or 0)
-    failed = int(summary["failed"]) if "failed" in summary else int(row.get("failed_install_count") or 0)
+    attempted = int(row.get("attempted_install_count", summary.get("attempts", 0)) or 0)
+    successful = int(row.get("successful_install_count", summary.get("successful", 0)) or 0)
+    failed = int(row.get("failed_install_count", summary.get("failed", 0)) or 0)
     open_errors = int(summary.get("open_errors") or 0)
     status_value = _row_compatibility_status(row)
     status = status_value.value if status_value else ""

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -3127,29 +3127,17 @@ class Database:
             ) AS usb ON TRUE
             LEFT JOIN LATERAL (
                 SELECT
-                    count(*) AS attempts,
-                    count(*) FILTER (WHERE o.operation_succeeded) AS successful,
-                    count(*) FILTER (
-                        WHERE o.has_failed
-                    ) AS failed,
-                    min(o.occurred_at) FILTER (WHERE o.operation_succeeded) AS first_success,
-                    max(o.occurred_at) FILTER (WHERE o.operation_succeeded) AS last_success,
-                    max(o.occurred_at) AS last_evidence
-                FROM (
-                    SELECT
-                        COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text) AS operation_key,
-                        bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED')
-                            AS operation_succeeded,
-                        bool_or(e.phase_outcome = 'FAILED') AS has_failed,
-                        min(e.occurred_at) AS occurred_at,
-                        min(e.received_at) AS received_at
-                    FROM compatibility_evidence_event AS e
-                    WHERE e.canonical_device_model_id = dm.id
-                      AND e.is_local_test IS NOT TRUE
-                      AND (COALESCE(e.write_started, TRUE)
-                           OR e.phase_outcome IN ('SUCCEEDED', 'FAILED'))
-                    GROUP BY e.event_id
-                ) AS o
+                    s.attempted_install_count AS attempts,
+                    s.successful_install_count AS successful,
+                    s.failed_install_count AS failed,
+                    (SELECT min(e.occurred_at) FROM compatibility_evidence_event e
+                     WHERE e.canonical_device_model_id = dm.id
+                       AND e.is_local_test IS NOT TRUE AND e.diagnostic_status = 'ACTIVE'
+                       AND e.phase_outcome = 'SUCCEEDED'
+                       AND e.automatic_finishing_result = 'VERIFIED') AS first_success,
+                    s.last_success, s.last_evidence
+                FROM compatibility_model_statistics AS s
+                WHERE s.canonical_device_model_id = dm.id
             ) AS evidence ON TRUE
             LEFT JOIN LATERAL (
                 SELECT s.compatibility_identity, s.review_status,

--- a/backend/catalog-api/src/terento_catalog/migrations/038_individual_compatibility_results.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/038_individual_compatibility_results.sql
@@ -1,0 +1,119 @@
+-- One retained map result is one installation in admin and public evidence.
+-- Original events and approval records remain unchanged. Event-ID replay
+-- protection remains enforced by the ingestion primary key.
+CREATE OR REPLACE VIEW compatibility_model_statistics AS
+WITH normalized_events AS (
+    SELECT
+        e.*,
+        COALESCE(e.canonical_device_model_id, 'identity:' || e.compatibility_identity) AS aggregate_key,
+        e.event_id::text AS operation_key,
+        (COALESCE(e.write_started, true) OR e.phase_outcome IN ('SUCCEEDED', 'FAILED')) AS compatibility_write_started
+    FROM compatibility_evidence_event e
+    WHERE (e.diagnostic_status = 'ACTIVE' OR e.phase_outcome = 'FAILED')
+      AND e.is_local_test IS NOT TRUE
+),
+operation_stats AS (
+    SELECT
+        e.aggregate_key,
+        e.operation_key,
+        min(e.compatibility_identity) AS compatibility_identity,
+        min(e.model) AS model,
+        min(e.variant) FILTER (WHERE e.variant IS NOT NULL AND btrim(e.variant) <> '') AS variant,
+        min(e.case_size_mm) FILTER (WHERE e.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(e.display_type) FILTER (WHERE e.display_type IS NOT NULL AND btrim(e.display_type) <> '') AS display_type,
+        min(e.canonical_device_model_id) FILTER (WHERE e.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        bool_or(e.compatibility_write_started) AS write_started,
+        bool_and(e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS operation_succeeded,
+        bool_or(e.phase_outcome = 'FAILED') AS result_failed,
+        bool_or(e.reconnect_verified) AS reconnect_verified,
+        min(NULLIF(e.firmware_version, '')) AS successful_firmware_version,
+        min(e.occurred_at) AS occurred_at,
+        count(*) AS map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'SUCCEEDED' AND e.automatic_finishing_result = 'VERIFIED') AS successful_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'FAILED') AS failed_map_result_count,
+        count(*) FILTER (WHERE e.phase_outcome = 'NOT_STARTED') AS not_started_map_result_count
+    FROM normalized_events e
+    GROUP BY e.aggregate_key, e.operation_key
+),
+event_stats AS (
+    SELECT
+        o.aggregate_key,
+        min(o.compatibility_identity) AS compatibility_identity,
+        min(o.model) AS model,
+        min(o.variant) FILTER (WHERE o.variant IS NOT NULL) AS variant,
+        min(o.case_size_mm) FILTER (WHERE o.case_size_mm IS NOT NULL) AS case_size_mm,
+        min(o.display_type) FILTER (WHERE o.display_type IS NOT NULL) AS display_type,
+        min(o.canonical_device_model_id) FILTER (WHERE o.canonical_device_model_id IS NOT NULL) AS canonical_device_model_id,
+        string_agg(DISTINCT COALESCE(o.successful_firmware_version, 'unknown'), ', ' ORDER BY COALESCE(o.successful_firmware_version, 'unknown')) AS firmware_versions,
+        count(*) FILTER (WHERE o.write_started) AS attempted_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded) AS successful_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.operation_succeeded AND o.reconnect_verified) AS reconnect_verified_install_count,
+        count(*) FILTER (WHERE o.write_started AND o.result_failed) AS failed_install_count,
+        count(DISTINCT o.successful_firmware_version) FILTER (WHERE o.write_started AND o.operation_succeeded) AS firmware_version_count,
+        round(100.0 * count(*) FILTER (WHERE o.write_started AND o.operation_succeeded)
+            / NULLIF(count(*) FILTER (WHERE o.write_started), 0), 1) AS success_rate,
+        max(o.occurred_at) FILTER (WHERE o.write_started AND o.operation_succeeded) AS last_success,
+        max(o.occurred_at) FILTER (WHERE o.result_failed) AS last_failure,
+        max(o.occurred_at) AS last_evidence,
+        sum(o.map_result_count) AS map_result_count,
+        sum(o.successful_map_result_count) AS successful_map_result_count,
+        sum(o.failed_map_result_count) AS failed_map_result_count,
+        sum(o.not_started_map_result_count) AS not_started_map_result_count,
+        count(*) FILTER (WHERE NOT o.write_started) AS prewrite_failure_count
+    FROM operation_stats o
+    GROUP BY o.aggregate_key
+),
+error_stats AS (
+    SELECT
+        e.aggregate_key,
+        jsonb_object_agg(e.error_key, e.error_count) AS error_categories
+    FROM (
+        SELECT
+            n.aggregate_key,
+            COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown') AS error_key,
+            count(*) AS error_count
+        FROM normalized_events n
+        WHERE n.phase_outcome = 'FAILED'
+        GROUP BY n.aggregate_key, COALESCE(n.failure_stage || ':' || n.failure_code, n.error_category, 'unknown')
+    ) e
+    GROUP BY e.aggregate_key
+)
+SELECT
+    COALESCE(NULLIF(r.identity_key, ''), e.compatibility_identity) AS compatibility_identity,
+    e.model, e.variant, e.case_size_mm, e.display_type, e.canonical_device_model_id,
+    e.firmware_versions, e.attempted_install_count, e.successful_install_count,
+    e.reconnect_verified_install_count, e.failed_install_count, e.firmware_version_count,
+    e.success_rate, e.last_success, e.last_failure, e.last_evidence,
+    e.map_result_count, e.successful_map_result_count, e.failed_map_result_count,
+    e.not_started_map_result_count, e.prewrite_failure_count,
+    COALESCE(errors.error_categories, '{}'::jsonb) AS error_categories,
+    terento_compatibility_status(e.successful_install_count, dm.map_capable IS TRUE) AS calculated_status,
+    (dm.map_capable IS TRUE) AS recognized_map_capable_evidence,
+    COALESCE(r.physical_device_evidence_count, 0) AS physical_device_evidence_count,
+    COALESCE(r.review_notes, '') AS review_notes,
+    COALESCE(r.review_status, 'PENDING') AS review_status,
+    COALESCE(r.public_statistics_enabled, false) AS public_statistics_enabled,
+    COALESCE(NULLIF(r.public_display_name, ''), NULLIF(r.identity_key, ''), e.compatibility_identity) AS public_display_name
+FROM event_stats e
+LEFT JOIN error_stats errors ON errors.aggregate_key = e.aggregate_key
+LEFT JOIN device_model dm ON dm.id = e.canonical_device_model_id
+LEFT JOIN LATERAL (
+    SELECT review.*
+    FROM compatibility_model_review review
+    WHERE COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity
+       OR (
+            e.canonical_device_model_id IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM compatibility_evidence_event linked_event
+                WHERE linked_event.canonical_device_model_id = e.canonical_device_model_id
+                  AND linked_event.compatibility_identity = COALESCE(NULLIF(review.identity_key, ''), review.model)
+                  AND linked_event.is_local_test IS NOT TRUE
+            )
+       )
+    ORDER BY
+        (COALESCE(NULLIF(review.identity_key, ''), review.model) = e.compatibility_identity) DESC,
+        (review.review_status = 'APPROVED') DESC,
+        review.updated_at DESC
+    LIMIT 1
+) r ON true;

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -971,18 +971,18 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertEqual(audit_call[1][6], "Exact model confirmed")
         self.assertFalse(any("phase_outcome" in query for query, _ in database.calls if "UPDATE compatibility_evidence_event" in query))
 
-    def test_admin_result_counts_are_separate_from_public_session_gate(self):
+    def test_admin_result_counts_use_the_public_statistics_view(self):
         db_source = inspect.getsource(Database.admin_device_snapshot)
         migration = CURRENT_MIGRATION.read_text(encoding="utf-8")
         operation_group = "GROUP BY COALESCE(e.operation_id::text, 'legacy:' || e.event_id::text)"
         self.assertNotIn(operation_group, db_source)
         self.assertNotIn("compatibility_device_card_failure_epoch AS epoch", db_source)
-        self.assertIn("GROUP BY e.event_id", db_source)
+        self.assertIn("FROM compatibility_model_statistics AS s", db_source)
         self.assertIn(
-            "WHERE o.has_failed",
+            "s.failed_install_count AS failed",
             db_source,
         )
-        self.assertNotIn("e.diagnostic_status = 'ACTIVE'", db_source)
+        self.assertIn("s.attempted_install_count AS attempts", db_source)
         self.assertIn("operation_stats AS (", migration)
         self.assertIn("starts_at TIMESTAMPTZ NOT NULL DEFAULT now()", migration)
         self.assertIn("WHERE e.diagnostic_status = 'ACTIVE'", migration)
@@ -1121,10 +1121,10 @@ class AdminSemanticsTests(unittest.TestCase):
             "variant": "51 mm, AMOLED",
             "compatibility_identity": identity,
             "canonical_device_model_id": "garmin-fenix-8-51-amoled",
-            "attempted_install_count": 2,
+            "attempted_install_count": 3,
             "successful_install_count": 1,
-            "failed_install_count": 1,
-            "success_rate": 50,
+            "failed_install_count": 2,
+            "success_rate": 33.3,
             "recognized_map_capable_evidence": True,
             "last_success": "2026-08-25T16:04:00+00:00",
             "last_evidence": "2026-08-25T16:05:00+00:00",

--- a/backend/catalog-api/tests/test_installation_result_counts.py
+++ b/backend/catalog-api/tests/test_installation_result_counts.py
@@ -10,13 +10,22 @@ class InstallationResultCountsTests(unittest.TestCase):
         self.assertEqual(_overview_map_event_context(event), 'Custom .img')
         self.assertEqual(_overview_map_event_href(event), '/admin/installations')
 
-    def test_table_status_uses_sessions_not_package_summary(self):
+    def test_table_uses_authoritative_counts_not_bounded_diagnostics(self):
         from terento_catalog.admin import _statistics_row
         markup = _statistics_row({'model': 'Watch', 'compatibility_identity': 'Watch',
                                   'successful_install_count': 2, 'map_capable': True},
                                  {'attempts': 3, 'successful': 3, 'failed': 0})
         self.assertIn('Tested:', markup)
         self.assertNotIn('Supported:', markup)
+
+    def test_dashboard_full_history_is_not_limited_by_diagnostic_rows(self):
+        from terento_catalog.admin import dashboard_page
+        markup = dashboard_page([{'model': 'Test watch', 'compatibility_identity': 'Test watch',
+                                 'attempted_install_count': 601, 'successful_install_count': 601,
+                                 'failed_install_count': 0}], {'username': 'test'}, 'csrf',
+                                operations=self.events()).decode()
+        self.assertIn('<span>Installation attempts</span><strong>601</strong>', markup)
+        self.assertIn('<span>Successful</span><strong>601</strong>', markup)
 
     def events(self):
         return [dict(event_id=f'result-{index}', operation_id='mixed-session',

--- a/backend/catalog-api/tools/check_catalog_database.py
+++ b/backend/catalog-api/tools/check_catalog_database.py
@@ -62,8 +62,8 @@ assert sum(row['operation_count'] for row in statistics if row['event_type'] == 
 devices, _ = database.admin_device_snapshot()
 watch = next(row for row in devices if row['device_id'] == device)
 assert watch['attempted_install_count'] == 2 and watch['successful_install_count'] == 2, watch
-assert watch['compatibility_successful_install_count'] == 1, watch
-print('PASS: mixed session = two admin successes, one catalog success, one custom chart result; public session gate unchanged')
+assert watch['compatibility_successful_install_count'] == 2, watch
+print('PASS: mixed session = two shared compatibility successes, one catalog success, one custom chart result')
 
 with database.connection() as connection:
     connection.execute("UPDATE compatibility_evidence_event SET phase_outcome='FAILED', automatic_finishing_result='FAILED' WHERE operation_id=%s AND provider='custom'", (operation_id,))
@@ -89,3 +89,40 @@ statistics = database.map_statistics({'eventType': 'INSTALL_FAILED'})
 assert sum(row['operation_count'] for row in statistics) == 1, statistics
 assert database.map_statistics({'eventType': 'INSTALL_SUCCEEDED'}) == []
 print('PASS: catalog failure fallback respects outcome filters')
+
+# Future results arrive individually; neither selected_map_count nor the UI's
+# bounded diagnostic history may cap the public/admin counters.
+future_session = uuid4()
+with database.connection() as connection:
+    connection.execute("INSERT INTO compatibility_model_review (model,identity_key,review_status,public_statistics_enabled) VALUES ('CI watch','CI watch','APPROVED',true)")
+for successes in range(1, 6):
+    event_id = uuid4()
+    with database.connection() as connection:
+        for delivery in range(2):
+            connection.execute('''
+                INSERT INTO compatibility_evidence_event
+                    (event_id,operation_id,map_result_index,selected_map_count,
+                     occurred_at,model,compatibility_identity,canonical_device_model_id,
+                     usb_vendor_id,usb_product_id,transport,provider,region,map_release,
+                     terento_version,macos_version,phase_outcome,automatic_finishing_result,write_started)
+                VALUES (%s,%s,%s,5,%s,'CI watch','CI watch',%s,2334,1,'MTP',
+                        'custom','custom','custom','1.0.0','26','SUCCEEDED','VERIFIED',true)
+                ON CONFLICT (event_id) DO NOTHING
+            ''', (event_id, future_session, successes - 1, now, device))
+    public = next(row for row in database.public_compatibility_statistics(100) if row['canonical_device_model_id'] == device)
+    admin = next(row for row in database.compatibility_statistics() if row['canonical_device_model_id'] == device)
+    devices, _ = database.admin_device_snapshot()
+    watch = next(row for row in devices if row['device_id'] == device)
+    for row in (public, admin, watch):
+        assert row['successful_install_count'] == successes, row
+        assert row['attempted_install_count'] == successes + 1, row
+        assert row['failed_install_count'] == 1, row
+    assert public['calculated_status'] == ('TESTED' if successes < 3 else 'SUPPORTED' if successes < 5 else 'VERIFIED'), public
+print('PASS: future per-map results promote all models at 3/5; public/admin/watch parity and replay idempotency')
+with database.connection() as connection:
+    connection.execute("UPDATE compatibility_evidence_event SET automatic_finishing_result='NOT_REACHED' WHERE event_id=%s", (event_id,))
+public = next(row for row in database.public_compatibility_statistics(100) if row['canonical_device_model_id'] == device)
+assert public['successful_install_count'] == 4 and public['calculated_status'] == 'SUPPORTED', public
+from terento_catalog.migrate import apply_migrations
+assert apply_migrations(database) == []
+print('PASS: unverified success cannot promote compatibility; migration replay is idempotent')


### PR DESCRIPTION
Owner-approved shared counting unit: each verified map installation, including custom IMG, counts independently for public/admin counters and status. Migration 038 replaces the view without rewriting telemetry; publication approvals and thresholds stay unchanged. Full-history counters are not capped by diagnostic pagination. Verified locally: 288 tests and disposable PostgreSQL migration, parity, 3/5 threshold, duplicate delivery and unverified outcome checks. Owner authorized deployment.