### PR TITLE
Retry GHCR manifest propagation after image push

### DIFF
--- a/.github/workflows/publish-vps-images.yml
+++ b/.github/workflows/publish-vps-images.yml
@@ -77,7 +77,18 @@ jobs:
           trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
           docker push "$image:sha-$GITHUB_SHA"
-          docker pull "$image:sha-$GITHUB_SHA"
+          pull_succeeded=false
+          for attempt in 1 2 3 4 5; do
+            if docker pull "$image:sha-$GITHUB_SHA"; then
+              pull_succeeded=true
+              break
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              printf 'GHCR pull attempt %s/5 failed after push; retrying\n' "$attempt" >&2
+              sleep $((attempt * 2))
+            fi
+          done
+          [[ "$pull_succeeded" == true ]]
           reference="$(docker image inspect --format '{{index .RepoDigests 0}}' "$image:sha-$GITHUB_SHA")"
           [[ "$reference" == "$image"@sha256:* ]]
           digest="${reference#*@}"

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -139,6 +139,9 @@ def main() -> int:
     assert "digest: ${{ steps.image.outputs.digest }}" in publisher
     assert "value: ${{ jobs.publish.outputs.digest }}" in publisher
     assert "git merge-base --is-ancestor" in publisher
+    assert "pull_succeeded=false" in publisher
+    assert "GHCR pull attempt" in publisher
+    assert 'sleep $((attempt * 2))' in publisher
     assert "VPS_SSH_KEY" not in publisher and "environment:" not in publisher
     assert "secrets." not in publisher.replace("secrets.GITHUB_TOKEN", "TOKEN")
     for gate in ("Tests/run-site-tests.sh", "Tests/run-release-documentation-tests.sh",


### PR DESCRIPTION
## Summary
- retry the post-push immutable image pull up to five times with backoff
- preserve digest inspection only after the image is available from GHCR
- add a CI workflow contract assertion for the retry guard

## Evidence
- deploy run `34647864305` built and pushed the API image successfully, then immediately failed on `docker pull` with `manifest unknown`
- no application code, database migration, or data cleanup changed here
- local workflow contract test passes