### PR TITLE
Add Overview operation totals and period-aware downloads

### DIFF
--- a/backend/catalog-api/docs/api.md
+++ b/backend/catalog-api/docs/api.md
@@ -108,11 +108,13 @@ synthetic `INSTALL_FAILED` map event. Existing explicit map events are kept;
 verified-success fallback projection is unchanged. A legacy `NULL
 write_started` value retains the established attempted-write behavior.
 
-The Overview also exposes `Downloads over time`, a display-only chart of the
-last 24 hourly changes in public GitHub release asset downloads. `.dmg` and
-`.zip` are separate series, while the two total fields use the newest
-cumulative values across all public releases and tags. The scheduler refreshes
-this data hourly; a failed GitHub read does not erase the last stored snapshot.
+The Overview also exposes `Downloads over time`, a display-only chart of public
+GitHub release asset download changes for the selected Overview period. The
+default `24h` period uses hourly buckets; `7d` and `30d` use local calendar-day
+buckets, and `all` uses compact month buckets. `.dmg` and `.zip` are separate
+series, while the two total fields use the newest cumulative values across all
+public releases and tags. The scheduler refreshes this data hourly; a failed
+GitHub read does not erase the last stored snapshot.
 
 The first administrator can
 be created only once through `/admin/setup` with the environment-provided

--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1265,11 +1265,23 @@ def _overview_trend_chart(
 
 
 def _overview_downloads_chart(
-    downloads: dict[str, Any], time_zone: str = "UTC", *, _compact: bool = False,
+    downloads: dict[str, Any], time_zone: str = "UTC", *, period: str = "24h",
+    _compact: bool = False,
 ) -> str:
     trend = [item for item in downloads.get("trend") or [] if isinstance(item, dict)]
     if not trend:
         return "<p class='overview-empty-state'>No GitHub download data yet.</p>"
+    chart_bucket = str(downloads.get("bucket") or {
+        "24h": "hour", "7d": "day", "30d": "day", "all": "month",
+    }.get(period, "hour"))
+    if chart_bucket not in {"hour", "day", "week", "month"}:
+        chart_bucket = "hour"
+    period_label = {
+        "24h": "the last 24 hours",
+        "7d": "the last 7 days",
+        "30d": "the last 30 days",
+        "all": "all time",
+    }.get(period, "the selected period")
     values = []
     for item in trend:
         counts = []
@@ -1314,7 +1326,7 @@ def _overview_downloads_chart(
             y = top + plot_height - height
             title = (
                 f"{label}: {count} · "
-                f"{_overview_chart_bucket_label(item.get('bucket'), 'hour', time_zone)} · {time_zone}"
+                f"{_overview_chart_bucket_label(item.get('bucket'), chart_bucket, time_zone)} · {time_zone}"
             )
             bars.append(
                 f"<rect class='{css_class}' x='{x:.1f}' y='{y:.2f}' width='{bar_width:.1f}' "
@@ -1334,12 +1346,12 @@ def _overview_downloads_chart(
             )
             labels.append(
                 f"<text x='{center:.1f}' y='{chart_height - 8}' text-anchor='{anchor}'>"
-                f"{html.escape(_overview_chart_bucket_label(item.get('bucket'), 'hour', time_zone))}</text>"
+                f"{html.escape(_overview_chart_bucket_label(item.get('bucket'), chart_bucket, time_zone))}</text>"
             )
     svg = (
         f"<svg class='overview-trend-chart overview-trend-{'mobile' if _compact else 'desktop'}' "
         f"viewBox='0 0 {chart_width} {chart_height}' role='img' "
-        f"aria-label='GitHub downloads over the last 24 hours'>"
+        f"aria-label='GitHub downloads over {period_label}'>"
         f"{''.join(grid)}{''.join(bars)}{''.join(labels)}</svg>"
     )
     if _compact:
@@ -1347,7 +1359,7 @@ def _overview_downloads_chart(
     return (
         "<div class='overview-chart-wrap'>"
         + svg
-        + _overview_downloads_chart(downloads, time_zone, _compact=True)
+        + _overview_downloads_chart(downloads, time_zone, period=period, _compact=True)
         + "<div class='overview-chart-legend'>"
         "<span><i class='overview-chart-download-dmg'></i>.dmg</span>"
         "<span><i class='overview-chart-download-zip'></i>.zip</span>"
@@ -1518,6 +1530,22 @@ def overview_page(
         except (TypeError, ValueError):
             return "—"
 
+    def map_total(key: str) -> str:
+        if key not in data or data.get(key) is None:
+            return "—"
+        try:
+            return str(max(0, int(data[key])))
+        except (TypeError, ValueError):
+            return "—"
+
+    map_totals = (
+        "<div class='overview-map-totals' aria-label='All-time map install totals'>"
+        f"<div class='overview-map-total' aria-label='All-time successful installs: {map_total('allTimeSuccessCount')}'><strong>{map_total('allTimeSuccessCount')}</strong><small>Successful</small></div>"
+        f"<div class='overview-map-total' aria-label='All-time failed installs: {map_total('allTimeFailedCount')}'><strong>{map_total('allTimeFailedCount')}</strong><small>Failed</small></div>"
+        f"<div class='overview-map-total' aria-label='All-time custom .img installs: {map_total('allTimeCustomCount')}'><strong>{map_total('allTimeCustomCount')}</strong><small>Custom</small></div>"
+        "</div>"
+    )
+
     downloads_section = (
         "<section class='overview-panel overview-download-panel' aria-labelledby='overview-downloads-title'>"
         "<div class='section-heading overview-download-heading'><div><p class='section-kicker'>GitHub releases</p>"
@@ -1526,7 +1554,7 @@ def overview_page(
         f"<div class='overview-download-total' aria-label='.dmg downloads total: {download_total('dmgTotal')}'><strong>{download_total('dmgTotal')}</strong><small>.dmg</small></div>"
         f"<div class='overview-download-total' aria-label='.zip downloads total: {download_total('zipTotal')}'><strong>{download_total('zipTotal')}</strong><small>.zip</small></div>"
         "</div></div>"
-        f"{_overview_downloads_chart(downloads, time_zone)}"
+        f"{_overview_downloads_chart(downloads, time_zone, period=period)}"
         "</section>"
     )
     secondary_grid_class = (
@@ -1561,7 +1589,7 @@ def overview_page(
           <a class='overview-kpi' href='/admin/providers'><span>Providers</span><strong>{healthy} / {provider_count}</strong></a>
         </section>
         {attention_section}
-        <div class='overview-primary-grid'><section class='overview-panel overview-chart-panel' aria-labelledby='overview-trend-title'><div class='section-heading'><div><p class='section-kicker'>Map operations</p><h2 id='overview-trend-title'>Map install operations over time</h2></div></div>{_overview_trend_chart(list(data.get('trend') or []), str(data.get('bucket') or 'day'), time_zone)}</section>{downloads_section}</div>
+        <div class='overview-primary-grid'><section class='overview-panel overview-chart-panel' aria-labelledby='overview-trend-title'><div class='section-heading overview-map-heading'><div><p class='section-kicker'>Map operations</p><h2 id='overview-trend-title'>Map install operations over time</h2></div>{map_totals}</div>{_overview_trend_chart(list(data.get('trend') or []), str(data.get('bucket') or 'day'), time_zone)}</section>{downloads_section}</div>
         <div class='{secondary_grid_class}'><section class='overview-panel' aria-labelledby='overview-activity-title'><div class='section-heading'><div><p class='section-kicker'>Latest</p><h2 id='overview-activity-title'>Recent map activity</h2></div><a class='section-link' href='{html.escape(map_statistics_href, quote=True)}'>View all&nbsp;{_admin_icon('arrow-right')}</a></div>{recent_content}</section>{model_panel}</div>
         {compatibility_summary}
       </main>
@@ -5297,11 +5325,11 @@ button,input,select,textarea{font-size:var(--admin-type-control-size);line-heigh
 .overview-chart-wrap{max-width:780px;margin:0 auto}
 .overview-download-panel{padding-top:16px;padding-bottom:16px}
 .overview-download-panel .section-heading{margin-bottom:6px}
-.overview-download-heading{align-items:flex-start;flex-wrap:wrap}
-.overview-download-totals{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap;margin-inline-start:auto}
-.overview-download-total{display:inline-flex;align-items:baseline;gap:4px;min-width:0;padding:5px 8px;border:1px solid var(--border);border-radius:8px;background:var(--surface-muted);font-size:var(--admin-type-label-size);line-height:var(--admin-type-label-line)}
-.overview-download-total strong{color:var(--graphite);font-size:16px;font-variant-numeric:tabular-nums}
-.overview-download-total small{color:var(--secondary);font-size:var(--admin-type-support-size)}
+.overview-map-heading,.overview-download-heading{align-items:flex-start;flex-wrap:wrap}
+.overview-map-totals,.overview-download-totals{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap;margin-inline-start:auto}
+.overview-map-total,.overview-download-total{display:inline-flex;align-items:baseline;gap:4px;min-width:0;padding:5px 8px;border:1px solid var(--border);border-radius:8px;background:var(--surface-muted);font-size:var(--admin-type-label-size);line-height:var(--admin-type-label-line)}
+.overview-map-total strong,.overview-download-total strong{color:var(--graphite);font-size:16px;font-variant-numeric:tabular-nums}
+.overview-map-total small,.overview-download-total small{color:var(--secondary);font-size:var(--admin-type-support-size)}
 .overview-chart-download-dmg{fill:var(--interactive);background:var(--interactive)}
 .overview-chart-download-zip{fill:var(--status-success-text);background:var(--status-success-text)}
 .overview-trend-chart{display:block;width:100%;height:260px;max-width:760px;min-height:0;margin:0 auto}
@@ -5311,9 +5339,9 @@ button,input,select,textarea{font-size:var(--admin-type-control-size);line-heigh
   .overview-trend-mobile{display:block;min-width:0;width:100%;height:auto;aspect-ratio:360/220}
   .overview-chart-wrap{width:100%;min-width:0;overflow:visible}
   .overview-trend-mobile text{font-size:13px}
-  .overview-download-totals{justify-content:flex-start;margin-inline-start:0}
+  .overview-map-totals,.overview-download-totals{justify-content:flex-start;margin-inline-start:0}
 }
-@media(max-width:560px){.overview-download-totals{flex-basis:100%}}
+@media(max-width:560px){.overview-map-totals,.overview-download-totals{flex-basis:100%}}
 .overview-attention-empty{display:grid;grid-template-columns:minmax(0,auto) minmax(180px,1fr) auto;align-items:center;gap:18px;min-height:76px;padding:12px 16px}
 .overview-attention-empty h2,.overview-provider-panel h2{font-family:var(--font-ui);font-size:var(--admin-type-subsection-size);line-height:var(--admin-type-subsection-line);letter-spacing:0}
 .overview-attention-empty .section-kicker,.overview-provider-panel .section-kicker{margin-bottom:1px}

--- a/backend/catalog-api/src/terento_catalog/db.py
+++ b/backend/catalog-api/src/terento_catalog/db.py
@@ -290,21 +290,40 @@ class Database:
         *,
         time_zone: str = "UTC",
         now: datetime | None = None,
+        period: str = "24h",
     ) -> dict[str, Any]:
-        """Return current totals and display-only hourly deltas for 24 hours."""
-        del time_zone  # Labels are localized by the admin chart renderer.
+        """Return current totals and period-aware display-only deltas."""
+        periods = {
+            "24h": timedelta(hours=24),
+            "7d": timedelta(days=7),
+            "30d": timedelta(days=30),
+            "all": None,
+        }
+        if period not in periods:
+            period = "24h"
+        bucket = {
+            "24h": "hour",
+            "7d": "day",
+            "30d": "day",
+            "all": "month",
+        }[period]
         now = now or datetime.now(timezone.utc)
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)
         now = now.astimezone(timezone.utc)
-        end = now.replace(minute=0, second=0, microsecond=0)
-        # Match the map-operation chart's rolling 24-hour window: include
-        # the current hour bucket and the bucket at the same hour yesterday.
-        # This keeps the visible range aligned when the hour changes instead
-        # of anchoring the chart to the calendar day.
-        start = (now - timedelta(hours=24)).replace(
-            minute=0, second=0, microsecond=0,
+        duration = periods[period]
+        start = (
+            datetime(1970, 1, 1, tzinfo=timezone.utc)
+            if duration is None
+            else now - duration
         )
+        end = now.replace(minute=0, second=0, microsecond=0)
+        if period == "24h":
+            # Match the map-operation chart's rolling 24-hour window: include
+            # the current hour bucket and the bucket at the same hour yesterday.
+            # This keeps the visible range aligned when the hour changes instead
+            # of anchoring the chart to the calendar day.
+            start = start.replace(minute=0, second=0, microsecond=0)
         with self.connection() as connection:
             latest = connection.execute(
                 """
@@ -321,6 +340,7 @@ class Database:
                     "zipTotal": None,
                     "lastObservedAt": None,
                     "trend": [],
+                    "bucket": bucket,
                 }
             trend = connection.execute(
                 """
@@ -344,26 +364,57 @@ class Database:
                 """,
                 (start,),
             ).fetchall()
-        indexed = {
-            row["bucket"]: dict(row)
-            for row in trend
-            if isinstance(row.get("bucket"), datetime)
-        }
-        filled = []
-        current = start
-        while current <= end:
-            filled.append(indexed.get(current, {
-                "bucket": current,
-                "dmg_count": 0,
-                "zip_count": 0,
-            }))
-            current += timedelta(hours=1)
+        raw_trend = [dict(row) for row in trend if isinstance(row.get("bucket"), datetime)]
+        if bucket == "hour":
+            indexed = {row["bucket"]: row for row in raw_trend}
+            filled = []
+            current = start
+            while current <= end:
+                filled.append(indexed.get(current, {
+                    "bucket": current,
+                    "dmg_count": 0,
+                    "zip_count": 0,
+                }))
+                current += timedelta(hours=1)
+        else:
+            aggregated: dict[datetime, dict[str, Any]] = {}
+            for row in raw_trend:
+                row_bucket = _overview_bucket_floor(
+                    row["bucket"], bucket, time_zone=time_zone,
+                )
+                target = aggregated.setdefault(row_bucket, {
+                    "bucket": row_bucket,
+                    "dmg_count": 0,
+                    "zip_count": 0,
+                })
+                target["dmg_count"] += max(0, int(row.get("dmg_count") or 0))
+                target["zip_count"] += max(0, int(row.get("zip_count") or 0))
+            if aggregated:
+                current = (
+                    min(aggregated)
+                    if period == "all"
+                    else _overview_bucket_floor(start, bucket, time_zone=time_zone)
+                )
+                end_bucket = _overview_bucket_floor(now, bucket, time_zone=time_zone)
+                filled = []
+                while current <= end_bucket:
+                    filled.append(aggregated.get(current, {
+                        "bucket": current,
+                        "dmg_count": 0,
+                        "zip_count": 0,
+                    }))
+                    current = _next_overview_bucket(
+                        current, bucket, time_zone=time_zone,
+                    )
+            else:
+                filled = []
         return {
             "hasData": True,
             "dmgTotal": int(latest["dmg_total"]),
             "zipTotal": int(latest["zip_total"]),
             "lastObservedAt": latest["observed_at"],
             "trend": filled,
+            "bucket": bucket,
         }
 
     def insert_compatibility_event(self, event: dict[str, Any]) -> bool:
@@ -1019,6 +1070,7 @@ class Database:
                    )
             )
         """
+        all_time_since = datetime(1970, 1, 1, tzinfo=timezone.utc)
         with self.connection() as connection:
             summary = connection.execute(
                 f"""
@@ -1042,6 +1094,34 @@ class Database:
                 {event_scope}
                 """,
                 (since, since),
+            ).fetchone() or {}
+            all_time_summary = connection.execute(
+                f"""
+                {compatibility_fallback_cte}
+                SELECT
+                    count(*) FILTER (
+                        WHERE e.event_type = 'INSTALL_SUCCEEDED'
+                          AND e.outcome = 'SUCCEEDED'
+                    ) + (
+                        SELECT count(*) FROM compatibility_fallback
+                        WHERE outcome = 'SUCCEEDED'
+                          AND provider_id IS DISTINCT FROM 'custom'
+                    ) AS all_time_success_count,
+                    count(*) FILTER (
+                        WHERE e.event_type = 'INSTALL_FAILED'
+                          AND e.outcome = 'FAILED'
+                    ) + (
+                        SELECT count(*) FROM compatibility_fallback
+                        WHERE outcome = 'FAILED'
+                    ) AS all_time_failed_count,
+                    (
+                        SELECT count(*) FROM compatibility_fallback
+                        WHERE outcome = 'SUCCEEDED'
+                          AND provider_id = 'custom'
+                    ) AS all_time_custom_count
+                {event_scope}
+                """,
+                (all_time_since, all_time_since),
             ).fetchone() or {}
             recent = list(connection.execute(
                 f"""
@@ -1146,6 +1226,9 @@ class Database:
             "completedInstallCount": completed,
             "failedInstallCount": failed,
             "installSuccessRate": completed / (completed + failed) * 100 if completed + failed else None,
+            "allTimeSuccessCount": int(all_time_summary.get("all_time_success_count") or 0),
+            "allTimeFailedCount": int(all_time_summary.get("all_time_failed_count") or 0),
+            "allTimeCustomCount": int(all_time_summary.get("all_time_custom_count") or 0),
             "hasData": int(summary.get("event_count") or 0) > 0,
             "recentActivity": [dict(row) for row in recent],
             "attention": [dict(row) for row in attention],

--- a/backend/catalog-api/src/terento_catalog/http_api.py
+++ b/backend/catalog-api/src/terento_catalog/http_api.py
@@ -488,7 +488,9 @@ class CatalogService:
             else datetime(1970, 1, 1, tzinfo=timezone.utc)
         )
         downloads_getter = getattr(self.database, "github_downloads_snapshot", None)
-        downloads = downloads_getter(time_zone=time_zone) if callable(downloads_getter) else {
+        downloads = downloads_getter(
+            time_zone=time_zone, period=period,
+        ) if callable(downloads_getter) else {
             "hasData": False,
             "dmgTotal": None,
             "zipTotal": None,

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -846,11 +846,26 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn(".dmg</span>", body)
         self.assertIn(".zip</span>", body)
 
+    def test_download_chart_uses_selected_period_bucket_and_label(self):
+        body = _overview_downloads_chart({
+            "hasData": True,
+            "bucket": "day",
+            "trend": [
+                {"bucket": "2026-09-10T00:00:00Z", "dmg_count": 2, "zip_count": 1},
+            ],
+        }, "UTC", period="7d")
+        self.assertIn("GitHub downloads over the last 7 days", body)
+        self.assertIn(".dmg downloads: 2 · 10 Sep · UTC", body)
+        self.assertNotIn("10:00", body)
+
     def test_overview_renders_github_download_totals(self):
         body = overview_page(
             {
                 "period": "24h",
-                "data": {"hasData": False, "recentActivity": [], "attention": [], "trend": [], "bucket": "hour"},
+                "data": {
+                    "hasData": False, "recentActivity": [], "attention": [], "trend": [], "bucket": "hour",
+                    "allTimeSuccessCount": 16, "allTimeFailedCount": 4, "allTimeCustomCount": 2,
+                },
                 "compatibility": {"hasData": False, "recentActivity": [], "failureReasons": []},
                 "downloads": {
                     "hasData": True, "dmgTotal": 23, "zipTotal": 11,
@@ -865,6 +880,10 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn("overview-download-total' aria-label='.dmg downloads total: 23'><strong>23</strong><small>.dmg", body)
         self.assertIn("overview-download-total' aria-label='.zip downloads total: 11'><strong>11</strong><small>.zip", body)
         self.assertIn("overview-download-totals", body)
+        self.assertIn("overview-map-heading", body)
+        self.assertIn("overview-map-total' aria-label='All-time successful installs: 16'><strong>16</strong><small>Successful", body)
+        self.assertIn("overview-map-total' aria-label='All-time failed installs: 4'><strong>4</strong><small>Failed", body)
+        self.assertIn("overview-map-total' aria-label='All-time custom .img installs: 2'><strong>2</strong><small>Custom", body)
         self.assertNotIn("Total downloads:</span>", body)
         heading_index = body.index("overview-download-heading")
         self.assertLess(

--- a/backend/catalog-api/tests/test_beta8_api.py
+++ b/backend/catalog-api/tests/test_beta8_api.py
@@ -41,7 +41,7 @@ class FakeProviderDatabase:
         self.run_overrides: dict[str, list[dict]] = {}
         self.map_statistic_filters: list[dict] = []
         self.overview_map_requests: list[tuple[datetime, str, str]] = []
-        self.overview_download_requests: list[str] = []
+        self.overview_download_requests: list[tuple[str, str]] = []
         self.local_purge_calls: list[dict] = []
 
     def admin_user_count(self) -> int:
@@ -93,13 +93,14 @@ class FakeProviderDatabase:
             "bucket": "hour",
         }
 
-    def github_downloads_snapshot(self, *, time_zone="UTC"):
-        self.overview_download_requests.append(time_zone)
+    def github_downloads_snapshot(self, *, time_zone="UTC", period="24h"):
+        self.overview_download_requests.append((period, time_zone))
         return {
             "hasData": True,
             "dmgTotal": 23,
             "zipTotal": 11,
             "lastObservedAt": datetime(2026, 9, 11, 20, tzinfo=UTC),
+            "bucket": "hour",
             "trend": [{
                 "bucket": datetime(2026, 9, 11, 20, tzinfo=UTC),
                 "dmg_count": 1,
@@ -1062,7 +1063,7 @@ class Beta8APITests(unittest.TestCase):
             self.assertEqual(response.status, 200)
             self.assertEqual(database.overview_map_requests[-1][1], "30d")
             self.assertEqual(database.overview_map_requests[-1][2], "Europe/Vilnius")
-            self.assertEqual(database.overview_download_requests[-1], "Europe/Vilnius")
+            self.assertEqual(database.overview_download_requests[-1], ("30d", "Europe/Vilnius"))
             self.assertIn("value='30d' selected", body.decode())
             self.assertIn("overview-download-total' aria-label='.dmg downloads total: 23'><strong>23</strong><small>.dmg", body.decode())
 
@@ -1072,6 +1073,7 @@ class Beta8APITests(unittest.TestCase):
             self.assertEqual(response.status, 200)
             self.assertEqual(database.overview_map_requests[-1][1], "all")
             self.assertIn("value='all' selected", body.decode())
+            self.assertEqual(database.overview_download_requests[-1], ("all", "UTC"))
             self.assertLess(
                 database.overview_map_requests[-1][0],
                 database.overview_map_requests[-2][0],

--- a/backend/catalog-api/tests/test_github_downloads.py
+++ b/backend/catalog-api/tests/test_github_downloads.py
@@ -181,6 +181,23 @@ class GithubDownloadTests(unittest.TestCase):
         self.assertEqual(result["hasData"], False)
         self.assertEqual(result["trend"], [])
 
+    def test_database_snapshot_aggregates_long_periods_in_local_days(self):
+        now = datetime(2026, 9, 11, 20, 13, tzinfo=timezone.utc)
+        database = SnapshotDatabase(
+            {"dmg_total": 15, "zip_total": 9, "observed_at": now},
+            [
+                {"bucket": datetime(2026, 9, 10, 21, tzinfo=timezone.utc), "dmg_count": 2, "zip_count": 1},
+                {"bucket": datetime(2026, 9, 11, 20, tzinfo=timezone.utc), "dmg_count": 3, "zip_count": 4},
+            ],
+        )
+        result = database.github_downloads_snapshot(
+            now=now, time_zone="Europe/Vilnius", period="7d",
+        )
+        self.assertEqual(result["bucket"], "day")
+        self.assertEqual(len(result["trend"]), 8)
+        self.assertEqual(sum(item["dmg_count"] for item in result["trend"]), 5)
+        self.assertEqual(sum(item["zip_count"] for item in result["trend"]), 5)
+
     def test_record_snapshot_upserts_a_utc_hour_and_serializes_counts(self):
         database = WriteDatabase()
         self.assertTrue(database.record_github_download_snapshot(


### PR DESCRIPTION
## Summary\n- add all-time Successful, Failed, and Custom badges to Map install operations over time\n- pass the selected Overview period into GitHub download snapshots\n- aggregate download trends by local day for 7d/30d and month for all-time\n- add regression coverage and update catalog API documentation\n\n## Validation\n- full backend catalog API test suite: 318 tests passed\n- git diff --check passed\n\nDeploy to beta after required checks pass.