### PR TITLE
Prevent false catalog deploy timeout failures

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -88,12 +88,34 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          health="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://api.terento.app/health)"
-          maps="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/maps/catalog.json)"
-          devices="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 https://api.terento.app/devices/catalog.json)"
+
+          retry_curl() {
+            local label="$1"
+            shift
+            local attempt response
+            for attempt in 1 2 3; do
+              if response="$(curl "$@")"; then
+                printf '%s' "$response"
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                printf '%s request attempt %s/3 failed; retrying\n' "$label" "$attempt" >&2
+                sleep $((attempt * 2))
+              fi
+            done
+            printf '%s request failed after 3 attempts\n' "$label" >&2
+            return 1
+          }
+
+          health="$(retry_curl health --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --retry 1 --retry-delay 2 --retry-max-time 10 https://api.terento.app/health)"
+          maps="$(retry_curl map-catalog --fail --silent --show-error --connect-timeout 5 --max-time 60 \
+            --retry 1 --retry-delay 2 --retry-max-time 15 https://api.terento.app/maps/catalog.json)"
+          devices="$(retry_curl device-catalog --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+            --retry 1 --retry-delay 2 --retry-max-time 15 https://api.terento.app/devices/catalog.json)"
           python3 scripts/infra/check-admin-boundary.py
           deletion_body_file="$RUNNER_TEMP/terento-compatibility-delete-contract.json"
-          deletion_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 \
+          deletion_status="$(retry_curl compatibility-delete-contract --silent --show-error --connect-timeout 5 --max-time 20 \
             -H 'Content-Type: application/json' --data '{}' -X DELETE \
             -o "$deletion_body_file" -w '%{http_code}' \
             https://api.terento.app/compatibility/events)"
@@ -109,11 +131,14 @@ jobs:
             exit 1
           fi
 
-          compatibility_script="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 10 https://terento.app/compatibility/compatibility.js)"
+          compatibility_script="$(retry_curl compatibility-script --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+            --retry 1 --retry-delay 2 --retry-max-time 10 https://terento.app/compatibility/compatibility.js)"
           grep -Fq 'https://api.terento.app' <<<"$compatibility_script"
-          operations_status="$(curl --silent --show-error --connect-timeout 5 --max-time 10 -o /dev/null -w '%{http_code}' -X POST https://api.terento.app/internal/operations/observations)"
+          operations_status="$(retry_curl operations-unauthorized --silent --show-error --connect-timeout 5 --max-time 20 \
+            -o /dev/null -w '%{http_code}' -X POST https://api.terento.app/internal/operations/observations)"
           test "$operations_status" = "401"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 10 \
+          retry_curl operations-report-context --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+            --retry 1 --retry-delay 2 --retry-max-time 15 \
             -H "Authorization: Bearer $OPERATIONS_INGEST_SECRET" \
             https://api.terento.app/internal/operations/report-context \
             | jq -e '.schemaVersion == 1 and (.providers | type == "array")' >/dev/null

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -124,6 +124,11 @@ def main() -> int:
     assert "needs: tests" in deploy_api, "catalog deploy must wait for backend tests"
     assert "Retain API deployment health" in deploy_api
     assert "https://api.terento.app/internal/operations/report-context" in deploy_api
+    assert "retry_curl()" in deploy_api
+    assert "map-catalog" in deploy_api
+    assert "request failed after 3 attempts" in deploy_api
+    assert "--max-time 60" in deploy_api
+    assert "--retry 1" in deploy_api
     assert "verify-release-client-contract:" in deploy_api
     assert "Packaging/validate-live-map-catalog.sh" in deploy_api
     assert "TERENTO_ADMIN_ACCESS_REQUIRED: 'true'" in deploy_api


### PR DESCRIPTION
## Summary
- retry transient public API verification requests up to three times with backoff
- allow the large map catalog endpoint up to 60 seconds per attempt
- keep strict health, HTTP, and JSON contract checks
- add workflow contract assertions for the retry guard

## Evidence
- all three failed attempts of run 34646696996 timed out specifically at `maps/catalog.json` after 15 seconds, while the endpoint returned HTTP 200 immediately after warm-up
- local workflow contract test passes
- no application data or event deletion logic changed in this PR