### PR TITLE
Make catalog deploy verification resilient to large responses

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -107,11 +107,11 @@ jobs:
             return 1
           }
 
-          health="$(retry_curl health --fail --silent --show-error --connect-timeout 5 --max-time 20 \
+          health="$(retry_curl health --fail --silent --show-error --compressed --connect-timeout 5 --max-time 20 \
             --retry 1 --retry-delay 2 --retry-max-time 10 https://api.terento.app/health)"
-          maps="$(retry_curl map-catalog --fail --silent --show-error --connect-timeout 5 --max-time 60 \
+          maps="$(retry_curl map-catalog --fail --silent --show-error --compressed --connect-timeout 5 --max-time 60 \
             --retry 1 --retry-delay 2 --retry-max-time 15 https://api.terento.app/maps/catalog.json)"
-          devices="$(retry_curl device-catalog --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+          devices="$(retry_curl device-catalog --fail --silent --show-error --compressed --connect-timeout 5 --max-time 30 \
             --retry 1 --retry-delay 2 --retry-max-time 15 https://api.terento.app/devices/catalog.json)"
           python3 scripts/infra/check-admin-boundary.py
           deletion_body_file="$RUNNER_TEMP/terento-compatibility-delete-contract.json"

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -127,6 +127,7 @@ def main() -> int:
     assert "retry_curl()" in deploy_api
     assert "map-catalog" in deploy_api
     assert "request failed after 3 attempts" in deploy_api
+    assert "map-catalog --fail --silent --show-error --compressed" in deploy_api
     assert "--max-time 60" in deploy_api
     assert "--retry 1" in deploy_api
     assert "verify-release-client-contract:" in deploy_api


### PR DESCRIPTION
The catalog API verification can time out while downloading the 460 KB maps catalog from GitHub-hosted runners. Request gzip compression for public catalog responses so the same schema checks complete reliably.

Adds a CI contract assertion and preserves existing retry and validation behavior.

Tests: ./.venv/bin/python Tests/ci-workflow-contract-tests.py