### PR TITLE
Stack Downloads chart series

### DIFF
--- a/backend/catalog-api/src/terento_catalog/admin.py
+++ b/backend/catalog-api/src/terento_catalog/admin.py
@@ -1291,7 +1291,7 @@ def _overview_downloads_chart(
             except (TypeError, ValueError):
                 counts.append(0)
         values.append(tuple(counts))
-    maximum = max((max(series) for series in values), default=1) or 1
+    maximum = max((sum(series) for series in values), default=1) or 1
     scale_maximum = max(4, math.ceil(maximum * 1.2))
     chart_width, chart_height = (360, 220) if _compact else (720, 260)
     left, top, bottom = 38, 20, 34
@@ -1315,15 +1315,20 @@ def _overview_downloads_chart(
     )
     for index, (counts, item) in enumerate(zip(values, trend)):
         center = left + (index + 0.5) * slot
-        bar_width = min(12, max(4, slot * 0.28))
-        gap = min(3, max(1, slot * 0.06))
-        group_width = bar_width * 2 + gap
-        for series_index, ((label, css_class), count) in enumerate(zip(series, counts)):
+        bar_width = min(44, slot * 0.58)
+        x = center - bar_width / 2
+        y = top + plot_height
+        clip_id = f"overview-download-bar-clip-{'mobile-' if _compact else ''}{index}"
+        bars.append(
+            f"<defs><clipPath id='{clip_id}'><rect x='{x:.1f}' "
+            f"y='{top:.1f}' width='{bar_width:.1f}' height='{plot_height:.1f}' rx='3'></rect></clipPath></defs>"
+            f"<g clip-path='url(#{clip_id})'>"
+        )
+        for (label, css_class), count in zip(series, counts):
             if count == 0:
                 continue
             height = plot_height * count / scale_maximum
-            x = center - group_width / 2 + series_index * (bar_width + gap)
-            y = top + plot_height - height
+            y -= height
             title = (
                 f"{label}: {count} · "
                 f"{_overview_chart_bucket_label(item.get('bucket'), chart_bucket, time_zone)} · {time_zone}"
@@ -1334,6 +1339,7 @@ def _overview_downloads_chart(
                 f"aria-label='{html.escape(title, quote=True)}'>"
                 f"<title>{html.escape(title)}</title></rect>"
             )
+        bars.append("</g>")
         label_step = max(1, round((len(values) - 1) / 11))
         show_label = len(values) <= 12 or index % label_step == 0 or index == len(values) - 1
         if _compact:

--- a/backend/catalog-api/tests/test_admin_semantics.py
+++ b/backend/catalog-api/tests/test_admin_semantics.py
@@ -846,6 +846,33 @@ class AdminSemanticsTests(unittest.TestCase):
         self.assertIn(".dmg</span>", body)
         self.assertIn(".zip</span>", body)
 
+    def test_download_chart_stacks_file_types_in_one_installation_style_bar(self):
+        import xml.etree.ElementTree as ET
+
+        body = _overview_downloads_chart({
+            "hasData": True,
+            "trend": [{
+                "bucket": "2026-09-11T20:00:00Z",
+                "dmg_count": 2,
+                "zip_count": 2,
+            }],
+        })
+        svg = ET.fromstring(body[body.index("<svg"):body.index("</svg>") + 6])
+        bars = svg.findall("g/rect")
+        self.assertEqual(len(bars), 2)
+        self.assertEqual(bars[0].attrib["x"], bars[1].attrib["x"])
+        self.assertAlmostEqual(
+            float(bars[1].attrib["y"]) + float(bars[1].attrib["height"]),
+            float(bars[0].attrib["y"]),
+            places=1,
+        )
+        self.assertAlmostEqual(
+            sum(float(bar.attrib["height"]) for bar in bars),
+            206 * 4 / 5,
+            places=1,
+        )
+        self.assertIn("<clipPath id='overview-download-bar-clip-0'>", body)
+
     def test_download_chart_uses_selected_period_bucket_and_label(self):
         body = _overview_downloads_chart({
             "hasData": True,


### PR DESCRIPTION
## Summary
- render .dmg and .zip downloads as one stacked bar per time bucket
- scale the chart by total downloads in each bucket
- match map-install chart bar width and clipping behavior
- add regression coverage for stacked downloads

## Validation
- TERENTO_PYTHON_BIN=/Users/gediminas/Documents/Codex/terento/.venv/bin/python ./Tests/run-backend-api-unit-tests.sh
- git diff --check