### PR TITLE
Fix rolling downloads chart and remove test events

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -827,22 +827,6 @@ def _overview_system_attention_item(card: dict[str, Any]) -> str:
     )
 
 
-def _overview_failure_reasons(reasons: list[dict[str, Any]]) -> str:
-    if not reasons:
-        return "<p class='empty'>No normalized failure categories are available for this period.</p>"
-    maximum = max(int(item.get("count") or 0) for item in reasons) or 1
-    rows: list[str] = []
-    for item in reasons:
-        count = int(item.get("count") or 0)
-        width = max(4, round(count / maximum * 100))
-        label = _overview_failure_reason_label(item.get("reason"))
-        rows.append(
-            f"<li><span>{html.escape(label)}</span><strong>{count}</strong>"
-            f"<span class='overview-bar' role='img' aria-label='{html.escape(label)}: {count}'><i style='width:{width}%'></i></span></li>"
-        )
-    return "<ul class='overview-reason-list'>" + "".join(rows) + "</ul>"
-
-
 def _overview_model_activity_item(item: dict[str, Any]) -> str:
     model = str(item.get("model") or item.get("compatibility_identity") or "Unknown device").strip()
     variant = _normalise_variant(item.get("variant"))
@@ -1503,7 +1487,6 @@ def overview_page(
         "/admin/devices" if review_required else
         "/admin/providers" if attention_providers else map_statistics_href
     )
-    failure_reasons = list(compatibility.get("failureReasons") or [])
     compatibility_recent = list(compatibility.get("recentActivity") or [])
     compatibility_recent_content = (
         ""
@@ -1511,10 +1494,6 @@ def overview_page(
         "<div class='overview-compatibility-activity' aria-label='Recent compatibility activity'><div class='section-heading'><div><p class='section-kicker'>Latest</p><h3>Recent compatibility activity</h3></div><a class='section-link' href='/admin/installations'>View all&nbsp;" + _admin_icon("arrow-right") + "</a></div><ul class='overview-activity-list'>" +
         "".join(_overview_compatibility_activity_row(item) for item in compatibility_recent) +
         "</ul></div>"
-    )
-    reasons_section = (
-        f"<section class='overview-panel' aria-labelledby='overview-reasons-title'><div class='section-heading'><div><p class='section-kicker'>Compatibility evidence</p><h2 id='overview-reasons-title'>Failures by reason</h2></div><span class='overview-info' title='Compatibility evidence only.' aria-label='Compatibility evidence only.'>i</span></div>{_overview_failure_reasons(failure_reasons)}<p class='overview-chart-note'>Compatibility evidence only. Map-operation failure counts are shown above.</p></section>"
-        if failure_reasons else ""
     )
     compatibility_summary = (
         f"<details class='overview-panel overview-compatibility-summary admin-disclosure' aria-labelledby='overview-compatibility-title'><summary id='overview-compatibility-title'>Compatibility evidence · details and activity</summary><div class='overview-compatibility-grid'><div><span>Installation attempts</span><strong>{compatibility_attempts}</strong></div><div><span>Variants</span><strong>{compatibility_variants}</strong></div><div><span>Success rate</span><strong>{compatibility_rate}</strong></div></div><p class='overview-chart-note'>Evidence remains stored separately; complete provider successes reconcile missing map-event rows in this view only.</p>{compatibility_recent_content}</details>"
@@ -1549,10 +1528,9 @@ def overview_page(
         f"<div class='overview-download-total'><span>Total downloads:</span><strong>{download_total('zipTotal')}</strong><small>.zip</small></div>"
         "</div></section>"
     )
-    primary_grid_class = "overview-primary-grid" if model_panel else "overview-primary-grid overview-primary-grid-single"
     secondary_grid_class = (
         "overview-secondary-grid"
-        if reasons_section else
+        if model_panel else
         "overview-secondary-grid overview-secondary-grid-single"
     )
     attention_section = (
@@ -1582,9 +1560,8 @@ def overview_page(
           <a class='overview-kpi' href='/admin/providers'><span>Providers</span><strong>{healthy} / {provider_count}</strong></a>
         </section>
         {attention_section}
-        <div class='{primary_grid_class}'><section class='overview-panel overview-chart-panel' aria-labelledby='overview-trend-title'><div class='section-heading'><div><p class='section-kicker'>Map operations</p><h2 id='overview-trend-title'>Map install operations over time</h2></div></div>{_overview_trend_chart(list(data.get('trend') or []), str(data.get('bucket') or 'day'), time_zone)}</section>{model_panel}</div>
-        {downloads_section}
-        <div class='{secondary_grid_class}'><section class='overview-panel' aria-labelledby='overview-activity-title'><div class='section-heading'><div><p class='section-kicker'>Latest</p><h2 id='overview-activity-title'>Recent map activity</h2></div><a class='section-link' href='{html.escape(map_statistics_href, quote=True)}'>View all&nbsp;{_admin_icon('arrow-right')}</a></div>{recent_content}</section>{reasons_section}</div>
+        <div class='overview-primary-grid'><section class='overview-panel overview-chart-panel' aria-labelledby='overview-trend-title'><div class='section-heading'><div><p class='section-kicker'>Map operations</p><h2 id='overview-trend-title'>Map install operations over time</h2></div></div>{_overview_trend_chart(list(data.get('trend') or []), str(data.get('bucket') or 'day'), time_zone)}</section>{downloads_section}</div>
+        <div class='{secondary_grid_class}'><section class='overview-panel' aria-labelledby='overview-activity-title'><div class='section-heading'><div><p class='section-kicker'>Latest</p><h2 id='overview-activity-title'>Recent map activity</h2></div><a class='section-link' href='{html.escape(map_statistics_href, quote=True)}'>View all&nbsp;{_admin_icon('arrow-right')}</a></div>{recent_content}</section>{model_panel}</div>
         {compatibility_summary}
       </main>
       <script>{_overview_period_script()}</script>
@@ -5262,7 +5239,7 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 @media(max-width:400px){.overview-kpis{grid-template-columns:1fr}}
 @media(max-width:700px){.overview-compatibility-grid{grid-template-columns:1fr}.provider-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}}
 @media(max-width:480px){.overview-compatibility-grid{grid-template-columns:1fr}}
-.overview-primary-grid,.overview-secondary-grid{display:grid;grid-template-columns:minmax(0,1.35fr) minmax(320px,1fr);gap:12px}.overview-primary-grid .overview-panel,.overview-secondary-grid .overview-panel{min-width:0}.overview-model-list,.overview-review-list{list-style:none;margin:0;padding:0}.overview-model-item,.overview-review-item{display:grid;grid-template-columns:minmax(0,1fr) max-content;gap:8px;align-items:start;padding:9px 0;border-top:1px solid color-mix(in srgb,var(--border) 75%,transparent)}.overview-model-item:first-child,.overview-review-item:first-child{border-top:0;padding-top:3px}.overview-model-item a,.overview-review-item a{display:grid;min-width:0;color:inherit;text-decoration:none}.overview-model-item a:hover strong,.overview-review-item a:hover strong{text-decoration:underline;text-underline-offset:3px}.overview-model-item strong,.overview-review-item strong{font-size:13px;overflow:hidden;text-overflow:ellipsis}.overview-model-item a span,.overview-review-item a span{color:var(--secondary);font-size:11px}.overview-model-item time{color:var(--secondary);font-size:11px;white-space:nowrap}.overview-model-failed strong{color:var(--danger)}.overview-review-block{margin-top:14px;padding-top:12px;border-top:1px solid var(--border)}.overview-review-block h3{margin:0 0 5px;color:var(--secondary);font-size:12px}.overview-activity-item{grid-template-columns:minmax(0,1fr) max-content}.overview-activity-item time{grid-column:2;grid-row:1 / span 2}.overview-activity-item .overview-activity-label{grid-column:1}.overview-activity-item a span:not(.overview-activity-label){grid-column:1}.overview-compact-empty{padding-bottom:14px}.inline-filter-row{justify-content:flex-start}.inline-filter-row label{flex:0 1 260px}.inline-filter-row select{flex:0 0 170px}
+.overview-primary-grid,.overview-secondary-grid{display:grid;gap:12px}.overview-primary-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.overview-secondary-grid{grid-template-columns:minmax(0,1.35fr) minmax(320px,1fr)}.overview-primary-grid .overview-panel,.overview-secondary-grid .overview-panel{min-width:0}.overview-model-list,.overview-review-list{list-style:none;margin:0;padding:0}.overview-model-item,.overview-review-item{display:grid;grid-template-columns:minmax(0,1fr) max-content;gap:8px;align-items:start;padding:9px 0;border-top:1px solid color-mix(in srgb,var(--border) 75%,transparent)}.overview-model-item:first-child,.overview-review-item:first-child{border-top:0;padding-top:3px}.overview-model-item a,.overview-review-item a{display:grid;min-width:0;color:inherit;text-decoration:none}.overview-model-item a:hover strong,.overview-review-item a:hover strong{text-decoration:underline;text-underline-offset:3px}.overview-model-item strong,.overview-review-item strong{font-size:13px;overflow:hidden;text-overflow:ellipsis}.overview-model-item a span,.overview-review-item a span{color:var(--secondary);font-size:11px}.overview-model-item time{color:var(--secondary);font-size:11px;white-space:nowrap}.overview-model-failed strong{color:var(--danger)}.overview-review-block{margin-top:14px;padding-top:12px;border-top:1px solid var(--border)}.overview-review-block h3{margin:0 0 5px;color:var(--secondary);font-size:12px}.overview-activity-item{grid-template-columns:minmax(0,1fr) max-content}.overview-activity-item time{grid-column:2;grid-row:1 / span 2}.overview-activity-item .overview-activity-label{grid-column:1}.overview-activity-item a span:not(.overview-activity-label){grid-column:1}.overview-compact-empty{padding-bottom:14px}.inline-filter-row{justify-content:flex-start}.inline-filter-row label{flex:0 1 260px}.inline-filter-row select{flex:0 0 170px}
 .system-health-page{padding-top:30px}.system-health-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}.system-health-card{min-height:150px;padding:18px;border:1px solid var(--border);border-radius:14px;background:var(--surface)}.system-health-card .section-heading{align-items:center;margin-bottom:14px}.system-health-card h2{font-size:16px}.system-health-description p{margin:0 0 10px;color:var(--secondary);font-size:12px;line-height:1.55}.system-health-explanation{margin:12px 0;font-size:11px}.system-health-explanation div{display:grid;grid-template-columns:48px 1fr;gap:7px;padding:5px 0;border-top:1px solid var(--border)}.system-health-explanation dt{font-weight:750;color:var(--graphite)}.system-health-explanation dd{margin:0;color:var(--secondary)}.system-health-badge{display:inline-flex;padding:4px 8px;border:1px solid;border-radius:999px;font-size:11px;font-weight:750}.system-health-healthy{border-color:var(--status-success-border);background:var(--status-success-surface);color:var(--status-success-text)}.system-health-warning{border-color:var(--status-tested-border);background:var(--status-tested-surface);color:var(--status-tested-text)}.system-health-failed{border-color:var(--status-error-border);background:var(--status-error-surface);color:var(--status-error-text)}.system-health-unknown{border-color:var(--status-neutral-border);background:var(--status-neutral-surface);color:var(--status-neutral-text)}
 @media(max-width:1100px){.system-health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}}
 @media(max-width:560px){.system-health-grid{grid-template-columns:1fr}.system-health-card{min-height:0}}
@@ -5270,7 +5247,6 @@ td:nth-child(4),td:nth-child(5),td:nth-child(6),td:nth-child(7){font-variant-num
 @media(max-width:900px){.overview-primary-grid,.overview-secondary-grid{grid-template-columns:1fr}}
 @media(max-width:760px){.overview-activity-item{grid-template-columns:1fr max-content}.overview-activity-item time{grid-column:2;grid-row:1 / span 2}.overview-activity-item a{grid-column:1;grid-row:1 / span 2}.overview-activity-item a span:not(.overview-activity-label){white-space:normal}}
 @media(max-width:480px){.inline-filter-row label,.inline-filter-row select{flex-basis:auto}}
-.overview-primary-grid-single{grid-template-columns:minmax(0,1fr)}
 .overview-attention-review .overview-attention-dot{color:var(--warning,var(--stone))}
 .provider-action-bar{padding:0 0 4px;background:transparent;border:0;border-radius:0}
 .map-statistics-definition-note{margin:10px 0 0}
@@ -5417,7 +5393,7 @@ h1,h2,h3,h4,.administration-grid h3,.overview-kpi strong,.admin-kpi-grid article
 .diagnostic-action-form button[type='submit']:hover{background:var(--interactive-hover)}
 .diagnostic-action-form button.secondary-button,.model-administration button.secondary-button{background:var(--surface);color:var(--interactive);border:1px solid var(--border)}
 .timestamp-metric strong{font-size:var(--admin-type-subsection-size)!important;line-height:var(--admin-type-subsection-line)!important}
-.overview-secondary-grid{align-items:start}.overview-primary-grid{align-items:stretch}.overview-primary-grid>.overview-panel{min-height:0}.overview-primary-grid .overview-model-panel{display:flex;min-height:0;flex-direction:column}.overview-primary-grid .overview-model-list{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain}
+.overview-primary-grid,.overview-secondary-grid{align-items:stretch}.overview-primary-grid>.overview-panel,.overview-secondary-grid>.overview-panel{min-height:0}.overview-secondary-grid>.overview-panel{display:flex;min-height:0;max-height:320px;flex-direction:column;overflow:hidden}.overview-secondary-grid .overview-activity-list,.overview-secondary-grid .overview-model-list{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain}
 .overview-compatibility-summary>summary,.model-administration>summary,.device-information-section>summary{margin-bottom:12px}
 .model-administration,.device-information-section{padding:16px;border:1px solid var(--border);border-radius:12px;background:var(--surface)}
 .attention-shortcuts{display:flex;flex-wrap:wrap;gap:8px 18px;margin:12px 0 20px;font-size:13px}

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -298,7 +298,13 @@ class Database:
             now = now.replace(tzinfo=timezone.utc)
         now = now.astimezone(timezone.utc)
         end = now.replace(minute=0, second=0, microsecond=0)
-        start = end - timedelta(hours=23)
+        # Match the map-operation chart's rolling 24-hour window: include
+        # the current hour bucket and the bucket at the same hour yesterday.
+        # This keeps the visible range aligned when the hour changes instead
+        # of anchoring the chart to the calendar day.
+        start = (now - timedelta(hours=24)).replace(
+            minute=0, second=0, microsecond=0,
+        )
         with self.connection() as connection:
             latest = connection.execute(
                 """

--- a/backend/catalog-api/src/terento_catalog/migrations/043_remove_authorized_test_install_2.sql
+++ b/backend/catalog-api/src/terento_catalog/migrations/043_remove_authorized_test_install_2.sql
@@ -1,0 +1,21 @@
+-- User-authorized one-time cleanup of a second test installation.
+-- The admin UI calls the operation UUID the Diagnostic ID and the individual
+-- compatibility row UUID the Installation ID. Match either identifier in
+-- either compatibility column so the cleanup remains exact if the IDs are
+-- supplied in the opposite order. Map events are keyed by operation_id.
+
+DELETE FROM map_download_event
+WHERE operation_id IN (
+    'a493ae4e-6106-4a38-927a-e02ba0e742a0'::uuid,
+    'bcec90c2-bc3b-4f39-a6df-2a077658b512'::uuid
+);
+
+DELETE FROM compatibility_evidence_event
+WHERE event_id IN (
+    'a493ae4e-6106-4a38-927a-e02ba0e742a0'::uuid,
+    'bcec90c2-bc3b-4f39-a6df-2a077658b512'::uuid
+)
+   OR operation_id IN (
+    'a493ae4e-6106-4a38-927a-e02ba0e742a0'::uuid,
+    'bcec90c2-bc3b-4f39-a6df-2a077658b512'::uuid
+);

--- a/backend/catalog-api/tests/test_admin_audit.py
+++ b/backend/catalog-api/tests/test_admin_audit.py
@@ -42,14 +42,14 @@ class AdminAuditTests(unittest.TestCase):
     def test_overview_model_activity_matches_chart_height_and_scrolls(self):
         from terento_catalog.admin import ADMIN_STYLES
 
-        self.assertIn('.overview-primary-grid{align-items:stretch}', ADMIN_STYLES)
-        self.assertIn('.overview-primary-grid>.overview-panel{min-height:0}', ADMIN_STYLES)
+        self.assertIn('.overview-primary-grid{grid-template-columns:repeat(2,minmax(0,1fr))}', ADMIN_STYLES)
+        self.assertIn('.overview-primary-grid,.overview-secondary-grid{align-items:stretch}', ADMIN_STYLES)
         self.assertIn(
-            '.overview-primary-grid .overview-model-panel{display:flex;min-height:0;flex-direction:column}',
+            '.overview-secondary-grid>.overview-panel{display:flex;min-height:0;max-height:320px;flex-direction:column;overflow:hidden}',
             ADMIN_STYLES,
         )
         self.assertIn(
-            '.overview-primary-grid .overview-model-list{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain}',
+            '.overview-secondary-grid .overview-activity-list,.overview-secondary-grid .overview-model-list{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain}',
             ADMIN_STYLES,
         )
 

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -77,6 +77,7 @@ IDENTITY_STATE_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "02
 PUBLIC_REVIEW_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "023_public_compatibility_review_audit.sql"
 WORKFLOW_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "040_diagnostic_issue_workflow.sql"
 AUTHORIZED_TEST_CLEANUP_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "041_remove_authorized_test_install.sql"
+FOLLOWUP_TEST_CLEANUP_MIGRATION = ROOT / "src" / "terento_catalog" / "migrations" / "043_remove_authorized_test_install_2.sql"
 
 
 class RecordingResult:
@@ -538,6 +539,9 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("overview-chart-panel", body)
         self.assertIn("Recent map activity", body)
         self.assertIn("Compatibility evidence", body)
+        self.assertIn("Downloads over time", body)
+        self.assertIn("overview-download-panel", body)
+        self.assertNotIn("Failures by reason", body)
         self.assertNotIn("Pending metric definition", body)
         self.assertNotIn("<span>Evidence success</span>", body)
 
@@ -601,6 +605,10 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("Review queue", body)
         self.assertIn("Review required", body)
         self.assertIn("Last 24 hours", body)
+        self.assertIn("<div class='overview-primary-grid'>", body)
+        self.assertIn("<div class='overview-secondary-grid'>", body)
+        self.assertIn("overview-model-panel", body)
+        self.assertNotIn("Failures by reason", body)
         self.assertNotIn("build", body.lower())
 
     def test_overview_hides_unlinked_model_activity_panel(self):
@@ -614,8 +622,9 @@ class AdminSemanticsTests(unittest.TestCase):
             {"username": "operator"}, "csrf",
         ).decode()
         self.assertNotIn("overview-model-title", body)
-        self.assertIn("overview-primary-grid-single", body)
+        self.assertIn("<div class='overview-primary-grid'>", body)
         self.assertIn("overview-secondary-grid-single", body)
+        self.assertNotIn("class='overview-primary-grid overview-primary-grid-single'", body)
 
     def test_overview_period_control_updates_without_hard_reload(self):
         body = overview_page(
@@ -2335,6 +2344,21 @@ class AdminSemanticsTests(unittest.TestCase):
         for identifier in (
             "10126c60-7129-49fc-8149-91b03f419960",
             "67dd09c7-f14f-4a22-8514-894eded0c050",
+        ):
+            self.assertIn(identifier, migration)
+        self.assertIn("DELETE FROM map_download_event", migration)
+        self.assertIn("DELETE FROM compatibility_evidence_event", migration)
+        self.assertIn("event_id IN", migration)
+        self.assertIn("operation_id IN", migration)
+        self.assertNotIn("compatibility_evidence_confirmation", migration)
+        self.assertNotIn("is_local_test IS TRUE", migration)
+        self.assertNotIn("DELETE FROM map_provider", migration)
+
+    def test_followup_authorized_test_cleanup_migration_is_exact(self):
+        migration = FOLLOWUP_TEST_CLEANUP_MIGRATION.read_text(encoding="utf-8")
+        for identifier in (
+            "a493ae4e-6106-4a38-927a-e02ba0e742a0",
+            "bcec90c2-bc3b-4f39-a6df-2a077658b512",
         ):
             self.assertIn(identifier, migration)
         self.assertIn("DELETE FROM map_download_event", migration)

--- a/backend/catalog-api/tests/test_github_downloads.py
+++ b/backend/catalog-api/tests/test_github_downloads.py
@@ -152,7 +152,7 @@ class GithubDownloadTests(unittest.TestCase):
         self.assertEqual(database.values["release_count"], 4)
         self.assertEqual(database.values["observed_at"], observed_at)
 
-    def test_database_snapshot_fills_last_24_utc_hours_and_uses_deltas(self):
+    def test_database_snapshot_fills_rolling_24_hour_window_and_uses_deltas(self):
         now = datetime(2026, 9, 11, 20, 13, tzinfo=timezone.utc)
         start = datetime(2026, 9, 10, 21, tzinfo=timezone.utc)
         database = SnapshotDatabase(
@@ -165,8 +165,9 @@ class GithubDownloadTests(unittest.TestCase):
         result = database.github_downloads_snapshot(now=now)
         self.assertTrue(result["hasData"])
         self.assertEqual((result["dmgTotal"], result["zipTotal"]), (15, 9))
-        self.assertEqual(len(result["trend"]), 24)
-        self.assertEqual(result["trend"][0]["dmg_count"], 2)
+        self.assertEqual(len(result["trend"]), 25)
+        self.assertEqual(result["trend"][0]["bucket"], datetime(2026, 9, 10, 20, tzinfo=timezone.utc))
+        self.assertEqual(result["trend"][1]["dmg_count"], 2)
         self.assertEqual(result["trend"][-1]["zip_count"], 4)
         query = database.connection_instance.queries[1][0]
         self.assertIn("lag(dmg_total)", query)


### PR DESCRIPTION
## Summary
- align Downloads over time to the rolling 24-hour hourly window
- keep the admin activity layout changes in the deploy commit
- add the exact authorized cleanup migration for diagnostic `a493ae4e-6106-4a38-927a-e02ba0e742a0` and installation `bcec90c2-bc3b-4f39-a6df-2a077658b512`

## Verification
- focused backend tests: 94 passed
- full catalog API suite: 316 passed
- migration deletes only matching map download operations and compatibility evidence rows by the supplied UUIDs; no issue status is changed