### PR TITLE
Fix oversized provider source and package filter selects

### DIFF
--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -453,7 +453,8 @@ projection and byte-identical legacy endpoint output. A live PostgreSQL
 migration integration check and beta device install/remove/update remain pending.
 The review found no proven unused transport/catalog lines safe to remove;
 legacy compatibility branches and the OTM package-count guard remain in use.
-# Admin filter sizing — 2026-09-11
+
+## Admin filter sizing — 2026-09-11
 
 Provider source and package filters share the admin control-height token (40px
 desktop, 44px mobile). Inputs and native selects inside column labels do not

--- a/backend/catalog-api/README.md
+++ b/backend/catalog-api/README.md
@@ -453,3 +453,9 @@ projection and byte-identical legacy endpoint output. A live PostgreSQL
 migration integration check and beta device install/remove/update remain pending.
 The review found no proven unused transport/catalog lines safe to remove;
 legacy compatibility branches and the OTM package-count guard remain in use.
+# Admin filter sizing — 2026-09-11
+
+Provider source and package filters share the admin control-height token (40px
+desktop, 44px mobile). Inputs and native selects inside column labels do not
+grow along the label's vertical flex axis. Search, status and page-size controls
+remain aligned; filtering and pagination semantics are unchanged.

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -5352,7 +5352,11 @@ button:active:not(:disabled),.button-link:active,.copy-button:active{transform:s
 .popularity-all-maps-disclosure input{width:100%;min-width:0;min-height:40px;margin:0}
 @media(max-width:700px){.popularity-all-maps-disclosure input{min-height:44px}}
 .filter-bar label>.sr-only,.inline-filter-row label>.sr-only{position:static;width:auto;height:auto;margin:0;overflow:visible;clip:auto;clip-path:none;white-space:normal;font-size:12px;font-weight:650;color:var(--secondary)}
-.filter-bar label>input,.filter-bar label>select{flex:none}
+.filter-bar label>input,.filter-bar label>select,.inline-filter-row label>input,.inline-filter-row label>select{flex:none}
+.inline-filter-row{align-items:flex-end}
+.inline-filter-row label{min-width:0}
+.inline-filter-row label>input,.inline-filter-row label>select{width:100%;height:var(--admin-control-height)}
+@media(max-width:700px){.inline-filter-row{align-items:stretch}.inline-filter-row label{flex-basis:auto}}
 .filter-bar>.filter-disclosure{align-self:flex-end}
 .filter-bar>.filter-clear{align-self:flex-end}
 .filter-bar>.results-count{align-self:flex-end;min-height:var(--admin-control-height);display:flex;align-items:center;white-space:normal}

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -27,6 +27,15 @@ class Tags(HTMLParser):
 
 
 class AdminAuditTests(unittest.TestCase):
+    def test_inline_filter_controls_do_not_inherit_vertical_flex_basis(self):
+        from terento_catalog.admin import ADMIN_STYLES
+        # Labels became columns: the old select flex-basis (170px) must not
+        # become a height. Reset both input and select, including tablet sizes.
+        self.assertIn('.inline-filter-row label>input,.inline-filter-row label>select{flex:none}', ADMIN_STYLES)
+        self.assertIn('.inline-filter-row label>input,.inline-filter-row label>select{width:100%;height:var(--admin-control-height)}', ADMIN_STYLES)
+        self.assertIn('.inline-filter-row{align-items:flex-end}', ADMIN_STYLES)
+        self.assertIn('@media(max-width:700px){.inline-filter-row{align-items:stretch}.inline-filter-row label{flex-basis:auto}}', ADMIN_STYLES)
+
     def test_identity_search_exposes_results_without_opening_select(self):
         from terento_catalog.admin import _diagnostics_script, _diagnostic_detail_dialog
         markup = _diagnostic_detail_dialog('Unknown', 'test', [{'phase_outcome': 'FAILED'}], resolved=False, csrf_token='test', identity_devices=[])


### PR DESCRIPTION
Fix the column-label flex regression that turned select width into 170px height. Reuse shared 40/44px control sizing for source and package filters. Preserve all options, search and pagination. Validation: 293 backend tests pass; browser desktop/tablet/mobile checks and search, broken-only empty state, 50-row pagination pass. No API, data or native app changes.