### PR TITLE
Retry deployment health observations

### DIFF
--- a/.github/workflows/deploy-catalog-api.yml
+++ b/.github/workflows/deploy-catalog-api.yml
@@ -159,11 +159,22 @@ jobs:
               summary:"Catalog API deployment and public health verification passed.",
               details:{migration:"success", database:"success", api_health:"success", catalog_contract:"success"}}' \
             > "$RUNNER_TEMP/terento-api-deployment.json"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
-            -H "Authorization: Bearer $OPERATIONS_INGEST_SECRET" \
-            -H "Content-Type: application/json" \
-            --data-binary "@$RUNNER_TEMP/terento-api-deployment.json" \
-            https://api.terento.app/internal/operations/observations
+          observation_posted=false
+          for attempt in 1 2 3; do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+              -H "Authorization: Bearer $OPERATIONS_INGEST_SECRET" \
+              -H "Content-Type: application/json" \
+              --data-binary "@$RUNNER_TEMP/terento-api-deployment.json" \
+              https://api.terento.app/internal/operations/observations; then
+              observation_posted=true
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              printf 'catalog API observation attempt %s/3 failed; retrying\n' "$attempt" >&2
+              sleep $((attempt * 2))
+            fi
+          done
+          test "$observation_posted" = true
 
   verify-release-client-contract:
     name: Verify deployed catalog with release client

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -77,8 +77,19 @@ jobs:
               summary:"Website deployment and live update-manifest verification passed.",
               details:{site_container:"success", live_manifest:"success"}}' \
             > "$RUNNER_TEMP/terento-site-deployment.json"
-          curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
-            -H "Authorization: Bearer $OPERATIONS_INGEST_SECRET" \
-            -H "Content-Type: application/json" \
-            --data-binary "@$RUNNER_TEMP/terento-site-deployment.json" \
-            https://api.terento.app/internal/operations/observations
+          observation_posted=false
+          for attempt in 1 2 3; do
+            if curl --fail --silent --show-error --connect-timeout 5 --max-time 30 \
+              -H "Authorization: Bearer $OPERATIONS_INGEST_SECRET" \
+              -H "Content-Type: application/json" \
+              --data-binary "@$RUNNER_TEMP/terento-site-deployment.json" \
+              https://api.terento.app/internal/operations/observations; then
+              observation_posted=true
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              printf 'website observation attempt %s/3 failed; retrying\n' "$attempt" >&2
+              sleep $((attempt * 2))
+            fi
+          done
+          test "$observation_posted" = true

--- a/Tests/ci-workflow-contract-tests.py
+++ b/Tests/ci-workflow-contract-tests.py
@@ -135,6 +135,8 @@ def main() -> int:
     assert "TERENTO_ADMIN_ACCESS_REQUIRED: 'true'" in deploy_api
     deploy_site = (WORKFLOWS / "deploy-site.yml").read_text(encoding="utf-8")
     assert "Retain website deployment health" in deploy_site
+    assert "website observation attempt" in deploy_site
+    assert "catalog API observation attempt" in deploy_api
     publisher = (WORKFLOWS / "publish-vps-images.yml").read_text(encoding="utf-8")
     assert "workflow_call:" in publisher
     assert "digest: ${{ steps.image.outputs.digest }}" in publisher


### PR DESCRIPTION
Deployment itself can succeed while the operational observation POST times out at the API edge, which incorrectly marks the site deploy as failed. Retry the idempotent observation POST up to three times in both deployment workflows, with an explicit contract test.

Tests: ./.venv/bin/python Tests/ci-workflow-contract-tests.py